### PR TITLE
update travis config and fix some test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
-  - sudo apt-get install python-numpy python-scipy python-matplotlib
+  - sudo apt-get install python-scipy
 install:
   - pip install sympy
   - wget http://bionetgen.googlecode.com/files/BioNetGen-2.2.5-stable.zip

--- a/pysb/examples/hello_pysb.py
+++ b/pysb/examples/hello_pysb.py
@@ -4,8 +4,6 @@
 """
 
 from pysb import *
-from pysb.integrate import odesolve
-from pylab import linspace, plot, xlabel, ylabel, show
 
 Model()
 
@@ -30,6 +28,8 @@ Rule('L_binds_R', L(s=None) + R(s=None) <> L(s=1) % R(s=1), kf, kr)
 Observable('LR', L(s=1) % R(s=1))
 
 if __name__ == '__main__':
+    from pylab import linspace, plot, xlabel, ylabel, show
+    from pysb.integrate import odesolve
     print __doc__
     # Simulate the model through 40 seconds
     time = linspace(0, 40, 100)

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -318,7 +318,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> print yfull[0:4, 1:3]
     Traceback (most recent call last):
       ...
-    IndexError: too many indices
+    IndexError: too many indices for array
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
     >>> print yarray.shape
     (10, 6)


### PR DESCRIPTION
In the travis config, drop explicit python-numpy from apt-get install list as
we want the version pre-installed in python site-packages. Installing
python-scipy will pull in the numpy .deb anyway, but the one in site-packages
will override it.

Fixed a doctest in integrate.py to reflect a certain numpy exception's new
message which was updated around v1.9. Technically this means that test will
now fail on older numpy versions.

In hello_pysb.py the imports required for simulation and plotting were moved
from the top level to the **main** block, meaning the model can be imported
without scipy or matplotlib installed (minor but good practice).
