### PR TITLE
Python 3 compatibility

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -29,7 +29,7 @@ sampled at intervals of 10 seconds::
     >>> t = [0, 10, 20, 30, 40, 50, 60]
     >>> solver = Solver(model, t)
     >>> solver.run()
-    >>> print solver.y[:, 1]
+    >>> print(solver.y[:, 1])
     [   0.   30.   60.   90.  120.  150.  180.]
 
 Creating a model

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -273,7 +273,7 @@ parameters. The rule interactions make use of the following
 operators::
 
    *+* operator to represent complexation 
-   *<>* operator to represent backward/forward reaction
+   *!=* operator to represent backward/forward reaction
    *>>* operator to represent forward-only reaction
    *%* operator to represent a binding interaction between two species
 
@@ -281,7 +281,7 @@ To illustrate the use of the operators and the rule syntax we write
 the complex formation reaction with labels illustrating the parts of
 the rule::
 
-   Rule('C8_Bid_bind', C8(b=None) + Bid(b=None, S='u') <> C8(b=1) % Bid(b=1, S='u'), *[kf, kr]) 
+   Rule('C8_Bid_bind', C8(b=None) + Bid(b=None, S='u') != C8(b=1) % Bid(b=1, S='u'), *[kf, kr]) 
 	     |              |     |           |         |     |    |     |             |
              |              |     |           |         |     |    |     |            parameter list
 	     |              |     |           |         |     |    |     |
@@ -328,7 +328,7 @@ With this state site added, we can now go ahead and write the rules
 that will account for the binding step and the unbinding step as
 follows::
 
-   Rule('C8_Bid_bind', C8(b=None) + Bid(b=None, S='u') <>C8(b=1) % Bid(b=1, S='u'), kf, kr)
+   Rule('C8_Bid_bind', C8(b=None) + Bid(b=None, S='u') !=C8(b=1) % Bid(b=1, S='u'), kf, kr)
    Rule('tBid_from_C8Bid', C8(b=1) % Bid(b=1, S='u') >> C8(b=None) % Bid(b=None, S='t'), kc)
 
 As shown, the initial reactants, *C8* and *Bid* initially in the
@@ -619,7 +619,7 @@ happens quite often in models and it is one of the basic functions we
 have found useful in our model development. Rather than typing many
 lines such as::
 
-   Rule("association",  Enz(b=None) + Sub(b=None, S="i") <> Enz(b=1)%Sub(b=1,S="i"), kf, kr)
+   Rule("association",  Enz(b=None) + Sub(b=None, S="i") != Enz(b=1)%Sub(b=1,S="i"), kf, kr)
    Rule("dissociation", Enz(b=1)%Sub(b=1,S="i") >> Enz(b=None) + Sub(b=None, S="a"), kc)
    
 multiple times, we find it more powerful, transparent and easy to
@@ -641,7 +641,7 @@ concepts into a programmatic format. Examine the function below::
        S = sub({'b': None, site: state1})                      # (5) define substrate state in function
        ES = enz(b=1) % sub({'b': 1, site: state1})             # (6) define state of enzyme:substrate complex
        P = sub({'b': None, site: state2})                      # (7) define state of product
-       Rule(r1_name, E + S <> ES, kf, kr)                      # (8) rule for enzyme + substrate association (bidirectional)
+       Rule(r1_name, E + S != ES, kf, kr)                      # (8) rule for enzyme + substrate association (bidirectional)
        Rule(r2_name, ES >> E + P, kc)                          # (9) rule for enzyme:substrate dissociation  (unidirectional)
 
 As shown it takes about ten lines to write the catalyze function

--- a/pysb/anneal_mod.py
+++ b/pysb/anneal_mod.py
@@ -3,6 +3,7 @@
 # Bug-fixes and changes by Carlos Lopez 2012
 #
 
+from __future__ import print_function
 import numpy
 from numpy import asarray, tan, exp, ones, squeeze, sign, \
      all, log, sqrt, pi, shape, array, minimum, where
@@ -51,9 +52,9 @@ class base_schedule(object):
         x0 : array
             The starting parameters vector.
         """
-        print "============================================================"
-        print "FINDING INITIAL TEMPERATURE WITH A COEFF OF VARIANCE OF", self.cvar
-        print "============================================================"
+        print("============================================================")
+        print("FINDING INITIAL TEMPERATURE WITH A COEFF OF VARIANCE OF", self.cvar)
+        print("============================================================")
 
         assert(not self.dims is None)
         lrange = self.lower
@@ -63,7 +64,7 @@ class base_schedule(object):
         fmin = _double_max
         x0 = best_state.x
         for _ in range(self.Ninit):
-            print "sampling T step:", _
+            print("sampling T step:", _)
             samp = squeeze(random.uniform(0, 1, size=self.dims)) - 0.5
             samp = samp/0.5
             varx0 = x0 * samp * cvar # random number within the cvar range
@@ -78,9 +79,9 @@ class base_schedule(object):
                 best_state.x = array(x0)
 
         self.T0 = (fmax-fmin)*1.5
-        print "================================="
-        print "SET INITIAL TEMPERATURE TO:", self.T0
-        print "================================="
+        print("=================================")
+        print("SET INITIAL TEMPERATURE TO:", self.T0)
+        print("=================================")
         return best_state.x
 
     def accept_test(self, dE):
@@ -295,9 +296,9 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 0
             if abs(af[-1]-best_state.cost) > feps*10:
                 retval = 5
-                print "Warning: Cooled to %f at %s but this is not" \
-                      % (squeeze(last_state.cost), str(squeeze(last_state.x))) \
-                      + " the smallest point found."
+                print("Warning: Cooled to %f at %s but this is not "
+                      "the smallest point found."
+                      % (squeeze(last_state.cost), squeeze(last_state.x)))
             break
         if (Tf is not None) and (schedule.T < Tf):
             retval = 1
@@ -306,7 +307,7 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 2
             break
         if (iters > maxiter):
-            print "Warning: Maximum number of iterations exceeded."
+            print("Warning: Maximum number of iterations exceeded.")
             retval = 3
             break
         if (maxaccept is not None) and (schedule.accepted > maxaccept):
@@ -325,12 +326,12 @@ if __name__ == "__main__":
     from numpy import cos
     # minimum expected at ~-0.195
     func = lambda x: cos(14.5*x-0.3) + (x+0.2)*x
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='cauchy')
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='fast')
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='boltzmann')
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='cauchy'))
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='fast'))
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='boltzmann'))
 
     # minimum expected at ~[-0.195, -0.1]
     func = lambda x: cos(14.5*x[0]-0.3) + (x[1]+0.2)*x[1] + (x[0]+0.2)*x[0]
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='cauchy')
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='fast')
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='boltzmann')
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='cauchy'))
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='fast'))
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='boltzmann'))

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -1,3 +1,4 @@
+from __future__ import print_function as _
 import pysb.core
 from pysb.generator.bng import BngGenerator
 import os
@@ -162,7 +163,7 @@ def run_ssa(model, t_end=10, n_steps=100, output_dir='/tmp',
                                 os.getpid(), random.randint(0, 100000))
 
     if os.path.exists(output_file_basename + '.bngl'):
-        print "WARNING! File %s already exists!" % (output_file_basename + '.bngl')
+        print("WARNING! File %s.bngl already exists!" % output_file_basename)
         output_file_basename += '_1'
 
     bng_filename = output_file_basename + '.bngl'
@@ -184,7 +185,7 @@ def run_ssa(model, t_end=10, n_steps=100, output_dir='/tmp',
         (p_out, p_err) = p.communicate()
         if p.returncode:
             raise GenerateNetworkError(p_out.rstrip("at line")+"\n"+p_err.rstrip())
-        print "Wrote " + gdat_filename # FIXME
+        print("Wrote " + gdat_filename) # FIXME
         output_arr = _parse_bng_outfile(gdat_filename)
         #ssa_file = open(ssa_filename, 'r')
         #output.write(ssa_file.read())

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -238,7 +238,8 @@ def generate_network(model, cleanup=True, append_stdout=False):
         bng_file.write(_generate_network_code)
         bng_file.close()
         p = subprocess.Popen(['perl', _get_bng_path(), bng_filename],
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             universal_newlines=True)
         (p_out, p_err) = p.communicate()
         if p.returncode:
             raise GenerateNetworkError(p_out.rstrip()+"\n"+p_err.rstrip())

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -7,7 +7,10 @@ import re
 import itertools
 import sympy
 import numpy
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 # Cached value of BNG path

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -272,20 +272,20 @@ def generate_equations(model):
         return
     lines = iter(generate_network(model).split('\n'))
     try:
-        while 'begin species' not in lines.next():
+        while 'begin species' not in next(lines):
             pass
         model.species = []
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end species' in line: break
             _parse_species(model, line)
 
-        while 'begin reactions' not in lines.next():
+        while 'begin reactions' not in next(lines):
             pass
         model.odes = [sympy.numbers.Zero()] * len(model.species)
         reaction_cache = {}
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end reactions' in line: break
             (number, reactants, products, rate, rule) = line.strip().split(' ', 4)
             # the -1 is to switch from one-based to zero-based indexing
@@ -332,10 +332,10 @@ def generate_equations(model):
             # now the 'reverse' value is no longer needed
             del r['reverse']
 
-        while 'begin groups' not in lines.next():
+        while 'begin groups' not in next(lines):
             pass
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end groups' in line: break
             _parse_group(model, line)
 

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -112,7 +112,7 @@ def _parse_bng_outfile(out_filename):
         column_names = [raw_name for raw_name in raw_names if not raw_name == '']
 
         # Create the dtype argument for the numpy record array
-        dt = zip(column_names, ('float',)*len(column_names))
+        dt = list(zip(column_names, ('float',)*len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
         arr = numpy.loadtxt(out_filename, dtype=dt, skiprows=1)

--- a/pysb/builder.py
+++ b/pysb/builder.py
@@ -43,7 +43,7 @@ subclass could be created as follows::
             k2 = self.parameter('k2', 1, prior=Uniform(-5, -1))
             A = self['A']
             B = self['B']
-            self.rule('A_B_bind', A(b=None) + B(b=None) <> A(b=1) % B(b=1),
+            self.rule('A_B_bind', A(b=None) + B(b=None) != A(b=1) % B(b=1),
                       k1, k2)
 
 This motif, implemented as a method, does several things: it manages the

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1368,7 +1368,7 @@ class Model(object):
         """
         # FIXME I don't even want to think about the inefficiency of this, but at least it works
         try:
-            return (i for i, s_cp in enumerate(self.species) if s_cp.is_equivalent_to(complex_pattern)).next()
+            return next((i for i, s_cp in enumerate(self.species) if s_cp.is_equivalent_to(complex_pattern)))
         except StopIteration:
             return None
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -690,7 +690,7 @@ class RuleExpression(object):
         self.is_reversible = is_reversible
 
     def __repr__(self):
-        operator = '<>' if self.is_reversible else '>>'
+        operator = '!=' if self.is_reversible else '>>'
         return '%s %s %s' % (repr(self.reactant_pattern), operator,
                              repr(self.product_pattern))
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -101,7 +101,7 @@ class SelfExporter(object):
             SelfExporter.default_model.add_component(obj)
 
         # load obj into target namespace under obj.name
-        if SelfExporter.target_globals.has_key(export_name):
+        if export_name in SelfExporter.target_globals:
             warnings.warn("'%s' already defined" % (export_name), SymbolExistsWarning, stacklevel)
         SelfExporter.target_globals[export_name] = obj
 
@@ -423,7 +423,7 @@ class MonomerPattern(object):
         value += ', '.join([
                 k + '=' + repr(self.site_conditions[k])
                 for k in self.monomer.sites
-                if self.site_conditions.has_key(k)
+                if k in self.site_conditions
                 ])
         value += ')'
         if self.compartment is not None:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -13,6 +13,12 @@ try:
     reload
 except NameError:
     from imp import reload
+try:
+    basestring
+except NameError:
+    # Under Python 3, do not pretend that bytes are a valid string
+    basestring = str
+    long = int
 
 def Initial(*args):
     """Declare an initial condition (see Model.initial)."""

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -9,7 +9,10 @@ import weakref
 import copy
 import itertools
 import sympy
-
+try:
+    reload
+except NameError:
+    from imp import reload
 
 def Initial(*args):
     """Declare an initial condition (see Model.initial)."""

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -498,10 +498,11 @@ class ComplexPattern(object):
         #   so some sort of canonicalization of that numbering is necessary.
         if not isinstance(other, ComplexPattern):
             raise Exception("Can only compare ComplexPattern to another ComplexPattern")
-        return \
-            self.compartment == other.compartment and \
-            sorted((mp.monomer, mp.site_conditions, mp.compartment) for mp in self.monomer_patterns) == \
-            sorted((mp.monomer, mp.site_conditions, mp.compartment) for mp in other.monomer_patterns)
+        return (self.compartment == other.compartment and
+                sorted((repr(mp.monomer), mp.site_conditions, mp.compartment)
+                       for mp in self.monomer_patterns) ==
+                sorted((repr(mp.monomer), mp.site_conditions, mp.compartment)
+                       for mp in other.monomer_patterns))
 
     def copy(self):
         """

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -234,12 +234,12 @@ class Monomer(Component):
         for site in sites:
             sites_seen.setdefault(site, 0)
             sites_seen[site] += 1
-        sites_dup = [site for site in sites_seen.keys() if sites_seen[site] > 1]
+        sites_dup = [site for site, count in sites_seen.items() if count > 1]
         if sites_dup:
             raise Exception("Duplicate sites specified: " + str(sites_dup))
 
         # ensure site_states keys are all known sites
-        unknown_sites = [site for site in site_states.keys() if not site in sites_seen]
+        unknown_sites = [site for site in site_states if not site in sites_seen]
         if unknown_sites:
             raise Exception("Unknown sites in site_states: " + str(unknown_sites))
         # ensure site_states values are all strings
@@ -316,7 +316,7 @@ class MonomerPattern(object):
 
     def __init__(self, monomer, site_conditions, compartment):
         # ensure all keys in site_conditions are sites in monomer
-        unknown_sites = [site for site in site_conditions.keys() if site not in monomer.sites]
+        unknown_sites = [site for site in site_conditions if site not in monomer.sites]
         if unknown_sites:
             raise Exception("MonomerPattern with unknown sites in " + str(monomer) + ": " + str(unknown_sites))
 

--- a/pysb/deprecated/anneal_sundials.py
+++ b/pysb/deprecated/anneal_sundials.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -93,7 +94,7 @@ def annlinit(model, abstol=1.0e-3, reltol=1.0e-3, nsteps = 1000, itermaxstep = N
     yout = numpy.zeros([nsteps, odesize])
 
     #initialize the arrays
-    #print "Initial parameter values:", y
+    #print("Initial parameter values:", y)
     xout[0] = 0.0 #CHANGE IF NEEDED
     #first step in yout
     for i in range(0, odesize):
@@ -158,15 +159,15 @@ def annlodesolve(model, tfinal, envlist, params, tinit = 0.0, ic=True):
     t = cvode.realtype(tinit)
     tout = tinit + tadd
     
-    #print "Beginning integration"
-    #print "TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize
-    #print "Integrating Parameters:\n", params
-    #print "y0:", yzero
+    #print("Beginning integration")
+    #print("TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize)
+    #print("Integrating Parameters:\n", params)
+    #print("y0:", yzero)
 
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -175,7 +176,7 @@ def annlodesolve(model, tfinal, envlist, params, tinit = 0.0, ic=True):
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     yobs = numpy.zeros([len(model.observables), nsteps])
@@ -214,7 +215,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = 0
@@ -223,9 +224,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # create a b-spline of the sim data and fit it to desired range
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -245,7 +246,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
         # assume a default variance
@@ -263,14 +264,14 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         objout += objarray.sum()
-        #print "OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
+        #print("OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
 
-    print "OBJOUT(total):", objout
+    print("OBJOUT(total):", objout)
     return objout
 
 def logparambounds(params, omag=1, useparams=[], usemag=None, initparams=[], initmag=None):
@@ -382,7 +383,7 @@ def tenninetycomp(outlistnorm, arglist, xpsamples=1.0):
     obj = ((1./varTdxp) * (Tdsim - Tdxp)**2.) + ((1./varTsxp) * (Tssim - Tsxp)**2.)
     #obj *= xpsamples
     
-    print "OBJOUT-10-90:(%g,%g):%g"%(Tdsim, Tssim, obj)
+    print("OBJOUT-10-90:(%g,%g):%g"%(Tdsim, Tssim, obj))
 
     return obj    
 
@@ -408,17 +409,17 @@ def annealfxn(zoparams, time, model, envlist, xpdata, xspairlist, lb, ub, tn = [
     paramarr = mapprms(zoparams, lb, ub, scaletype="log")
 
     #debug
-    #print "ZOPARAMS:\n", zoparams,"\n"
-    #print paramarr
+    #print("ZOPARAMS:\n", zoparams,"\n")
+    #print(paramarr)
 
     # eliminate values outside the boundaries, i.e. those outside [0,1)
     if numpy.greater_equal(paramarr, lb).all() and numpy.less_equal(paramarr, ub).all():
-        print "integrating... "
+        print("integrating... ")
         outlist = annlodesolve(model, time, envlist, paramarr)
 
         # normalized data needs a bit more tweaking before objfxn calculation
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -429,18 +430,18 @@ def annealfxn(zoparams, time, model, envlist, xpdata, xspairlist, lb, ub, tn = [
             if tn:
                 tn = tenninetycomp(outlistnorm, tn, len(xpdata[0]))
                 objout += tn 
-            print "NORM objout TOT:", objout
+            print("NORM objout TOT:", objout)
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
             if tn:
                 tn = tenninetycomp(outlist[0], tn)
                 objout += tn 
-            print "objout TOT:", objout
+            print("objout TOT:", objout)
     else:
-        print "======> VALUE OUT OF BOUNDS NOTED"
+        print("======> VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(paramarr, lb), numpy.less_equal(paramarr, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i,"\n======", paramarr[i],"\n", zoparams[i],"\n"
+            print("======>",i,"\n======", paramarr[i],"\n", zoparams[i],"\n")
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
 
     # save the params and temps for analysis

--- a/pysb/deprecated/anneal_sundials_OLD.py
+++ b/pysb/deprecated/anneal_sundials_OLD.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -152,7 +153,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
     else:
         #only a subset of parameters are used for annealing
         for i in range(len(useparams)):
-            #print "changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i]
+            #print("changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i])
             data.p[useparams[i]] = params[i]
 
     # update yzero if initial conditions are being modified as part of the parameters
@@ -177,7 +178,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -186,7 +187,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     obs_names = [name for name, rp in model.observable_patterns]
@@ -226,7 +227,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = 0
@@ -237,9 +238,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # code.interact(local=locals())
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -259,7 +260,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
         # assume a default variance
@@ -278,17 +279,17 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         #import code
         #code.interact(local=locals())
 
         objout += objarray.sum()
-        print "OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
+        print("OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
 
-    print "OBJOUT(total):", objout
+    print("OBJOUT(total):", objout)
     return objout
 
 def getgenparambounds(params, omag=1, N=1000., useparams=[], usemag=None, useN=None ):
@@ -322,7 +323,7 @@ def getgenparambounds(params, omag=1, N=1000., useparams=[], usemag=None, useN=N
             ub[i] = params[i] * pow(10, omag)
             lb[i] = params[i] / pow(10, omag)
             dx[i] = (ub[i] - lb[i])/N
-    #print dx
+    #print(dx)
     lower = params - dx/2
     lower[numpy.where(lower<0.)] = 0.0 #make sure we don't go negative on parameters
     upper = params + dx/2
@@ -351,11 +352,11 @@ def annealfxn(params, useparams, time, model, envlist, xpdata, xspairlist, lb, u
 
     
     if numpy.greater_equal(params, lb).all() and numpy.less_equal(params, ub).all():
-        print "Integrating..."
+        print("Integrating...")
         outlist = annlodesolve(model, time, envlist, params, useparams)
         # specify that this is normalized data
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -366,10 +367,10 @@ def annealfxn(params, useparams, time, model, envlist, xpdata, xspairlist, lb, u
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
     else:
-        print "======>VALUE OUT OF BOUNDS NOTED"
+        print("======>VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(params, lb), numpy.less_equal(params, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i, params[i]
+            print("======>",i, params[i])
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
 
     # save the params and temps for analysis
@@ -448,7 +449,7 @@ def tenninetycomp(outlistnorm, arglist, xpsamples=1.0):
     obj = ((1./varTdxp) * (Tdsim - Tdxp)**2.) + ((1./varTsxp) * (Tssim - Tsxp)**2.)
     obj *= xpsamples
     
-    print "OBJOUT-10-90:(%f,%f):%f"%(Tdsim, Tssim, obj)
+    print("OBJOUT-10-90:(%f,%f):%f"%(Tdsim, Tssim, obj))
 
     return obj    
 
@@ -465,11 +466,11 @@ def annealfxncust(params, useparams, time, model, envlist, xpdata, xspairlist, t
     #
 
     if numpy.greater_equal(params, lb).all() and numpy.less_equal(params, ub).all():
-        print "Integrating..."
+        print("Integrating...")
         outlist = annlodesolve(model, time, envlist, params, useparams)
         # specify that this is normalized data
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -481,16 +482,16 @@ def annealfxncust(params, useparams, time, model, envlist, xpdata, xspairlist, t
             # Now SMAC
             tn = tenninetycomp(outlistnorm, tenninetylist,len(xpdata[0]))
             objout += tn 
-            print "objout TOT:", objout
+            print("objout TOT:", objout)
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
             tn = tenninetycomp(outlistnorm, tenninetylist)
             objout += tn 
     else:
-        print "======>VALUE OUT OF BOUNDS NOTED"
+        print("======>VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(params, lb), numpy.less_equal(params, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i, params[i]
+            print("======>",i, params[i])
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
     return objout
 

--- a/pysb/deprecated/bng_parser.py
+++ b/pysb/deprecated/bng_parser.py
@@ -10,7 +10,7 @@ reserved_list = [
     'reaction_rules',
     'observables',
     ]
-reserved = dict([r, r.upper()] for r in reserved_list)
+reserved = dict((r, r.upper()) for r in reserved_list)
 
 tokens = [
     'ID',
@@ -29,7 +29,7 @@ tokens = [
     'LPAREN',
     'RPAREN',
     'NEWLINE',
-    ] + reserved.values()
+    ] + list(reserved.values())
 
 t_COMMA       = r','
 t_PLUS        = r'\+'

--- a/pysb/deprecated/bng_parser.py
+++ b/pysb/deprecated/bng_parser.py
@@ -1,4 +1,5 @@
-from ply import lex, yacc;
+from __future__ import print_function
+from ply import lex, yacc
 
 
 reserved_list = [
@@ -53,7 +54,7 @@ def t_FLOAT(t):
     try:
         t.value = float(t.value)    
     except ValueError:
-        print "Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value)
+        print("Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value))
         t.value = float("nan")
     return t
 
@@ -62,7 +63,7 @@ def t_INTEGER(t):
     try:
         t.value = int(t.value)    
     except ValueError:
-        print "Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value)
+        print("Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value))
         t.value = 0
     return t
 
@@ -80,7 +81,7 @@ t_ignore  = ' \t'
 
 # Error handling rule
 def t_error(t):
-    print "Illegal character '%s' on line %d" % (t.value[0], t.lineno)
+    print("Illegal character '%s' on line %d" % (t.value[0], t.lineno))
     t.lexer.skip(1)
 
 
@@ -101,7 +102,7 @@ def list_helper(p):
 def p_model(p):
     'model : block_list'
     p[0] = p[1]
-    print "model:", p[0]
+    print("model:", p[0])
 
 def p_block_list(p):
     '''block_list : block_list block
@@ -122,27 +123,27 @@ def p_block_empty(p):
 def p_parameter_block(p):
     'parameter_block : BEGIN PARAMETERS NEWLINE parameter_st_list END PARAMETERS NEWLINE'
     p[0] = p[4]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_molecule_type_block(p):
     'molecule_type_block : BEGIN MOLECULE_TYPES NEWLINE END MOLECULE_TYPES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_species_block(p):
     'species_block : BEGIN SPECIES NEWLINE END SPECIES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_reaction_rules_block(p):
     'reaction_rules_block : BEGIN REACTION_RULES NEWLINE END REACTION_RULES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_observables_block(p):
     'observables_block : BEGIN OBSERVABLES NEWLINE END OBSERVABLES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_parameter_st_list(p):
     '''parameter_st_list : parameter_st_list parameter_st
@@ -164,52 +165,52 @@ def p_number(p):
 # def p_statement_list(p):
 #     '''statement_list : statement_list statement'''
 #     p[0] = p[1] + [p[2]]
-#     #print "statement_list:", p[0]
+#     #print("statement_list:", p[0])
 
 # def p_statement_list_trivial(p):
 #     '''statement_list : statement'''
 #     p[0] = [p[1]]
-#     #print "statement_list_trivial:", p[0]
+#     #print("statement_list_trivial:", p[0])
 
 # def p_statement_empty(p):
 #     'statement : NEWLINE'
-#     #print "statement_empty:", p[0]
+#     #print("statement_empty:", p[0])
 
 # def p_statement(p):
 #     'statement : rule NEWLINE'
 #     p[0] = p[1]
-#     #print "statement:", p[0]
+#     #print("statement:", p[0])
 
 # def p_rule(p):
 #     '''rule : irr_rule
 #             | rev_rule'''
 #     p[0] = p[1]
-#     #print "rule:", p[0]
+#     #print("rule:", p[0])
 
 # def p_irr_rule(p):
 #     'irr_rule : expression IRRARROW expression LPAREN FLOAT RPAREN'
-#     #print "irr_rule"
+#     #print("irr_rule")
 #     p[0] = RuleIrreversible(reactants=p[1], products=p[3], rate=p[5])
 
 # def p_rev_rule(p):
 #     'rev_rule : expression REVARROW expression LPAREN FLOAT COMMA FLOAT RPAREN'
-#     #print "rev_rule"
+#     #print("rev_rule")
 #     p[0] = RuleReversible(reactants=p[1], products=p[3], rates=[p[5], p[7]])
 
 # def p_expression_plus(p):
 #     'expression : expression PLUS expression'
 #     p[0] = p[1] + p[3]
-#     #print "expression_plus:", p[0]
+#     #print("expression_plus:", p[0])
 
 # def p_expression_species(p):
 #     'expression : SPECIES'
-#     #print "expression_species:", p[1]
+#     #print("expression_species:", p[1])
 #     p[0] = [Species(name=p[1])]
 
 # Error rule for syntax errors
 def p_error(p):
-    print "Syntax error in input:"
-    print p
+    print("Syntax error in input:")
+    print(p)
 
 precedence = (
     ('left', 'PLUS'),

--- a/pysb/deprecated/pysundials_helpers.py
+++ b/pysb/deprecated/pysundials_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from scipy.integrate._ode import IntegratorBase
 from pysundials import cvode as _cvode, nvecserial
 import ctypes
@@ -64,7 +65,7 @@ class cvode(IntegratorBase):
         flag = _cvode.CVode(self.cvode_mem, t1, self.y, tret, _cvode.CV_NORMAL)
         if flag < 0:
             self.success = 0
-            print "cvodes error: %d (see SUNDIALS manual for more information)" % flag
+            print("cvodes error: %d (see SUNDIALS manual for more information)" % flag)
         return (self.y, t1)
 
 IntegratorBase.integrator_classes.append(cvode)

--- a/pysb/deprecated/varsens_sundials.py
+++ b/pysb/deprecated/varsens_sundials.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -13,7 +14,7 @@ from pysundials import cvode
 
 def spinner(i):
     spin = ("|", "/","-", "\\")
-    print "\r[%s] %d"%(spin[i%4],i),
+    print("\r[%s] %d"%(spin[i%4],i), end=' ')
     sys.stdout.flush()
 
 # reltol of 1.0e-3, relative error of ~1%. abstol of 1.0e-3, enough for values that oscillate in the hundreds to thousands
@@ -90,7 +91,7 @@ def odeinit(model, reltol=1.0e-3, abstol=1.0e-3, nsteps = 1000, itermaxstep = No
     yout = numpy.zeros([nsteps, odesize])
 
     #initialize the arrays
-    #print "Initial parameter values:", y
+    #print("Initial parameter values:", y)
     xout[0] = 0.0 #CHANGE IF NEEDED
     #first step in yout
     for i in range(0, odesize):
@@ -121,7 +122,7 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
     else:
         #only a subset of parameters are used for annealing
         for i in range(len(useparams)):
-            #print "changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i]
+            #print("changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i])
             data.p[useparams[i]] = params[i]
 
     # FIXME:
@@ -148,15 +149,15 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
     t = cvode.realtype(tinit)
     tout = tinit + tadd
     
-    #print "Beginning integration"
-    #print "TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize
-    #print "Integrating Parameters:\n", params
-    #print "y0:", yzero
+    #print("Beginning integration")
+    #print("TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize)
+    #print("Integrating Parameters:\n", params)
+    #print("y0:", yzero)
 
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -165,7 +166,7 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     #obs_names = [name for name, rp in model.observable_patterns]
@@ -203,7 +204,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = []
@@ -214,9 +215,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # code.interact(local=locals())
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -236,7 +237,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
             # assume a default variance
@@ -251,16 +252,16 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         #import code
         #code.interact(local=locals())
 
         objout.append(objarray.sum())
-        #print "OBJOUT(%d,%d):%f  OBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
-    #print "OBJOUT(total):", objout
+        #print("OBJOUT(%d,%d):%f  OBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
+    #print("OBJOUT(total):", objout)
     return numpy.asarray(objout)
 
 def getlog(sobolarr, params, omag=1, useparams=[], usemag=None):
@@ -320,7 +321,7 @@ def getlin(sobolarr, params, CV =.25, useparams=[], useCV=None):
         for i in range(sobprmarr.shape[0]):
             sobprmarr[i] = (sobolarr[i]*(ub-lb)) + lb
     else:
-        print "array shape not allowed... "
+        print("array shape not allowed... ")
         
 
     # sobprmarr is the N x len(params) array for sobol analysis
@@ -361,7 +362,7 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
     # specify that this is normalized data
     if norm is True:
         # First process the A and B matrices
-        print "processing matrix A, %d iterations:", sobmtxA.shape[0]
+        print("processing matrix A, %d iterations:", sobmtxA.shape[0])
         for i in range(sobmtxA.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxA[i], useparams, ic)
             datamax = numpy.max(outlist[0], axis = 1)
@@ -371,7 +372,7 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
             yA[i] = compare_data(xpdata, outlistnorm, xspairlist, vardata)
             spinner(i)
 
-        print "\nprocessing matrix B, %d iterations:", sobmtxB.shape[0]
+        print("\nprocessing matrix B, %d iterations:", sobmtxB.shape[0])
         for i in range(sobmtxB.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxB[i], useparams, ic)
             datamax = numpy.max(outlist[0], axis = 1)
@@ -383,9 +384,9 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
             spinner(i)
 
         # now the C matrix, a bit more complicated b/c it is of size params x samples
-        print "\nprocessing matrix C_n, %d parameters:"%(sobmtxC.shape[0])
+        print("\nprocessing matrix C_n, %d parameters:"%(sobmtxC.shape[0]))
         for i in range(sobmtxC.shape[0]):
-            print "\nprocessing processing parameter %d, %d iterations"%(i,sobmtxC.shape[1])
+            print("\nprocessing processing parameter %d, %d iterations"%(i,sobmtxC.shape[1]))
             for j in range(sobmtxC.shape[1]):
                 outlist = odesolve(model, time, envlist, sobmtxC[i][j], useparams, ic)
                 datamax = numpy.max(outlist[0], axis = 1)
@@ -397,21 +398,21 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
                 spinner(j)
     else:
         # First process the A and B matrices
-        print "processing matrix A:"
+        print("processing matrix A:")
         for i in range(sobmtxA.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxA[i], useparams, ic)
             yA[i] = compare_data(xpdata, outlist[0], xspairlist, vardata)
             spinner(i)
 
-        print "processing matrix B:"
+        print("processing matrix B:")
         for i in range(sobmtxB.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxB[i], useparams, ic)
             yB[i] = compare_data(xpdata, outlistnorm, xspairlist, vardata)
             spinner(i)
 
-        print "processing matrix C_n"
+        print("processing matrix C_n")
         for i in range(sobmtxC.shape[0]):
-            print "processing processing parameter %d"%i
+            print("processing processing parameter %d"%i)
             for j in range(sobmtxC.shape[1]):
                 outlist = odesolve(model, time, envlist, sobmtxC[i][j], useparams, ic)
                 yC[i][j] = compare_data(xpdata, outlistnorm, xspairlist, vardata)

--- a/pysb/examples/bax_pore.py
+++ b/pysb/examples/bax_pore.py
@@ -4,6 +4,7 @@ bax_pore_sequential.py). Inhibition of pore formation by Mcl-1 is also
 implemented.
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -61,8 +62,8 @@ Observable('BAX4_inh', BAX(inh=ANY, t1=1, t2=3) % BAX(t1=4, t2=1) % BAX(t1=2, t2
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_bax_pore.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_bax_pore.py for example usage.""")

--- a/pysb/examples/bax_pore.py
+++ b/pysb/examples/bax_pore.py
@@ -20,7 +20,7 @@ Annotation(MCL1, 'http://identifiers.org/uniprot/Q07820')
 Parameter('kdimf', 1e-6)
 Parameter('kdimr', 1e-7)
 Rule('bax_dim',
-     BAX(t1=None, t2=None) + BAX(t1=None, t2=None) <>
+     BAX(t1=None, t2=None) + BAX(t1=None, t2=None) !=
      BAX(t1=1, t2=None) % BAX(t1=None, t2=1),
      kdimf, kdimr)
 
@@ -28,7 +28,7 @@ Rule('bax_dim',
 Parameter('ktetf', 1e-3)
 Parameter('ktetr', 1e-4)
 Rule('bax_tet',
-     BAX(t1=1, t2=None) % BAX(t1=None, t2=1) + BAX(t1=2, t2=None) % BAX(t1=None, t2=2) <>
+     BAX(t1=1, t2=None) % BAX(t1=None, t2=1) + BAX(t1=2, t2=None) % BAX(t1=None, t2=2) !=
      BAX(t1=1, t2=3) % BAX(t1=4, t2=1) % BAX(t1=2, t2=4) % BAX(t1=3, t2=2),
      ktetf, ktetr)
 
@@ -36,7 +36,7 @@ Rule('bax_tet',
 Parameter('kbaxmcl1f', 1e-5)
 Parameter('kbaxmcl1r', 1e-6)
 Rule('bax_inh_mcl1',
-     BAX(inh=None) + MCL1(b=None) <>
+     BAX(inh=None) + MCL1(b=None) !=
      BAX(inh=1)    % MCL1(b=1),
      kbaxmcl1f, kbaxmcl1r)
 

--- a/pysb/examples/bax_pore_sequential.py
+++ b/pysb/examples/bax_pore_sequential.py
@@ -3,6 +3,7 @@ complex one at a time (contrast with bax_pore.py). Also implements cargo
 transport (Smac).
 """
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import assemble_pore_sequential, pore_transport, pore_species
 
@@ -50,8 +51,9 @@ Observable('cSmac', Smac(loc='c'))
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_bax_pore_sequential.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_bax_pore_sequential.py for example
+usage.""")

--- a/pysb/examples/bngwiki_egfr_simple.py
+++ b/pysb/examples/bngwiki_egfr_simple.py
@@ -60,12 +60,12 @@ Observable('Sos1_act', EGFR(Y1068=1) % Grb2(SH2=1, SH3=2) % Sos1(PxxP=2))
 
 # Ligand-receptor binding
 Rule('egf_bind_egfr',
-     EGFR(L=None, CR1=None) + EGF(R=None) <> EGFR(L=1, CR1=None) % EGF(R=1),
+     EGFR(L=None, CR1=None) + EGF(R=None) != EGFR(L=1, CR1=None) % EGF(R=1),
      kp1, km1)
 
 # Receptor-aggregation
 Rule('egfr_dimerize',
-     EGFR(L=ANY, CR1=None) + EGFR(L=ANY, CR1=None) <>
+     EGFR(L=ANY, CR1=None) + EGFR(L=ANY, CR1=None) !=
      EGFR(L=ANY, CR1=1) % EGFR(L=ANY, CR1=1),
      kp2, km2)
 
@@ -79,12 +79,12 @@ Rule('egfr_dephos',
 
 # Grb2 binding to pY1068
 Rule('grb2_bind_egfr',
-     EGFR(Y1068='P') + Grb2(SH2=None) <> EGFR(Y1068=('P',1)) % Grb2(SH2=1),
+     EGFR(Y1068='P') + Grb2(SH2=None) != EGFR(Y1068=('P',1)) % Grb2(SH2=1),
      kp4, km4)
 
 # Grb2 binding to Sos1
 Rule('sos1_bind_grb2',
-     Grb2(SH3=None) + Sos1(PxxP=None) <> Grb2(SH3=1) % Sos1(PxxP=1),
+     Grb2(SH3=None) + Sos1(PxxP=None) != Grb2(SH3=1) % Sos1(PxxP=1),
      kp5, km5)
 
 # Receptor dimer internalization/degradation

--- a/pysb/examples/bngwiki_egfr_simple.py
+++ b/pysb/examples/bngwiki_egfr_simple.py
@@ -3,6 +3,7 @@
 http://bionetgen.org/index.php/Egfr_simple
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -93,7 +94,8 @@ Rule('egfr_dimer_degrade',
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/bngwiki_simple.py
+++ b/pysb/examples/bngwiki_simple.py
@@ -3,6 +3,7 @@
 http://bionetgen.org/index.php/Simple
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -40,7 +41,8 @@ Observable('Lbound', EGF(R=ANY))  # Molecules
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/bngwiki_simple.py
+++ b/pysb/examples/bngwiki_simple.py
@@ -33,7 +33,7 @@ Initial(EGF(R=None), EGF0)
 Initial(EGFR(L=None, CR1=None, Y1068='U'), EGFR0)
 
 
-Rule('egf_binds_egfr', EGF(R=None) + EGFR(L=None) <> EGF(R=1) % EGFR(L=1), kp1, km1)
+Rule('egf_binds_egfr', EGF(R=None) + EGFR(L=None) != EGF(R=1) % EGFR(L=1), kp1, km1)
 
 
 # Species LR EGF(R!1).EGFR(L!1)

--- a/pysb/examples/earm_1_0.py
+++ b/pysb/examples/earm_1_0.py
@@ -7,6 +7,7 @@ Cell Death. PLoS Biol 6(12): e299. doi:10.1371/journal.pbio.0060299
 http://www.plosbiology.org/article/info:doi/10.1371/journal.pbio.0060299
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -294,8 +295,8 @@ for m in model.monomers:
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_earm_1_0.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_earm_1_0.py for example usage.""")

--- a/pysb/examples/earm_1_0.py
+++ b/pysb/examples/earm_1_0.py
@@ -86,7 +86,7 @@ def catalyze(enz, sub, prod, kf, kr, kc):
     S = sub(b=None)
     ES = enz(b=1) % sub(b=1)
     P = prod(b=None)
-    Rule(r1_name, E + S <> ES, kf, kr)
+    Rule(r1_name, E + S != ES, kf, kr)
     Rule(r2_name, ES >> E + P, kc)
 
 
@@ -98,7 +98,7 @@ def catalyze_convert(s1, s2, p, kf, kr, kc):
     B = s2(b=None)
     AB = s1(b=1) % s2(b=1)
     C = p(b=None)
-    Rule(r1_name, A + B <> AB, kf, kr)
+    Rule(r1_name, A + B != AB, kf, kr)
     Rule(r2_name, AB >> C, kc)
 
 
@@ -108,7 +108,7 @@ def inhibit(targ, inh, kf, kr):
     T = targ(b=None)
     I = inh(b=None)
     TI = targ(b=1) % inh(b=1)
-    Rule(r_name, T + I <> TI, kf, kr)
+    Rule(r_name, T + I != TI, kf, kr)
 
 
 # L + pR <--> L:pR --> DISC
@@ -183,7 +183,7 @@ catalyze(tBid, Bax, aBax, kf12, kr12, kc12)
 # aBax <-->  MBax 
 Parameter('kf13', transloc)
 Parameter('kr13', transloc)
-Rule('transloc_MBax_aBax', aBax(b=None) <> MBax(b=None), kf13, kr13)
+Rule('transloc_MBax_aBax', aBax(b=None) != MBax(b=None), kf13, kr13)
 
 # MBax + Bcl2 <-->  MBax:Bcl2  
 Parameter('kf14', 1e-06/v)
@@ -193,7 +193,7 @@ inhibit(MBax, Bcl2, kf14, kr14)
 # MBax + MBax <-->  Bax2
 Parameter('kf15', 1e-06/v*2)
 Parameter('kr15', 1e-03)
-Rule('dimerize_MBax_to_Bax2', MBax(b=None) + MBax(b=None) <> Bax2(b=None), kf15, kr15)
+Rule('dimerize_MBax_to_Bax2', MBax(b=None) + MBax(b=None) != Bax2(b=None), kf15, kr15)
 
 # Bax2 + Bcl2 <-->  Bax2:Bcl2  
 Parameter('kf16', 1e-06/v)
@@ -203,7 +203,7 @@ inhibit(Bax2, Bcl2, kf16, kr16)
 # Bax2 + Bax2 <-->  Bax4
 Parameter('kf17', 1e-06/v*2)
 Parameter('kr17', 1e-03)
-Rule('dimerize_Bax2_to_Bax4', Bax2(b=None) + Bax2(b=None) <> Bax4(b=None), kf17, kr17)
+Rule('dimerize_Bax2_to_Bax4', Bax2(b=None) + Bax2(b=None) != Bax4(b=None), kf17, kr17)
 
 # Bax4 + Bcl2 <-->  Bax4:Bcl2  
 Parameter('kf18', 1e-06/v)
@@ -231,7 +231,7 @@ catalyze(AMito, mSmac, ASmac, kf21, kr21, kc21)
 # ACytoC <-->  cCytoC
 Parameter('kf22', transloc)
 Parameter('kr22', transloc)
-Rule('transloc_cCytoC_ACytoC', ACytoC(b=None) <> cCytoC(b=None), kf22, kr22)
+Rule('transloc_cCytoC_ACytoC', ACytoC(b=None) != cCytoC(b=None), kf22, kr22)
 
 # Apaf + cCytoC <-->  Apaf:cCytoC --> aApaf + cCytoC
 Parameter('kf23', 5e-07)
@@ -242,7 +242,7 @@ catalyze(cCytoC, Apaf, aApaf, kf23, kr23, kc23)
 # aApaf + pC9 <-->  Apop
 Parameter('kf24', 5e-08)
 Parameter('kr24', 1e-03)
-Rule('bind_aApaf_pC9_as_Apop', aApaf(b=None) + pC9(b=None) <> Apop(b=None), kf24, kr24)
+Rule('bind_aApaf_pC9_as_Apop', aApaf(b=None) + pC9(b=None) != Apop(b=None), kf24, kr24)
 
 # Apop + pC3 <-->  Apop:pC3 --> Apop + C3
 Parameter('kf25', 5e-09)
@@ -253,7 +253,7 @@ catalyze(Apop, pC3, C3, kf25, kr25, kc25)
 # ASmac <-->  cSmac
 Parameter('kf26', transloc)
 Parameter('kr26', transloc)
-Rule('transloc_cSmac_ASmac', ASmac(b=None) <> cSmac(b=None), kf26, kr26)
+Rule('transloc_cSmac_ASmac', ASmac(b=None) != cSmac(b=None), kf26, kr26)
 
 # Apop + XIAP <-->  Apop:XIAP  
 Parameter('kf27', 2e-06)

--- a/pysb/examples/earm_1_3.py
+++ b/pysb/examples/earm_1_3.py
@@ -12,6 +12,7 @@ http://www.ploscompbiol.org/article/info:doi/10.1371/journal.pcbi.1002482
 # duplicating the body of that model here, we'll start this model off as a copy
 # of that one then modify and add components as necessary.
 
+from __future__ import print_function
 import re
 from pysb import *
 import pysb.bng
@@ -145,9 +146,9 @@ for species in all_species:
 
 def show_species():
     """Print a table of species like Table S2"""
-    print '   | %-12s %8s %20s %10s' \
-        % ('species', 'initial', 'synth rate', 'deg rate')
-    print '-' * (5 + 12 + 1 + 8 + 1 + 20 + 1 + 10)
+    print('   | %-12s %8s %20s %10s' %
+          ('species', 'initial', 'synth rate', 'deg rate'))
+    print('-' * (5 + 12 + 1 + 8 + 1 + 20 + 1 + 10))
     for i, species in enumerate(all_species, 1):
         mp_names = [mp.monomer.name for mp in species.monomer_patterns]
         name = '_'.join(mp_names)
@@ -165,39 +166,43 @@ def show_species():
         else:
             ks_expr = '0'
         values = (i, display_name, ic_value, ks_expr, kdeg.value)
-        print '%2d | %-12s %8d %20s %10g' % values
+        print('%2d | %-12s %8d %20s %10g' % values)
 
 def show_rates():
     """Print a table of rate parameters like Table S4"""
     # FIXME kf14-kf21 need to be un-scaled by v to make the table look right
-    print ("%-20s        " * 3) % ('forward', 'reverse', 'catalytic')
-    print '-' * (9 + 11 + 7) * 3
+    print(("%-20s        " * 3) % ('forward', 'reverse', 'catalytic'))
+    print('-' * (9 + 11 + 7) * 3)
     for i in list(range(1,29)) + [31]:
         for t in ('f', 'r', 'c'):
             n = 'k%s%d' % (t,i)
             p = model.parameters.get(n)
             if p is not None:
-                print "%-9s%11g       " % (p.name, p.value),
-        print
+                print("%-9s%11g       " % (p.name, p.value), end=' ')
+        print()
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\n"
-    print "Initial species concentrations and synthesis/degradation rates\n" \
-        "==========\n" \
-        "(compare to supporting text S3, table S2 from Gaudet et al., " \
-        "however note that\nthe numbering and ordering is different)\n" 
+    print(__doc__, "\n", model)
+    print("""
+Initial species concentrations and synthesis/degradation rates
+==========
+(compare to supporting text S3, table S2 from Gaudet et al.,
+however note that the numbering and ordering is different.)""")
     show_species()
-    print "\n"
+    print("\n")
 
-    print "Kinetic rate parameters\n" \
-        "==========\n" \
-        "(compare to supporting text S3, table S4 from Gaudet et al., " \
-        "however note that\nkf14-kf21 are off by a factor of 'v' (%g) as " \
-        "this volume scaling factor has\nbeen moved from the ODEs to the " \
-        "rate values in this implementation)\n" % v
+    print("""
+Kinetic rate parameters
+==========
+(compare to supporting text S3, table S4 from Gaudet et al.,
+however note that kf14-kf21 are off by a factor of 'v' (%g) as
+this volume scaling factor has been moved from the ODEs to the
+rate values in this implementation)
+""" % v)
     show_rates()
-    print "\n\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print("""
+
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/earm_1_3.py
+++ b/pysb/examples/earm_1_3.py
@@ -172,7 +172,7 @@ def show_rates():
     # FIXME kf14-kf21 need to be un-scaled by v to make the table look right
     print ("%-20s        " * 3) % ('forward', 'reverse', 'catalytic')
     print '-' * (9 + 11 + 7) * 3
-    for i in range(1,29) + [31]:
+    for i in list(range(1,29)) + [31]:
         for t in ('f', 'r', 'c'):
             n = 'k%s%d' % (t,i)
             p = model.parameters.get(n)

--- a/pysb/examples/explicit.py
+++ b/pysb/examples/explicit.py
@@ -1,6 +1,7 @@
 """Example of how to write a model without using SelfExporter.
 """
 
+from __future__ import print_function
 from pysb import *
 import pysb.core
 
@@ -27,7 +28,8 @@ model.initial(L(r=None), L_0)
 model.initial(R(l=None), R_0)
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/fricker_2010_apoptosis.py
+++ b/pysb/examples/fricker_2010_apoptosis.py
@@ -10,6 +10,7 @@ http://jcb.rupress.org/content/190/3/377.long
 Implemented by: Jeremie Roux, Will Chen, Jeremy Muhlich
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -169,10 +170,11 @@ for m in model.monomers:
 ####
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")
 
 
 ####

--- a/pysb/examples/fricker_2010_apoptosis.py
+++ b/pysb/examples/fricker_2010_apoptosis.py
@@ -53,7 +53,7 @@ Rule('RL_FADD_Binding', pR (b=ANY, rf=None) + FADD (rf=None, fe=None) >> pR (b=A
 #C8 binds to L:R:FADD
 Parameter('kf30', 3.19838e-03) #3.19838e-03
 Parameter('kr30', 0.1) #0.1
-Rule('RLFADD_C8_Binding', FADD (rf=ANY, fe=None) + pC8 (fe=None, ee=None, D384='U') <> FADD (rf=ANY, fe=1) % pC8 (fe=1, ee=None, D384='U'), kf30, kr30)
+Rule('RLFADD_C8_Binding', FADD (rf=ANY, fe=None) + pC8 (fe=None, ee=None, D384='U') != FADD (rf=ANY, fe=1) % pC8 (fe=1, ee=None, D384='U'), kf30, kr30)
 
 #FLIP(variants) bind to L:R:FADD
 Parameter('kf31', 69.3329e-03)
@@ -62,7 +62,7 @@ Parameter('kf32', 69.4022e-03)
 Parameter('kr32', 0.08)
 # FIXME: this pattern requires a dummy kr31 which is ultimately ignored
 for flip_m, kf, kr, reversible in (zip(flip_monomers, (kf31,kf32), (kr31,kr32), (False,True))):
-    rule = Rule('RLFADD_%s_Binding' % flip_m.name, FADD (rf=ANY, fe=None) + flip_m (fe=None, ee=None) <> FADD (rf=ANY, fe=1) % flip_m (fe=1, ee=None), kf, kr)
+    rule = Rule('RLFADD_%s_Binding' % flip_m.name, FADD (rf=ANY, fe=None) + flip_m (fe=None, ee=None) != FADD (rf=ANY, fe=1) % flip_m (fe=1, ee=None), kf, kr)
     if reversible is False:
         rule.is_reversible = False;
         rule.rate_reverse = None;
@@ -76,7 +76,7 @@ p43_HeteroD = pC8 (fe=ANY, ee=1, D384='C') % flipL (fe=ANY, ee=1, D384='C')
 Parameter('kf33', 2.37162)
 Parameter('kr33', 0.1)
 Parameter('kc33', 1e-05)
-Rule('RLFADD_C8_C8_Binding', pC8 (fe=ANY, ee=None, D384='U') + pC8 (fe=ANY, ee=None, D384='U') <> pC8_HomoD, kf33, kr33)
+Rule('RLFADD_C8_C8_Binding', pC8 (fe=ANY, ee=None, D384='U') + pC8 (fe=ANY, ee=None, D384='U') != pC8_HomoD, kf33, kr33)
 
 #L:R:FADD:C8 L:R:FADD:FLIP(variants) dimerizes
 Parameter('kf34', 4.83692)
@@ -85,7 +85,7 @@ Parameter('kf35', 2.88545)
 Parameter('kr35', 1)
 # FIXME: this pattern requires a dummy kr31 which is ultimately ignored
 for flip_m, kf, kr, reversible in (zip(flip_monomers, (kf34,kf35), (kr34,kr35), (False,True))):
-    rule = Rule('RLFADD_C8_%s_Binding' % flip_m.name, pC8 (fe=ANY, ee=None, D384='U') + flip_m (fe=ANY, ee=None) <> pC8 (fe=ANY, ee=1, D384='U') % flip_m (fe=ANY, ee=1), kf, kr)
+    rule = Rule('RLFADD_C8_%s_Binding' % flip_m.name, pC8 (fe=ANY, ee=None, D384='U') + flip_m (fe=ANY, ee=None) != pC8 (fe=ANY, ee=1, D384='U') % flip_m (fe=ANY, ee=1), kf, kr)
     if reversible is False:
         rule.is_reversible = False;
         rule.rate_reverse = None;

--- a/pysb/examples/hello_pysb.py
+++ b/pysb/examples/hello_pysb.py
@@ -23,7 +23,7 @@ Initial(L(s=None), L_0)
 Initial(R(s=None), R_0)
 
 # Declare the binding rule
-Rule('L_binds_R', L(s=None) + R(s=None) <> L(s=1) % R(s=1), kf, kr)
+Rule('L_binds_R', L(s=None) + R(s=None) != L(s=1) % R(s=1), kf, kr)
 
 # Observe the complex
 Observable('LR', L(s=1) % R(s=1))

--- a/pysb/examples/hello_pysb.py
+++ b/pysb/examples/hello_pysb.py
@@ -3,6 +3,7 @@
 (This is the example shown on the pysb.org home page.)
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -30,10 +31,10 @@ Observable('LR', L(s=1) % R(s=1))
 if __name__ == '__main__':
     from pylab import linspace, plot, xlabel, ylabel, show
     from pysb.integrate import odesolve
-    print __doc__
+    print(__doc__)
     # Simulate the model through 40 seconds
     time = linspace(0, 40, 100)
-    print "Simulating..."
+    print("Simulating...")
     x = odesolve(model, time)
     # Plot the trajectory of LR
     plot(time, x['LR'])

--- a/pysb/examples/kinase_cascade.py
+++ b/pysb/examples/kinase_cascade.py
@@ -10,6 +10,7 @@ http://www.nature.com/msb/journal/v5/n1/full/msb200874.html
 Implemented by: Jeremy Muhlich
 """
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import catalyze_state
 
@@ -83,7 +84,8 @@ Observable('ppERK', ERK(t185='p', y187='p'))
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/move_connected.py
+++ b/pysb/examples/move_connected.py
@@ -1,6 +1,7 @@
 """Demonstration of the move_connected keyword for Rules
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -35,7 +36,8 @@ Parameter('ABx_0', 1)
 Initial(A(b=1)**X % B(a=1)**X, ABx_0)
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/move_connected.py
+++ b/pysb/examples/move_connected.py
@@ -20,7 +20,7 @@ Compartment('Y', Main, 2, Vy)
 # A and B, both embedded in membrane X, bind reversibly
 Parameter('Kab_f', 1)
 Parameter('Kab_r', 1)
-Rule('Ax_bind_Bx', A(b=None) ** X + B(a=None) ** X <> A(b=1) ** X % B(a=1) ** X,
+Rule('Ax_bind_Bx', A(b=None) ** X + B(a=None) ** X != A(b=1) ** X % B(a=1) ** X,
      Kab_f, Kab_r)
 
 # The A:B complex is transported back and forth from X to Y
@@ -29,7 +29,7 @@ Parameter('Ktrans_r', 1)
 # move_connected is required or B will be "left behind" and BNG will complain
 # (change move_connected to False and run pysb.tools.export_bng_net on this file
 # and watch for the WARNING line in the output log)
-Rule('ABx_trans_y', A(b=ANY) ** X <> A(b=ANY) ** Y,
+Rule('ABx_trans_y', A(b=ANY) ** X != A(b=ANY) ** Y,
      Ktrans_f, Ktrans_r, move_connected=True)
 
 Parameter('ABx_0', 1)

--- a/pysb/examples/paper_figures/fig2a.py
+++ b/pysb/examples/paper_figures/fig2a.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2A from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.bng import generate_network, generate_equations
 import re
@@ -42,18 +43,18 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
+print("BNGL Rules")
+print("==========")
 for line in bng_code.split("\n"):
     for rule in model.rules:
         match = re.match(r'^\s*%s:\s*(.*)' % rule.name, line)
         if match:
-            print match.group(1)
-print
-print "ODEs"
-print "===="
+            print(match.group(1))
+print()
+print("ODEs")
+print("====")
 for species, ode in zip(model.species, model.odes):
-    print "%s: %s" % (species, ode)
+    print("%s: %s" % (species, ode))
 
 def test_fig2a():
     assert num_rules == 2, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig2a.py
+++ b/pysb/examples/paper_figures/fig2a.py
@@ -12,7 +12,7 @@ def catalyze(enz, e_site, sub, s_site, prod, klist):
 
     # Create the rules
     rb = Rule('bind_%s_%s' % (enz().monomer.name, sub().monomer.name),
-           enz({e_site:None}) + sub({s_site:None}) <>
+           enz({e_site:None}) + sub({s_site:None}) !=
            enz({e_site:1}) % sub({s_site:1}),
            kf, kr)
     rc = Rule('catalyze_%s%s_to_%s' %

--- a/pysb/examples/paper_figures/fig2b.py
+++ b/pysb/examples/paper_figures/fig2b.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2B from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import *
 from pysb.bng import generate_equations
@@ -19,13 +20,13 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
-print num_rules, "rules"
-print
-print "ODEs"
-print "===="
-print num_odes, "ODEs"
+print("BNGL Rules")
+print("==========")
+print(num_rules, "rules")
+print()
+print("ODEs")
+print("====")
+print(num_odes, "ODEs")
 
 def test_fig2c():
     assert num_rules == 5, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig2c.py
+++ b/pysb/examples/paper_figures/fig2c.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2C from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import bind_table
 from pysb.bng import generate_network, generate_equations
@@ -53,13 +54,13 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
-print num_rules, "rules"
-print
-print "ODEs"
-print "===="
-print num_odes, "ODEs"
+print("BNGL Rules")
+print("==========")
+print(num_rules, "rules")
+print()
+print("ODEs")
+print("====")
+print(num_odes, "ODEs")
 
 def test_fig2c():
     assert num_rules == 28, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig5c.py
+++ b/pysb/examples/paper_figures/fig5c.py
@@ -1,9 +1,10 @@
 """Reaction graph for Figure 5C from the PySB publication"""
 
+from __future__ import print_function
 import pysb.tools.render_reactions
 
 from earm.mito.lopez_embedded import model
 
 # print out the graphviz representation of the contact map
-print pysb.tools.render_reactions.run(model)
+print(pysb.tools.render_reactions.run(model))
 

--- a/pysb/examples/paper_figures/fig5d.py
+++ b/pysb/examples/paper_figures/fig5d.py
@@ -1,5 +1,6 @@
 """Produce contact map for Figure 5D from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from earm import lopez_modules
 from earm import albeck_modules
@@ -38,5 +39,5 @@ try:
     os.unlink('fig5d_cm.jpg')
 except OSError:
     pass
-print
-print "Generated fig5d_cm.dot in", output_dir
+print()
+print("Generated fig5d_cm.dot in", output_dir)

--- a/pysb/examples/paper_figures/fig6.py
+++ b/pysb/examples/paper_figures/fig6.py
@@ -1,5 +1,6 @@
 """Produce contact map for Figure 5D from the PySB publication"""
 
+from __future__ import print_function
 import pysb.integrate
 import pysb.util
 import numpy as np
@@ -58,11 +59,11 @@ def objective_func(x, rate_mask, lb, ub):
     if caller_func in {'anneal', '_minimize_anneal'}:
         caller_locals = caller_frame.f_locals
         if caller_locals['n'] == 1:
-            print caller_locals['best_state'].cost, caller_locals['current_state'].cost
+            print(caller_locals['best_state'].cost, caller_locals['current_state'].cost)
         
     # Apply hard bounds
     if np.any((x < lb) | (x > ub)):
-        print "bounds-check failed"
+        print("bounds-check failed")
         return np.inf
 
     # Simulate model with rates taken from x (which is log transformed)
@@ -167,7 +168,7 @@ def estimate(start_values=None):
 
     # Display annealing results
     for v in ('xmin', 'Jmin', 'Tfinal', 'feval', 'iters', 'accept', 'retval'):
-        print "%s: %s" % (v, locals()[v])
+        print("%s: %s" % (v, locals()[v]))
 
     return params_estimated
 

--- a/pysb/examples/paper_figures/figS1b.py
+++ b/pysb/examples/paper_figures/figS1b.py
@@ -1,5 +1,6 @@
 """Elements for Figure S1B from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import catalyze_one_step
 from pysb.bng import generate_network, generate_equations
@@ -27,18 +28,18 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
+print("BNGL Rules")
+print("==========")
 for line in bng_code.split("\n"):
     for rule in model.rules:
         match = re.match(r'^\s*%s:\s*(.*)' % rule.name, line)
         if match:
-            print match.group(1)
-print
-print "ODEs"
-print "===="
+            print(match.group(1))
+print()
+print("ODEs")
+print("====")
 for species, ode in zip(model.species, model.odes):
-    print "%s: %s" % (species, ode)
+    print("%s: %s" % (species, ode))
 
 def test_figs1b():
     assert num_rules == 1, "number of rules not as expected"

--- a/pysb/examples/robertson.py
+++ b/pysb/examples/robertson.py
@@ -32,6 +32,7 @@ Analysis: An Introduction, J. Walsh, ed., Academic Press, 1966, pp. 178-182.
 # which integrates the system and plots the trajectories.
 
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -75,7 +76,7 @@ if __name__ == '__main__':
     substitutions.update(('s%d' % i, 'y%d' % (i+1))
                          for i in range(len(model.odes)))
 
-    print __doc__, "\n", model, "\n"
+    print(__doc__, "\n", model, "\n")
 
     # Iterate over each equation
     for i, eq in enumerate(model.odes):
@@ -83,9 +84,9 @@ if __name__ == '__main__':
         # mappings we built above
         eq_sub = eq.subs(substitutions)
         # Display the equation
-        print 'y%d\' = %s' % (i+1, eq_sub)
+        print('y%d\' = %s' % (i+1, eq_sub))
 
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_robertson.py for example usage."
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_robertson.py for example usage.""")

--- a/pysb/examples/run_bax_pore.py
+++ b/pysb/examples/run_bax_pore.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Simulate the bax_pore model and plot the results."""
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -8,7 +9,7 @@ from bax_pore import model
 
 
 t = linspace(0, 100)
-print "Simulating..."
+print("Simulating...")
 x = odesolve(model, t)
 
 p = plot(t, c_[x['BAX4'], x['BAX4_inh']])

--- a/pysb/examples/run_bax_pore_sequential.py
+++ b/pysb/examples/run_bax_pore_sequential.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Simulate the bax_pore_sequential model and plot the results."""
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -10,7 +11,7 @@ from bax_pore_sequential import model, max_size
 # System is very stiff, and using logspace instead of linspace to produce the
 # vector of time points happens to help with the integration
 t = logspace(-3, 5) # 1e-3 to 1e5
-print "Simulating..."
+print("Simulating...")
 x = odesolve(model, t)
 
 # Plot trajectory of each pore

--- a/pysb/examples/run_earm_1_0.py
+++ b/pysb/examples/run_earm_1_0.py
@@ -2,6 +2,7 @@
 """Reproduce figures 4A and 4B from the EARM 1.0 publication (Albeck et
 al. 2008)."""
 
+from __future__ import print_function
 from pysb.integrate import odesolve
 from pylab import *
 
@@ -18,7 +19,7 @@ L_0_baseline = model.parameters['L_0'].value
 
 
 def fig_4a():
-    print "Simulating model for figure 4A..."
+    print("Simulating model for figure 4A...")
     t = linspace(0, 20*3600, 20*60+1)  # 20 hours, in seconds, 1 min sampling
     dt = t[1] - t[0]
 
@@ -35,11 +36,11 @@ def fig_4a():
     fs = empty_like(Ls)
     Ts = empty_like(Ls)
     Td = empty_like(Ls)
-    print "Scanning over %d values of L_0" % len(Ls)
+    print("Scanning over %d values of L_0" % len(Ls))
     for i in range(len(Ls)):
         model.parameters['L_0'].value = Ls[i]
 
-        print "  L_0 = %g" % Ls[i]
+        print("  L_0 = %g" % Ls[i])
         x = odesolve(model, t)
 
         fs[i] = (x['PARP_unbound'][0] - x['PARP_unbound'][-1]) / x['PARP_unbound'][0]
@@ -63,7 +64,7 @@ def fig_4a():
 
 
 def fig_4b():
-    print "Simulating model for figure 4B..."
+    print("Simulating model for figure 4B...")
 
     t = linspace(0, 6*3600, 6*60+1)  # 6 hours
     x = odesolve(model, t)

--- a/pysb/examples/run_kinase_cascade.py
+++ b/pysb/examples/run_kinase_cascade.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from pysb.integrate import odesolve
 from pylab import linspace, plot, legend, show
 
@@ -7,7 +8,7 @@ from kinase_cascade import model
 
 
 tspan = linspace(0, 1200)
-print "Simulating..."
+print("Simulating...")
 yfull = odesolve(model, tspan)
 plot(tspan, yfull['ppMEK'], label='ppMEK')
 plot(tspan, yfull['ppERK'], label='ppERK')

--- a/pysb/examples/run_robertson.py
+++ b/pysb/examples/run_robertson.py
@@ -3,6 +3,7 @@
 trajectories.
 """
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -11,7 +12,7 @@ from robertson import model
 # We will integrate from t=0 to t=40
 t = linspace(0, 40)
 # Simulate the model
-print "Simulating..."
+print("Simulating...")
 y = odesolve(model, t, rtol=1e-4, atol=[1e-8, 1e-14, 1e-6])
 # Gather the observables of interest into a matrix
 yobs = array([y[obs] for obs in ('A_total', 'B_total', 'C_total')]).T

--- a/pysb/examples/run_tutorial_a.py
+++ b/pysb/examples/run_tutorial_a.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from pysb.integrate import Solver
 from tutorial_a import model
 
 t = [0, 10, 20, 30, 40, 50, 60]
 solver = Solver(model, t)
 solver.run()
-print solver.y[:, 1]
+print(solver.y[:, 1])

--- a/pysb/examples/synth_deg.py
+++ b/pysb/examples/synth_deg.py
@@ -1,5 +1,6 @@
 """A trivial example of synthesis and degradation rules"""
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -17,7 +18,8 @@ Initial(A(), A_0)
 Observable('A_total', A())
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/export/__main__.py
+++ b/pysb/export/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import re
@@ -10,7 +11,7 @@ def validate_argv(argv):
 
 def main(argv):
     if not validate_argv(argv):
-        print pysb.export.__doc__,
+        print(pysb.export.__doc__, end=' ')
         return 1
 
     model_filename = argv[1]
@@ -35,7 +36,7 @@ def main(argv):
         # as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
@@ -44,7 +45,7 @@ def main(argv):
         raise Exception("File '%s' isn't a model file" % model_filename)
 
     # Export the model
-    print pysb.export.export(model, format, model_module.__doc__)
+    print(pysb.export.export(model, format, model_module.__doc__))
 
     return 0
 

--- a/pysb/export/__main__.py
+++ b/pysb/export/__main__.py
@@ -34,7 +34,7 @@ def main(argv):
         # which we use, there will be trouble (use the imp package and import
         # as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/export/mathematica.py
+++ b/pysb/export/mathematica.py
@@ -104,7 +104,10 @@ import pysb
 import pysb.bng
 import sympy
 import re
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from math import floor, log
 from pysb.export import Exporter
 

--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -163,7 +163,10 @@ import pysb
 import pysb.bng
 import sympy
 import re
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from pysb.export import Exporter, pad
 
 class MatlabExporter(Exporter):

--- a/pysb/export/potterswheel.py
+++ b/pysb/export/potterswheel.py
@@ -65,7 +65,10 @@ import sympy
 import re
 import sys
 import os
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from pysb.export import Exporter
 
 class PottersWheelExporter(Exporter):

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -72,7 +72,10 @@ import pysb.bng
 import sympy
 import textwrap
 from pysb.export import Exporter, pad
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import re
 
 class PythonExporter(Exporter):

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -14,7 +14,10 @@ import sympy
 from sympy.printing.mathml import MathMLPrinter
 import itertools
 import textwrap
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 def indent(text, n=0):
     """Re-indent a multi-line string, stripping leading newlines and trailing

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -138,7 +138,7 @@ class BngGenerator(object):
 
 def format_monomer_site(monomer, site):
     ret = site
-    if monomer.site_states.has_key(site):
+    if site in monomer.site_states:
         for state in monomer.site_states[site]:
             ret += '~' + state
     return ret

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -108,7 +108,7 @@ class KappaGenerator(object):
 
 def format_monomer_site(monomer, site):
     ret = site
-    if monomer.site_states.has_key(site):
+    if site in monomer.site_states:
         for state in monomer.site_states[site]:
             ret += '~' + state
     return ret

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -2,8 +2,13 @@ import pysb.core
 import pysb.bng
 import numpy
 from scipy.integrate import ode
-from scipy.weave import inline
-import scipy.weave.build_tools
+try:
+    from scipy.weave import inline
+except ImportError:
+    inline = None
+else:
+    import scipy.weave.build_tools
+
 import distutils.errors
 import sympy
 import re
@@ -81,8 +86,9 @@ class Solver(object):
         if not hasattr(Solver, '_use_inline'):
             Solver._use_inline = False
             try:
-                inline('int i;', force=1)
-                Solver._use_inline = True
+                if inline is not None:
+                    inline('int i;', force=1)
+                    Solver._use_inline = True
             except (scipy.weave.build_tools.CompileError,
                     distutils.errors.CompileError, ImportError):
                 pass

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -9,6 +9,11 @@ import sympy
 import re
 import itertools
 
+def _exec(code, locals):
+    # This is function call under Python 3, and a statement with a
+    # tuple under Python 2. The effect should be the same.
+    exec(code, locals)
+
 # some sane default options for a few well-known integrators
 default_integrator_options = {
     'vode': {
@@ -117,7 +122,7 @@ class Solver(object):
             if Solver._use_inline:
                 inline(code_eqs, ['ydot', 't', 'y', 'p']);
             else:
-                exec code_eqs_py in locals()
+                _exec(code_eqs_py, locals())
             return ydot
 
         # build integrator options list from our defaults and any kwargs passed

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -302,7 +302,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> from numpy import linspace
     >>> numpy.set_printoptions(precision=4)
     >>> yfull = odesolve(model, linspace(0, 40, 10))
-    >>> print yfull['A_total']   #doctest: +NORMALIZE_WHITESPACE
+    >>> print yfull['A_total']             #doctest: +NORMALIZE_WHITESPACE
     [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
@@ -312,13 +312,13 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
 
     >>> print yfull.shape
     (10,)
-    >>> print yfull.dtype   #doctest: +NORMALIZE_WHITESPACE
+    >>> print yfull.dtype                  #doctest: +NORMALIZE_WHITESPACE
     [('__s0', '<f8'), ('__s1', '<f8'), ('__s2', '<f8'), ('A_total', '<f8'),
     ('B_total', '<f8'), ('C_total', '<f8')]
-    >>> print yfull[0:4, 1:3]
+    >>> print yfull[0:4, 1:3]              #doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
-    IndexError: too many indices for array
+    IndexError: too many indices...
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
     >>> print yarray.shape
     (10, 6)

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -134,14 +134,14 @@ class Solver(object):
         self.y = numpy.ndarray((len(tspan), len(model.species)))
         self.ydot = numpy.ndarray(len(model.species))
         if len(model.observables):
-            self.yobs = numpy.ndarray(len(tspan), zip(model.observables.keys(),
-                                                      itertools.repeat(float)))
+            self.yobs = numpy.ndarray(len(tspan), list(zip(model.observables.keys(),
+                                                      itertools.repeat(float))))
         else:
             self.yobs = numpy.ndarray((len(tspan), 0))
         exprs = model.expressions_dynamic()
         if len(exprs):
-            self.yexpr = numpy.ndarray(len(tspan), zip(exprs.keys(),
-                                                       itertools.repeat(float)))
+            self.yexpr = numpy.ndarray(len(tspan), list(zip(exprs.keys(),
+                                                       itertools.repeat(float))))
         else:
             self.yexpr = numpy.ndarray((len(tspan), 0))
         self.yobs_view = self.yobs.view(float).reshape(len(self.yobs), -1)
@@ -336,7 +336,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     solver.run(param_values, y0)
 
     species_names = ['__s%d' % i for i in range(solver.y.shape[1])]
-    yfull_dtype = zip(species_names, itertools.repeat(float))
+    yfull_dtype = list(zip(species_names, itertools.repeat(float)))
     if len(solver.yobs.dtype):
         yfull_dtype += solver.yobs.dtype.descr
     yfull = numpy.ndarray(len(solver.y), yfull_dtype)

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -302,7 +302,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> from numpy import linspace
     >>> numpy.set_printoptions(precision=4)
     >>> yfull = odesolve(model, linspace(0, 40, 10))
-    >>> print yfull['A_total']             #doctest: +NORMALIZE_WHITESPACE
+    >>> print(yfull['A_total'])            #doctest: +NORMALIZE_WHITESPACE
     [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
@@ -310,21 +310,21 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     integer indexing (note that the view's data buffer is shared with the
     original array so there is no extra memory cost):
 
-    >>> print yfull.shape
+    >>> print(yfull.shape)
     (10,)
-    >>> print yfull.dtype                  #doctest: +NORMALIZE_WHITESPACE
+    >>> print(yfull.dtype)                 #doctest: +NORMALIZE_WHITESPACE
     [('__s0', '<f8'), ('__s1', '<f8'), ('__s2', '<f8'), ('A_total', '<f8'),
     ('B_total', '<f8'), ('C_total', '<f8')]
-    >>> print yfull[0:4, 1:3]              #doctest: +ELLIPSIS
+    >>> print(yfull[0:4, 1:3])             #doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
     IndexError: too many indices...
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
-    >>> print yarray.shape
+    >>> print(yarray.shape)
     (10, 6)
-    >>> print yarray.dtype
+    >>> print(yarray.dtype)
     float64
-    >>> print yarray[0:4, 1:3]
+    >>> print(yarray[0:4, 1:3])
     [[  0.0000e+00   0.0000e+00]
      [  2.1672e-05   1.0093e-01]
      [  1.6980e-05   1.4943e-01]

--- a/pysb/jacobian.py
+++ b/pysb/jacobian.py
@@ -131,7 +131,7 @@ class JacobianGenerator(object):
 
     def make_groups(self, elements, size):
         groups = []
-        offsets = range(0, len(elements), size) + [None]
+        offsets = list(range(0, len(elements), size)) + [None]
         for i in range(0, len(offsets) - 1):
             groups.append(elements[offsets[i]:offsets[i+1]])
         return groups

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -11,8 +11,7 @@ The other functions are used internally and manage the execution of the Kappa
 software and the parsing of the data into a Numpy format.
 """
 
-__author__ = "johnbachman"
-
+from __future__ import print_function as _
 import pysb
 from pysb.generator.kappa import KappaGenerator
 import os
@@ -21,6 +20,9 @@ import random
 import re
 import sympy
 import numpy as np
+
+__author__ = "johnbachman"
+
 
 def run_simulation(model, **kwargs):
     """Runs the given model using KaSim and returns the parsed results.
@@ -159,7 +161,7 @@ def run_complx(gen, kappa_filename, args):
         kappa_file.write(gen.get_content())
         kappa_file.close()
         cmd = 'complx ' + ' '.join(args) + ' ' + kappa_filename
-        print "Command: " + cmd
+        print("Command: " + cmd)
         p = subprocess.Popen(['complx'] + args + [kappa_filename],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         #p.communicate()
@@ -261,7 +263,7 @@ def run_kasim(model, time=10000, points=200, output_dir='.', cleanup=False,
 
         kappa_file.close()
 
-        print "Running kasim"
+        print("Running kasim")
         p = subprocess.Popen(['KaSim'] + args)
                            #stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         p.communicate()

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -321,7 +321,7 @@ def parse_kasim_outfile(out_filename):
             else: column_names.append(raw_name)
 
         # Create the dtype argument for the numpy record array
-        dt = zip(column_names, ('float',)*len(column_names))
+        dt = list(zip(column_names, ('float',)*len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
         arr = np.loadtxt(out_filename, dtype=dt, skiprows=1)

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -145,10 +145,10 @@ def _macro_rule(rule_prefix, rule_expression, klist, ksuffixes,
         >>> Monomer('B', ['s'])
         Monomer('B', ['s'])
         >>> 
-        >>> _macro_rule('bind', A(s=None) + B(s=None) <> A(s=1) % B(s=1),
+        >>> _macro_rule('bind', A(s=None) + B(s=None) != A(s=1) % B(s=1),
         ... [1e6, 1e-1], ['kf', 'kr']) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('bind_A_B_to_AB', A(s=None) + B(s=None) <> A(s=1) % B(s=1),
+         Rule('bind_A_B_to_AB', A(s=None) + B(s=None) != A(s=1) % B(s=1),
              bind_A_B_to_AB_kf, bind_A_B_to_AB_kr),
          Parameter('bind_A_B_to_AB_kf', 1000000.0),
          Parameter('bind_A_B_to_AB_kr', 0.1),
@@ -299,7 +299,7 @@ def equilibrate(s1, s2, klist):
         Monomer('B')
         >>> equilibrate(A(), B(), [1, 1]) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('equilibrate_A_to_B', A() <> B(), equilibrate_A_to_B_kf, equilibrate_A_to_B_kr),
+         Rule('equilibrate_A_to_B', A() != B(), equilibrate_A_to_B_kf, equilibrate_A_to_B_kr),
          Parameter('equilibrate_A_to_B_kf', 1.0),
          Parameter('equilibrate_A_to_B_kr', 1.0),
          ])
@@ -307,14 +307,14 @@ def equilibrate(s1, s2, klist):
     """
     
     # turn any Monomers into MonomerPatterns
-    return _macro_rule('equilibrate', s1 <> s2, klist, ['kf', 'kr'])
+    return _macro_rule('equilibrate', s1 != s2, klist, ['kf', 'kr'])
 
 # Binding
 # =======
 
 def bind(s1, site1, s2, site2, klist):
     """
-    Generate the reversible binding reaction S1 + S2 <> S1:S2.
+    Generate the reversible binding reaction S1 + S2 != S1:S2.
 
     Parameters
     ----------
@@ -354,7 +354,7 @@ def bind(s1, site1, s2, site2, klist):
         Monomer('B', ['y'])
         >>> bind(A, 'x', B, 'y', [1e-4, 1e-1]) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('bind_A_B', A(x=None) + B(y=None) <> A(x=1) % B(y=1), bind_A_B_kf, bind_A_B_kr),
+         Rule('bind_A_B', A(x=None) + B(y=None) != A(x=1) % B(y=1), bind_A_B_kf, bind_A_B_kr),
          Parameter('bind_A_B_kf', 0.0001),
          Parameter('bind_A_B_kr', 0.1),
          ])
@@ -365,7 +365,7 @@ def bind(s1, site1, s2, site2, klist):
     _verify_sites(s2, site2)
 
     return _macro_rule('bind',
-                       s1({site1: None}) + s2({site2: None}) <>
+                       s1({site1: None}) + s2({site2: None}) !=
                        s1({site1: 1}) % s2({site2: 1}),
                        klist, ['kf', 'kr'], name_func=bind_name_func)
 
@@ -377,8 +377,8 @@ def bind_name_func(rule_expression):
 
 def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
     """
-    Generate the reversible binding reaction S1 + S2 <> S1:S2, with optional complexes attached to either
-    S1 (C1:S1 + S2 <> C1:S1:S2), S2 (S1 + C2:S2 <> C2:S2:S1), or both (C1:S1 + C2:S2 <> C1:S1:S2:C2).
+    Generate the reversible binding reaction S1 + S2 != S1:S2, with optional complexes attached to either
+    S1 (C1:S1 + S2 != C1:S1:S2), S2 (S1 + C2:S2 != C2:S2:S1), or both (C1:S1 + C2:S2 != C1:S1:S2:C2).
 
     Parameters
     ----------
@@ -427,19 +427,19 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         Monomer('D', ['g', 'h'])
         >>> bind(A, 'a', B, 'c', [1e4, 1e-1])
         ComponentSet([
-         Rule('bind_A_B', A(a=None) + B(c=None) <> A(a=1) % B(c=1), bind_A_B_kf, bind_A_B_kr),
+         Rule('bind_A_B', A(a=None) + B(c=None) != A(a=1) % B(c=1), bind_A_B_kf, bind_A_B_kr),
          Parameter('bind_A_B_kf', 10000.0),
          Parameter('bind_A_B_kr', 0.1),
          ])
         >>> bind(C, 'e', D, 'g', [1e4, 1e-1])
         ComponentSet([
-         Rule('bind_C_D', C(e=None) + D(g=None) <> C(e=1) % D(g=1), bind_C_D_kf, bind_C_D_kr),
+         Rule('bind_C_D', C(e=None) + D(g=None) != C(e=1) % D(g=1), bind_C_D_kf, bind_C_D_kr),
          Parameter('bind_C_D_kf', 10000.0),
          Parameter('bind_C_D_kr', 0.1),
          ])
         >>> bind_complex(A(a=1) % B(c=1), 'b', C(e=2) % D(g=2), 'h', [1e-4, 1e-1])
         ComponentSet([
-         Rule('bind_AB_DC', A(a=1, b=None) % B(c=1) + D(g=3, h=None) % C(e=3) <> A(a=1, b=50) % B(c=1) % D(g=3, h=50) % C(e=3), bind_AB_DC_kf, bind_AB_DC_kr),
+         Rule('bind_AB_DC', A(a=1, b=None) % B(c=1) + D(g=3, h=None) % C(e=3) != A(a=1, b=50) % B(c=1) % D(g=3, h=50) % C(e=3), bind_AB_DC_kf, bind_AB_DC_kr),
          Parameter('bind_AB_DC_kf', 0.0001),
          Parameter('bind_AB_DC_kr', 0.1),
          ])
@@ -487,7 +487,7 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         #Create rule.
         def create_rule(s1ub, s1b, s2ub, s2b):
             return _macro_rule('bind',
-                                s1ub + s2ub <>
+                                s1ub + s2ub !=
                                 s1b % s2b,
                                 klist, ['kf', 'kr'], name_func=bind_name_func)
         
@@ -575,7 +575,7 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
                     s2complexpatub %= mon
                     s2complexpatb %= mon
         return _macro_rule('bind',
-                           s1complexpatub + s2complexpatub <>
+                           s1complexpatub + s2complexpatub !=
                            s1complexpatb % s2complexpatb,
                            klist, ['kf', 'kr'], name_func=bind_name_func)
 
@@ -657,15 +657,15 @@ def bind_table(bindtable, row_site, col_site, kf=None):
         ...             [R2,  (3e-4, 3e-1),         None]],
         ...            'x', 'y') # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('bind_R1_C1', R1(x=None) + C1(y=None) <> R1(x=1) % C1(y=1),
+         Rule('bind_R1_C1', R1(x=None) + C1(y=None) != R1(x=1) % C1(y=1),
              bind_R1_C1_kf, bind_R1_C1_kr),
          Parameter('bind_R1_C1_kf', 0.0001),
          Parameter('bind_R1_C1_kr', 0.1),
-         Rule('bind_R1_C2', R1(x=None) + C2(y=None) <> R1(x=1) % C2(y=1),
+         Rule('bind_R1_C2', R1(x=None) + C2(y=None) != R1(x=1) % C2(y=1),
              bind_R1_C2_kf, bind_R1_C2_kr),
          Parameter('bind_R1_C2_kf', 0.0002),
          Parameter('bind_R1_C2_kr', 0.2),
-         Rule('bind_R2_C1', R2(x=None) + C1(y=None) <> R2(x=1) % C1(y=1),
+         Rule('bind_R2_C1', R2(x=None) + C1(y=None) != R2(x=1) % C1(y=1),
              bind_R2_C1_kf, bind_R2_C1_kr),
          Parameter('bind_R2_C1_kf', 0.0003),
          Parameter('bind_R2_C1_kr', 0.3),
@@ -777,13 +777,13 @@ def bind_table_complex(bindtable, row_site, col_site, m1=None, m2=None, kf=None)
         Monomer('C2', ['y', 'c2'])
         >>> bind(C1, 'y', C2, 'y', [1e4, 1e-1])
         ComponentSet([
-         Rule('bind_C1_C2', C1(y=None) + C2(y=None) <> C1(y=1) % C2(y=1), bind_C1_C2_kf, bind_C1_C2_kr),
+         Rule('bind_C1_C2', C1(y=None) + C2(y=None) != C1(y=1) % C2(y=1), bind_C1_C2_kf, bind_C1_C2_kr),
          Parameter('bind_C1_C2_kf', 10000.0),
          Parameter('bind_C1_C2_kr', 0.1),
          ])
         >>> bind(R1, 'c1', R2, 'x', [1e3, 1e-1])
         ComponentSet([
-         Rule('bind_R1_R2', R1(c1=None) + R2(x=None) <> R1(c1=1) % R2(x=1), bind_R1_R2_kf, bind_R1_R2_kr),
+         Rule('bind_R1_R2', R1(c1=None) + R2(x=None) != R1(c1=1) % R2(x=1), bind_R1_R2_kf, bind_R1_R2_kr),
          Parameter('bind_R1_R2_kf', 1000.0),
          Parameter('bind_R1_R2_kr', 0.1),
          ])
@@ -791,13 +791,13 @@ def bind_table_complex(bindtable, row_site, col_site, m1=None, m2=None, kf=None)
                                 [R1,                  (1e-4, 1e-1),      (2e-4, 2e-1)],\
                                 [R1(c1=1) % R2(x=1),  (3e-4, 3e-1),      None]], 'x', 'c2', m1=R1, m2=C2)
         ComponentSet([
-         Rule('bind_C2C1_R1', C2(y=1, c2=None) % C1(y=2) + R1(x=None) <> C2(y=1, c2=50) % C1(y=2) % R1(x=50), bind_C2C1_R1_kf, bind_C2C1_R1_kr),
+         Rule('bind_C2C1_R1', C2(y=1, c2=None) % C1(y=2) + R1(x=None) != C2(y=1, c2=50) % C1(y=2) % R1(x=50), bind_C2C1_R1_kf, bind_C2C1_R1_kr),
          Parameter('bind_C2C1_R1_kf', 0.0001),
          Parameter('bind_C2C1_R1_kr', 0.1),
-         Rule('bind_R1_C2', R1(x=None) + C2(c2=None) <> R1(x=1) % C2(c2=1), bind_R1_C2_kf, bind_R1_C2_kr),
+         Rule('bind_R1_C2', R1(x=None) + C2(c2=None) != R1(x=1) % C2(c2=1), bind_R1_C2_kf, bind_R1_C2_kr),
          Parameter('bind_R1_C2_kf', 0.0002),
          Parameter('bind_R1_C2_kr', 0.2),
-         Rule('bind_R1R2_C2C1', R1(x=None, c1=1) % R2(x=1) + C2(y=2, c2=None) % C1(y=2) <> R1(x=50, c1=1) % R2(x=1) % C2(y=2, c2=50) % C1(y=2), bind_R1R2_C2C1_kf, bind_R1R2_C2C1_kr),
+         Rule('bind_R1R2_C2C1', R1(x=None, c1=1) % R2(x=1) + C2(y=2, c2=None) % C1(y=2) != R1(x=50, c1=1) % R2(x=1) % C2(y=2, c2=50) % C1(y=2), bind_R1R2_C2C1_kf, bind_R1R2_C2C1_kr),
          Parameter('bind_R1R2_C2C1_kf', 0.0003),
          Parameter('bind_R1R2_C2C1_kr', 0.3),
          ])
@@ -831,7 +831,7 @@ def bind_table_complex(bindtable, row_site, col_site, m1=None, m2=None, kf=None)
 
 def catalyze(enzyme, e_site, substrate, s_site, product, klist):
     """
-    Generate the two-step catalytic reaction E + S <> E:S >> E + P.
+    Generate the two-step catalytic reaction E + S != E:S >> E + P.
 
     Parameters
     ----------
@@ -882,7 +882,7 @@ def catalyze(enzyme, e_site, substrate, s_site, product, klist):
         Monomer('P')
         >>> catalyze(E(), 'b', S(), 'b', P(), (1e-4, 1e-1, 1)) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('bind_E_S_to_ES', E(b=None) + S(b=None) <> E(b=1) % S(b=1),
+         Rule('bind_E_S_to_ES', E(b=None) + S(b=None) != E(b=1) % S(b=1),
              bind_E_S_to_ES_kf, bind_E_S_to_ES_kr),
          Parameter('bind_E_S_to_ES_kf', 0.0001),
          Parameter('bind_E_S_to_ES_kr', 0.1),
@@ -909,7 +909,7 @@ def catalyze(enzyme, e_site, substrate, s_site, product, klist):
         >>> catalyze(Kinase(), 'b', Substrate(y='U'), 'b', Substrate(y='P'), (1e-4, 1e-1, 1)) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
          Rule('bind_Kinase_SubstrateU_to_KinaseSubstrateU',
-             Kinase(b=None) + Substrate(b=None, y='U') <> Kinase(b=1) % Substrate(b=1, y='U'),
+             Kinase(b=None) + Substrate(b=None, y='U') != Kinase(b=1) % Substrate(b=1, y='U'),
              bind_Kinase_SubstrateU_to_KinaseSubstrateU_kf,
              bind_Kinase_SubstrateU_to_KinaseSubstrateU_kr),
          Parameter('bind_Kinase_SubstrateU_to_KinaseSubstrateU_kf', 0.0001),
@@ -945,7 +945,7 @@ def catalyze(enzyme, e_site, substrate, s_site, product, klist):
 
     # create the rules
     components = _macro_rule('bind',
-                             enzyme_free + substrate_free <> es_complex,
+                             enzyme_free + substrate_free != es_complex,
                              klist[0:2], ['kf', 'kr'])
     components |= _macro_rule('catalyze',
                               es_complex >> enzyme_free + product,
@@ -956,7 +956,7 @@ def catalyze(enzyme, e_site, substrate, s_site, product, klist):
 def catalyze_state(enzyme, e_site, substrate, s_site, mod_site,
                    state1, state2, klist):
     """
-    Generate the two-step catalytic reaction E + S <> E:S >> E + P. A wrapper
+    Generate the two-step catalytic reaction E + S != E:S >> E + P. A wrapper
     around catalyze() with a signature specifying the state change of the
     substrate resulting from catalysis.
 
@@ -1019,7 +1019,7 @@ def catalyze_state(enzyme, e_site, substrate, s_site, mod_site,
         >>> catalyze_state(Kinase, 'b', Substrate, 'b', 'y', 'U', 'P', (1e-4, 1e-1, 1)) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
          Rule('bind_Kinase_SubstrateU_to_KinaseSubstrateU',
-             Kinase(b=None) + Substrate(b=None, y='U') <> Kinase(b=1) % Substrate(b=1, y='U'),
+             Kinase(b=None) + Substrate(b=None, y='U') != Kinase(b=1) % Substrate(b=1, y='U'),
              bind_Kinase_SubstrateU_to_KinaseSubstrateU_kf,
              bind_Kinase_SubstrateU_to_KinaseSubstrateU_kr),
          Parameter('bind_Kinase_SubstrateU_to_KinaseSubstrateU_kf', 0.0001),
@@ -1495,7 +1495,7 @@ def assemble_polymer_sequential(subunit, site1, site2, max_size, ktable,
         rule_name_base = 'assemble_%s_sequential' % \
                          ('pore' if closed else 'chain')
         components |= _macro_rule(rule_name_base,
-                                  s + polymer_prev <> polymer_next,
+                                  s + polymer_prev != polymer_next,
                                   klist, ['kf', 'kr'],
                                   name_func=name_func)
     return components
@@ -1596,14 +1596,14 @@ def assemble_pore_sequential(subunit, site1, site2, max_size, ktable):
         >>> assemble_pore_sequential(Unit, 'p1', 'p2', 3, [[1e-4, 1e-1]] * 2) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
          Rule('assemble_pore_sequential_Unit_2',
-              Unit(p1=None, p2=None) + Unit(p1=None, p2=None) <>
+              Unit(p1=None, p2=None) + Unit(p1=None, p2=None) !=
                   Unit(p1=None, p2=1) % Unit(p1=1, p2=None),
               assemble_pore_sequential_Unit_2_kf,
               assemble_pore_sequential_Unit_2_kr),
          Parameter('assemble_pore_sequential_Unit_2_kf', 0.0001),
          Parameter('assemble_pore_sequential_Unit_2_kr', 0.1),
          Rule('assemble_pore_sequential_Unit_3',
-              Unit(p1=None, p2=None) + Unit(p1=None, p2=1) % Unit(p1=1, p2=None) <>
+              Unit(p1=None, p2=None) + Unit(p1=None, p2=1) % Unit(p1=1, p2=None) !=
                   MatchOnce(Unit(p1=3, p2=1) % Unit(p1=1, p2=2) % Unit(p1=2, p2=3)),
               assemble_pore_sequential_Unit_3_kf,
               assemble_pore_sequential_Unit_3_kr),
@@ -1623,7 +1623,7 @@ def pore_transport(subunit, sp_site1, sp_site2, sc_site, min_size, max_size,
     The pore structure is defined by the `pore_species` macro -- `subunit`
     monomers bind to each other from `sp_site1` to `sp_site2` to form a closed
     ring. The transport reaction is modeled as a catalytic process of the form
-    pore + csource <> pore:csource >> pore + cdest
+    pore + csource != pore:csource >> pore + cdest
 
     Parameters
     ----------
@@ -1688,7 +1688,7 @@ def pore_transport(subunit, sp_site1, sp_site2, sc_site, min_size, max_size,
              MatchOnce(Unit(p1=3, p2=1, sc_site=None) %
                  Unit(p1=1, p2=2, sc_site=None) %
                  Unit(p1=2, p2=3, sc_site=None)) +
-                 Cargo(c_site=None, loc='mito') <>
+                 Cargo(c_site=None, loc='mito') !=
              MatchOnce(Unit(p1=3, p2=1, sc_site=4) %
                  Unit(p1=1, p2=2, sc_site=None) %
                  Unit(p1=2, p2=3, sc_site=None) %
@@ -1767,7 +1767,7 @@ def pore_transport(subunit, sp_site1, sp_site2, sc_site, min_size, max_size,
         # Create the rules (just like catalyze)
         name_func = functools.partial(pore_transport_rule_name, size=size)
         components |= _macro_rule('pore_transport_complex',
-                                  pore_free + csource_free <> pc_complex,
+                                  pore_free + csource_free != pc_complex,
                                   klist[0:2], ['kf', 'kr'],
                                   name_func=name_func)
         components |= _macro_rule('pore_transport_dissociate',
@@ -1784,7 +1784,7 @@ def pore_bind(subunit, sp_site1, sp_site2, sc_site, size, cargo, c_site,
 
     The pore structure is defined by the `pore_species` macro -- `subunit`
     monomers bind to each other from `sp_site1` to `sp_site2` to form a closed
-    ring. The binding reaction takes the form pore + cargo <> pore:cargo.
+    ring. The binding reaction takes the form pore + cargo != pore:cargo.
 
     Parameters
     ----------
@@ -1835,7 +1835,7 @@ def pore_bind(subunit, sp_site1, sp_site2, sc_site, size, cargo, c_site,
              MatchOnce(Unit(p1=3, p2=1, sc_site=None) %
                  Unit(p1=1, p2=2, sc_site=None) %
                  Unit(p1=2, p2=3, sc_site=None)) +
-                 Cargo(c_site=None) <>
+                 Cargo(c_site=None) !=
              MatchOnce(Unit(p1=3, p2=1, sc_site=4) %
                  Unit(p1=1, p2=2, sc_site=None) %
                  Unit(p1=2, p2=3, sc_site=None) %
@@ -1896,7 +1896,7 @@ def pore_bind(subunit, sp_site1, sp_site2, sc_site, size, cargo, c_site,
     # Create the rules
     name_func = functools.partial(pore_bind_rule_name, size=size)
     components |= _macro_rule('pore_bind',
-                              pore_free + cargo_free <> pc_complex,
+                              pore_free + cargo_free != pc_complex,
                               klist[0:2], ['kf', 'kr'],
                               name_func=name_func)
 
@@ -1995,10 +1995,10 @@ def assemble_chain_sequential(subunit, site1, site2, max_size, ktable):
         Monomer('Unit', ['p1', 'p2'])
         >>> assemble_chain_sequential(Unit, 'p1', 'p2', 3, [[1e-4, 1e-1]] * 2) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('assemble_chain_sequential_Unit_2', Unit(p1=None, p2=None) + Unit(p1=None, p2=None) <> Unit(p1=None, p2=1) % Unit(p1=1, p2=None), assemble_chain_sequential_Unit_2_kf, assemble_chain_sequential_Unit_2_kr),
+         Rule('assemble_chain_sequential_Unit_2', Unit(p1=None, p2=None) + Unit(p1=None, p2=None) != Unit(p1=None, p2=1) % Unit(p1=1, p2=None), assemble_chain_sequential_Unit_2_kf, assemble_chain_sequential_Unit_2_kr),
          Parameter('assemble_chain_sequential_Unit_2_kf', 0.0001),
          Parameter('assemble_chain_sequential_Unit_2_kr', 0.1),
-         Rule('assemble_chain_sequential_Unit_3', Unit(p1=None, p2=None) + Unit(p1=None, p2=1) % Unit(p1=1, p2=None) <> MatchOnce(Unit(p1=None, p2=1) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None)), assemble_chain_sequential_Unit_3_kf, assemble_chain_sequential_Unit_3_kr),
+         Rule('assemble_chain_sequential_Unit_3', Unit(p1=None, p2=None) + Unit(p1=None, p2=1) % Unit(p1=1, p2=None) != MatchOnce(Unit(p1=None, p2=1) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None)), assemble_chain_sequential_Unit_3_kf, assemble_chain_sequential_Unit_3_kr),
          Parameter('assemble_chain_sequential_Unit_3_kf', 0.0001),
          Parameter('assemble_chain_sequential_Unit_3_kr', 0.1),
          ])
@@ -2146,10 +2146,10 @@ def assemble_chain_sequential_base(base, basesite, subunit, site1, site2, max_si
         Monomer('Complex2', ['s1', 's2'])
         >>> assemble_chain_sequential_base(Base(b2=ANY), 'b1', Unit, 'p1', 'p2', 3, [[1e-4, 1e-1]] * 2, Complex1(s1=ANY) % Complex2(s1=ANY, s2=ANY)) # doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
-         Rule('assemble_chain_sequential_base_Unit_2', Unit(p1=None, p2=None) + Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=None) <> Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None), assemble_chain_sequential_base_Unit_2_kf, assemble_chain_sequential_base_Unit_2_kr),
+         Rule('assemble_chain_sequential_base_Unit_2', Unit(p1=None, p2=None) + Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=None) != Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None), assemble_chain_sequential_base_Unit_2_kf, assemble_chain_sequential_base_Unit_2_kr),
          Parameter('assemble_chain_sequential_base_Unit_2_kf', 0.0001),
          Parameter('assemble_chain_sequential_base_Unit_2_kr', 0.1),
-         Rule('assemble_chain_sequential_base_Unit_3', Unit(p1=None, p2=None) + Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None) <> MatchOnce(Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=3) % Unit(p1=3, p2=None)), assemble_chain_sequential_base_Unit_3_kf, assemble_chain_sequential_base_Unit_3_kr),
+         Rule('assemble_chain_sequential_base_Unit_3', Unit(p1=None, p2=None) + Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=None) != MatchOnce(Complex1(s1=<class 'pysb.core.ANY'>) % Complex2(s1=<class 'pysb.core.ANY'>, s2=<class 'pysb.core.ANY'>) % Base(b1=1, b2=<class 'pysb.core.ANY'>) % Unit(p1=1, p2=2) % Unit(p1=2, p2=3) % Unit(p1=3, p2=None)), assemble_chain_sequential_base_Unit_3_kf, assemble_chain_sequential_base_Unit_3_kr),
          Parameter('assemble_chain_sequential_base_Unit_3_kf', 0.0001),
          Parameter('assemble_chain_sequential_base_Unit_3_kr', 0.1),
          ])
@@ -2171,7 +2171,7 @@ def assemble_chain_sequential_base(base, basesite, subunit, site1, site2, max_si
         chain_next = chain_species_base(base, basesite, subunit, site1, site2, size, comp)
         name_func = functools.partial(chain_rule_name, size=size)
         components |= _macro_rule('assemble_chain_sequential_base',
-                                  s + chain_prev <> chain_next,
+                                  s + chain_prev != chain_next,
                                   klist, ['kf', 'kr'],
                                   name_func=name_func)
 

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -247,7 +247,7 @@ def _verify_sites_complex(c, *site_list):
         allsitesdict[mon] = mon.monomer.sites
     for site in site_list:
         specsitesdict = {}
-        for monomer, li in allsitesdict.iteritems():
+        for monomer, li in allsitesdict.items():
             for s in li:
                 if site in li:
                     specsitesdict[monomer] = site
@@ -510,13 +510,14 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
     else:
         _verify_sites_complex(s1, site1)
         _verify_sites_complex(s2, site2)
-        #Retrieve a dictionary specifiying the MonomerPattern within the complex that contains the given binding site.
-        specsitesdict1 = _verify_sites_complex(s1, site1)
-        specsitesdict2 = _verify_sites_complex(s2, site2)
+        #Retrieve a dictionary specifiying the MonomerPattern within
+        #the complex that contains the given binding site. Convert to list.
+        specsites1 = list(_verify_sites_complex(s1, site1))
+        specsites2 = list(_verify_sites_complex(s2, site2))
         #Return error if binding site exists on multiple monomers and a monomer for binding (m1/m2) hasn't been specified.
-        if len(specsitesdict1) > 1 and m1==None:
+        if len(specsites1) > 1 and m1==None:
             raise ValueError("Binding site '%s' present in more than one monomer in complex '%s'.  Specify variable m1, the monomer used for binding within the complex." % (site1, s1))
-        if len(specsitesdict2) > 1 and m2==None:
+        if len(specsites2) > 1 and m2==None:
             raise ValueError("Binding site '%s' present in more than one monomer in complex '%s'.  Specify variable m2, the monomer used for binding within the complex." % (site2, s2))
         if not s1.is_concrete:
             raise ValueError("Complex '%s' must be concrete." % (s1))
@@ -525,7 +526,7 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         #To avoid creating rules with multiple bonds to the same site when combining the two complexes, check for the maximum bond integer in s1 and add to all s2 bond integers.
         maxint = 0
         for monomer in s1.monomer_patterns:
-            for stateint in monomer.site_conditions.itervalues():
+            for stateint in monomer.site_conditions.values():
                 if isinstance(stateint, int):
                     if stateint > maxint:
                         maxint = stateint
@@ -536,10 +537,10 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         #If the given binding site is only present in one monomer in the complex:
         if m1==None:
           #Build up ComplexPattern for use in rule (with state of given binding site specified).
-            s1complexpatub = specsitesdict1.keys()[0]({site1:None})
-            s1complexpatb = specsitesdict1.keys()[0]({site1:50})
+            s1complexpatub = specsites1[0]({site1:None})
+            s1complexpatb = specsites1[0]({site1:50})
             for monomer in s1.monomer_patterns:
-                if monomer not in specsitesdict1.keys():
+                if monomer not in specsites1:
                     s1complexpatub %= monomer
                     s1complexpatb %= monomer
         else:
@@ -555,10 +556,10 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
                     s1complexpatb %= mon
         if m2==None:
           #Build up ComplexPattern for use in rule (with state of given binding site specified).
-            s2complexpatub = specsitesdict2.keys()[0]({site2:None})
-            s2complexpatb = specsitesdict2.keys()[0]({site2:50})
+            s2complexpatub = specsites2[0]({site2:None})
+            s2complexpatb = specsites2[0]({site2:50})
             for monomer in s2.monomer_patterns:
-                if monomer not in specsitesdict2.keys():
+                if monomer not in specsites2:
                     s2complexpatub %= monomer
                     s2complexpatb %= monomer
         #If the binding site is present on more than one monomer in the complex, the monomer must be specified by the user.  Use specified m2 to build ComplexPattern.

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -26,7 +26,7 @@ def serialize_component_list(model, filename):
     """
 
     f = open(filename, 'w')
-    pickle.dump(model.all_components().values(), f)
+    pickle.dump(list(model.all_components().values()), f)
     f.close()
 
 def check_model_against_component_list(model, component_list):
@@ -48,8 +48,9 @@ def check_model_against_component_list(model, component_list):
            "%d components." % \
            (model.name, len(model.all_components().values()), len(component_list))
 
+    model_components = list(model.all_components().values())
     for i, comp in enumerate(component_list):
-        model_comp_str = repr(model.all_components().values()[i])
+        model_comp_str = repr(model_components[i])
         comp_str = repr(comp) 
         assert comp_str == model_comp_str, \
                "Model %s does not match reference version: " \

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -5,11 +5,11 @@ import pickle
 def with_model(func):
     """Decorate a test to set up and tear down a Model."""
     def inner(*args, **kwargs):
-        model = Model(func.func_name, _export=False)
+        model = Model(func.__name__, _export=False)
         # manually set up SelfExporter, targeting func's globals
         SelfExporter.default_model = model
         SelfExporter.target_module = func.__module__
-        SelfExporter.target_globals = func.func_globals
+        SelfExporter.target_globals = func.__globals__
         SelfExporter.target_globals['model'] = model
         try:
             # call the actual test function

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -41,12 +41,12 @@ def check_model_against_component_list(model, component_list):
     To serialize the list of components to create a record of a
     validated state, see :py:func:`serialize_component_list`.
     """
-    assert len(model.all_components().values()) == len(component_list), \
+    assert len(model.all_components()) == len(component_list), \
            "Model %s does not have the same " \
            "number of components as the previously validated version. " \
            "The validated model has %d components, current model has " \
            "%d components." % \
-           (model.name, len(model.all_components().values()), len(component_list))
+           (model.name, len(model.all_components()), len(component_list))
 
     model_components = list(model.all_components().values())
     for i, comp in enumerate(component_list):

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -6,7 +6,7 @@ import sympy
 import re
 import sys
 import os
-from StringIO import StringIO
+from io import StringIO
 
 
 def run(model):

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import pysb
 import pysb.bng
 import sympy
@@ -129,14 +130,14 @@ if __name__ == '__main__':
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    # print run(model)
+    # print(run(model))
     run(model)
 
 

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -51,6 +51,7 @@ as a "modifier" (enzyme or catalyst).
 
 """
 
+from __future__ import print_function
 import pysb
 import pysb.bng
 import sympy
@@ -129,7 +130,7 @@ usage = usage[1:]  # strip leading newline
 if __name__ == '__main__':
     # sanity checks on filename
     if len(sys.argv) <= 1:
-        print usage,
+        print(usage, end=' ')
         exit()
     model_filename = sys.argv[1]
     if not os.path.exists(model_filename):
@@ -145,14 +146,14 @@ if __name__ == '__main__':
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    print run(model)
+    print(run(model))
 
 
 

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -95,7 +95,7 @@ def render_species_as_dot(species_list, graph_name=""):
                             label=monomer_label, shape="none", fontname="Arial",
                             fontsize=8)
         for bi, sites in bonds.items():
-            node_names, port_names = zip(*sites)
+            node_names, port_names = list(zip(*sites))
             sgraph.add_edge(node_names, tailport=port_names[0],
                             headport=port_names[1], label=str(bi))
     return graph.string()

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -23,6 +23,7 @@ Note that some PDF viewers will auto-reload a changed PDF, so you may not even
 need to manually reopen it every time you rerun the tool.
 """
 
+from __future__ import print_function
 import sys
 import os
 import re
@@ -106,7 +107,7 @@ usage = usage[1:]  # strip leading newline
 if __name__ == '__main__':
     # sanity checks on filename
     if len(sys.argv) <= 1:
-        print usage,
+        print(usage, end=' ')
         exit()
     model_filename = sys.argv[1]
     if not os.path.exists(model_filename):
@@ -122,11 +123,11 @@ if __name__ == '__main__':
         # as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    print run(model)
+    print(run(model))

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble (use the imp package and import
         # as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -1,3 +1,4 @@
+from __future__ import print_function as _
 from pysb import ComponentSet
 import pysb.core
 import inspect
@@ -43,7 +44,7 @@ def synthetic_data(model, tspan, obs_list=None, sigma=0.1):
 def get_param_num(model, name):
     for i in range(len(model.parameters)):
         if model.parameters[i].name == name:
-            print i, model.parameters[i]
+            print(i, model.parameters[i])
             break
     return i
 

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -2,7 +2,7 @@ from pysb import ComponentSet
 import pysb.core
 import inspect
 import numpy
-import cStringIO
+import io
 
 __all__ = ['alias_model_components', 'rules_using_parameter']
 
@@ -56,7 +56,7 @@ def write_params(model,paramarr, name=None):
     if name is not None:
         fobj = open(name, 'w')
     else:
-        fobj = cStringIO.StringIO()
+        fobj = io.StringIO()
     for i in range(len(model.parameters)):
         fobj.write("%s, %.17g\n"%(model.parameters[i].name, paramarr[i]))
     if name is None:

--- a/scripts/pysb_export
+++ b/scripts/pysb_export
@@ -1,5 +1,6 @@
 #!python
 
+from __future__ import print_function
 import os
 import sys
 from pysb.export.__main__ import main, validate_argv
@@ -16,7 +17,7 @@ Supported formats:
   %s""" % (script_name, format_list)
 
 if not validate_argv(sys.argv):
-   print usage
+   print(usage)
    sys.exit(1)
 sys.exit(main(sys.argv))
 


### PR DESCRIPTION
This pull request allows pysb to be used under Python 3.4 (and probably 3.3, but I didn't test that). All tests pass, and things seem to generally work the same as under Python 2.7.

The code is made both Python 2 and 3 compatible. This is the modern approach to doing the conversion. A single codebase makes everything easier and faster. Since the pysb codebase is rather clean, there's no need to use helper modules like six.