### PR TITLE
Test conversions

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -222,9 +222,9 @@ def generate_network(model, cleanup=True, append_stdout=False):
     """
     gen = BngGenerator(model)
     if not model.initial_conditions:
-        raise NoInitialConditionsError()
+        raise pysb.core.NoInitialConditionsError()
     if not model.rules:
-        raise NoRulesError()
+        raise pysb.core.NoRulesError()
     bng_filename = '%s_%d_%d_temp.bngl' % (model.name, os.getpid(), random.randint(0, 10000))
     net_filename = bng_filename.replace('.bngl', '.net')
     output = StringIO()
@@ -404,14 +404,3 @@ def _parse_group(model, line):
             obs.coefficients.append(int(terms[0]))
             # -1 to change to 0-based indexing
             obs.species.append(int(terms[1]) - 1)
-
-
-class NoInitialConditionsError(RuntimeError):
-    """Model initial_conditions is empty."""
-    def __init__(self):
-        RuntimeError.__init__(self, "Model has no initial conditions")
-
-class NoRulesError(RuntimeError):
-    """Model rules is empty."""
-    def __init__(self):
-        RuntimeError.__init__(self, "Model has no rules")

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1455,6 +1455,15 @@ class DuplicateSiteError(ValueError):
 class UnknownSiteError(ValueError):
     pass
 
+class NoInitialConditionsError(RuntimeError):
+    """Model initial_conditions is empty."""
+    def __init__(self):
+        RuntimeError.__init__(self, "Model has no initial conditions")
+
+class NoRulesError(RuntimeError):
+    """Model rules is empty."""
+    def __init__(self):
+        RuntimeError.__init__(self, "Model has no rules")
 
 class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
     """

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -104,9 +104,10 @@ class PythonExporter(Exporter):
         for i, p in enumerate(self.model.parameters):
             code_eqs = re.sub(r'\b(%s)\b' % p.name, 'p[%d]' % i, code_eqs)
 
-        output.write('"""')
-        output.write(self.docstring)
-        output.write('"""\n\n')
+        if self.docstring:
+            output.write('"""')
+            output.write(self.docstring)
+            output.write('"""\n\n')
         output.write("# exported from PySB model '%s'\n" % self.model.name)
         output.write(pad(r"""
             import numpy

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -1,4 +1,5 @@
 import pysb
+from pysb.core import NoInitialConditionsError
 
 class KappaGenerator(object):
 
@@ -84,7 +85,7 @@ class KappaGenerator(object):
 
     def generate_species(self):
         if not self.model.initial_conditions:
-            raise Exception("BNG generator requires initial conditions.")
+            raise NoInitialConditionsError()
         species_codes = [format_complexpattern(cp) for cp, param in self.model.initial_conditions]
         #max_length = max(len(code) for code in species_codes)
         max_length = 0

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -302,7 +302,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> from numpy import linspace
     >>> numpy.set_printoptions(precision=4)
     >>> yfull = odesolve(model, linspace(0, 40, 10))
-    >>> print yfull['A_total']   #doctest: +NORMALIZE_WHITESPACE
+    >>> print yfull['A_total']             #doctest: +NORMALIZE_WHITESPACE
     [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
@@ -312,13 +312,13 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
 
     >>> print yfull.shape
     (10,)
-    >>> print yfull.dtype   #doctest: +NORMALIZE_WHITESPACE
+    >>> print yfull.dtype                  #doctest: +NORMALIZE_WHITESPACE
     [('__s0', '<f8'), ('__s1', '<f8'), ('__s2', '<f8'), ('A_total', '<f8'),
     ('B_total', '<f8'), ('C_total', '<f8')]
-    >>> print yfull[0:4, 1:3]
+    >>> print yfull[0:4, 1:3]              #doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
-    IndexError: too many indices for array
+    IndexError: too many indices...
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
     >>> print yarray.shape
     (10, 6)

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -1,7 +1,7 @@
 from pysb.testing import *
 from pysb import *
 from pysb.bng import *
-from pysb.core import as_complex_pattern
+from pysb import NoInitialConditionsError, NoRulesError
 
 @with_model
 def test_generate_network():

--- a/pysb/tests/test_conversion.py
+++ b/pysb/tests/test_conversion.py
@@ -1,0 +1,27 @@
+# -*- coding:utf-8; -*-
+import os.path
+import glob
+
+from pysb.tests.test_examples import get_example_models, expected_exceptions
+from pysb import export
+
+def test_conversion():
+    for model in get_example_models():
+        for format in export.formats:
+            fn = lambda: check_convert(model, format)
+            fn.description = "Check conversion: {} → {}".format(model.name, format)
+            yield fn
+
+def check_convert(model, format):
+    """Tests that conversion runs without error for the given model and format"""
+    try:
+        export.export(model, format)
+    except Exception as e:
+        # Some example models are deliberately incomplete, so here we will treat
+        # any of these "expected" exceptions as a success.
+        model_base_name = model.name.rsplit('.', 1)[1]
+        exception_class = expected_exceptions.get(model_base_name)
+        if exception_class and isinstance(e, exception_class):
+            pass
+        else:
+            raise

--- a/pysb/tests/test_examples.py
+++ b/pysb/tests/test_examples.py
@@ -1,5 +1,5 @@
-from pysb.bng import generate_network, NoInitialConditionsError
-from pysb.core import SelfExporter
+from pysb.bng import generate_network
+from pysb.core import SelfExporter, NoInitialConditionsError
 import traceback
 import os
 import importlib

--- a/pysb/tests/test_examples.py
+++ b/pysb/tests/test_examples.py
@@ -7,7 +7,9 @@ import importlib
 def test_generate_network():
     """Run network generation on all example models"""
     for model in get_example_models():
-        yield (check_generate_network, model)
+        fn = lambda: check_generate_network(model)
+        fn.description = "Generate network from {}".format(model.name)
+        yield fn
 
 def get_example_models():
     """Generator that yields the model objects for all example models"""


### PR DESCRIPTION
This adds a simple test where all examples are converted to all formats. Unfortunately some tests fail :)
I fixed the most obvious ones, but there's more to be done. I think the test is fine, and the problem is in the export code.

```
======================================================================
ERROR: Check conversion: pysb.examples.bngwiki_egfr_simple → sbml
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/zbyszek/src/pysb/pysb/tests/test_conversion.py", line 11, in <lambda>
    fn = lambda: check_convert(model, format)
  File "/home/zbyszek/src/pysb/pysb/tests/test_conversion.py", line 18, in check_convert
    export.export(model, format)
  File "/home/zbyszek/src/pysb/pysb/export/__init__.py", line 150, in export
    return e.export()
  File "/home/zbyszek/src/pysb/pysb/export/sbml.py", line 125, in export
    ics[self.model.get_species_index(cp)][1] = ic_param.value
AttributeError: 'Expression' object has no attribute 'value'
```

```
======================================================================
ERROR: Check conversion: pysb.examples.bngwiki_egfr_simple → python
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/zbyszek/src/pysb/pysb/tests/test_conversion.py", line 11, in <lambda>
    fn = lambda: check_convert(model, format)
  File "/home/zbyszek/src/pysb/pysb/tests/test_conversion.py", line 18, in check_convert
    export.export(model, format)
  File "/home/zbyszek/src/pysb/pysb/export/__init__.py", line 150, in export
    return e.export()
  File "/home/zbyszek/src/pysb/pysb/export/python.py", line 168, in export
    ic_data = (i, self.model.parameters.index(param),
  File "/home/zbyszek/src/pysb/pysb/core.py", line 1558, in index
    raise ValueError("%s is not in ComponentSet" % c)
ValueError: EGF_init is not in ComponentSet
```

The tests fail the same under Python 2.7 and Python 3.4 (when the py3 branch is merged).
