### PR TITLE
fix mutable default args on a couple of methods

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -222,8 +222,14 @@ class Monomer(Component):
 
     """
 
-    def __init__(self, name, sites=[], site_states={}, _export=True):
+    def __init__(self, name, sites=None, site_states=None, _export=True):
         Component.__init__(self, name, _export)
+
+        # Create default empty containers.
+        if sites is None:
+            sites = []
+        if site_states is None:
+            site_states = {}
 
         # ensure sites is some kind of list (presumably of strings) but not a string itself
         if not isinstance(sites, collections.Iterable) or isinstance(sites, basestring):
@@ -1475,12 +1481,13 @@ class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
     # The implementation is based on a list instead of a linked list (as
     # OrderedSet is), since we only allow add and retrieve, not delete.
 
-    def __init__(self, iterable=[]):
+    def __init__(self, iterable=None):
         self._elements = []
         self._map = {}
         self._index_map = {}
-        for value in iterable:
-            self.add(value)
+        if iterable is not None:
+            for value in iterable:
+                self.add(value)
 
     def __iter__(self):
         return iter(self._elements)


### PR DESCRIPTION
Monomer.__init__ is the real issue here (the ComponentSet one is actually harmless in practice). I introduced this myself, 6 (!) years ago to the day, when PySB (and my Python experience) was about 1 month old. I'm actually surprised this hasn't bitten anyone already.