### PR TITLE
Calculate Jacobian of ODEs analytically and supply to integrator

### DIFF
--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -164,6 +164,9 @@ class Solver(object):
         jac_eqs_list = []
         for i, row in enumerate(jac_matrix):
             for j, entry in enumerate(row):
+                # Skip zero entries in the Jacobian
+                if entry == 0:
+                    continue
                 jac_eq_str = 'jac[%d, %d] = %s;' % (i, j, sympy.ccode(entry))
                 jac_eqs_list.append(jac_eq_str)
         jac_eqs = eqn_substitutions('\n'.join(jac_eqs_list))
@@ -204,7 +207,7 @@ class Solver(object):
         self.y = numpy.ndarray((len(tspan), len(model.species)))
         self.ydot = numpy.ndarray(len(model.species))
         # Initialization of matrix for storing the Jacobian
-        self.jac = numpy.ndarray((len(model.odes), len(model.species)))
+        self.jac = numpy.zeros((len(model.odes), len(model.species)))
         if len(model.observables):
             self.yobs = numpy.ndarray(len(tspan), zip(model.observables.keys(),
                                                       itertools.repeat(float)))

--- a/pysb/tests/jacobian_runtimes.py
+++ b/pysb/tests/jacobian_runtimes.py
@@ -6,15 +6,15 @@ from pysb.integrate import Solver
 from pysb.examples import robertson, earm_1_0
 import numpy as np
 
-def check_runtime(model, tspan, iterations, use_inline, use_jacobian):
+def check_runtime(model, tspan, iterations, use_inline, use_analytic_jacobian):
     Solver._use_inline = use_inline
-    sol = Solver(model, tspan, use_jacobian=use_jacobian)
+    sol = Solver(model, tspan, use_analytic_jacobian=use_analytic_jacobian)
     start_time = timeit.default_timer()
     for i in range(iterations):
         sol.run()
     elapsed = timeit.default_timer() - start_time
-    print "use_inline=%s, use_jacobian=%s, %d iterations" % \
-          (use_inline, use_jacobian, iterations)
+    print "use_inline=%s, use_analytic_jacobian=%s, %d iterations" % \
+          (use_inline, use_analytic_jacobian, iterations)
     print "Time: %f sec\n" % elapsed
 
 if __name__ == '__main__':

--- a/pysb/tests/jacobian_runtimes.py
+++ b/pysb/tests/jacobian_runtimes.py
@@ -1,0 +1,31 @@
+"""Run EARM and Robertson example models and compare runtimes with and
+without inline and with and without the analytically-derived Jacobian."""
+
+import timeit
+from pysb.integrate import Solver
+from pysb.examples import robertson, earm_1_0
+import numpy as np
+
+def check_runtime(model, tspan, iterations, use_inline, use_jacobian):
+    Solver._use_inline = use_inline
+    sol = Solver(model, tspan, use_jacobian=use_jacobian)
+    start_time = timeit.default_timer()
+    for i in range(iterations):
+        sol.run()
+    elapsed = timeit.default_timer() - start_time
+    print "use_inline=%s, use_jacobian=%s, %d iterations" % \
+          (use_inline, use_jacobian, iterations)
+    print "Time: %f sec\n" % elapsed
+
+if __name__ == '__main__':
+    arg_list = [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    print("-- EARM --")
+    earm_tspan = np.linspace(0, 1e4, 1000)
+    for args in arg_list:
+        check_runtime(earm_1_0.model, earm_tspan, 1000, *args)
+
+    print("-- Robertson --")
+    rob_tspan = np.linspace(0, 100)
+    for args in arg_list:
+        check_runtime(robertson.model, rob_tspan, 5000, *args)

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -1,9 +1,26 @@
 from pysb.integrate import Solver
-from pysb.examples.robertson import model
+from pysb.examples import robertson, earm_1_0
 import numpy as np
 
 def test_robertson_integration():
     t = np.linspace(0, 100)
-    sol = Solver(model, t)
+    # Run with and without inline
+    Solver._use_inline = False
+    sol = Solver(robertson.model, t, use_jacobian=True)
     sol.run()
     assert sol.y.shape[0] == t.shape[0]
+    # Run with and without inline
+    Solver._use_inline = True
+    sol = Solver(robertson.model, t, use_jacobian=True)
+    sol.run()
+
+def test_earm_integration():
+    t = np.linspace(0, 1e4, 1000)
+    # Run with and without inline
+    Solver._use_inline = False
+    sol = Solver(earm_1_0.model, t, use_jacobian=True)
+    sol.run()
+    Solver._use_inline = True
+    sol = Solver(earm_1_0.model, t, use_jacobian=True)
+    sol.run()
+

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -6,21 +6,21 @@ def test_robertson_integration():
     t = np.linspace(0, 100)
     # Run with and without inline
     Solver._use_inline = False
-    sol = Solver(robertson.model, t, use_jacobian=True)
+    sol = Solver(robertson.model, t, use_analytic_jacobian=True)
     sol.run()
     assert sol.y.shape[0] == t.shape[0]
     # Run with and without inline
     Solver._use_inline = True
-    sol = Solver(robertson.model, t, use_jacobian=True)
+    sol = Solver(robertson.model, t, use_analytic_jacobian=True)
     sol.run()
 
 def test_earm_integration():
     t = np.linspace(0, 1e4, 1000)
     # Run with and without inline
     Solver._use_inline = False
-    sol = Solver(earm_1_0.model, t, use_jacobian=True)
+    sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
     sol.run()
     Solver._use_inline = True
-    sol = Solver(earm_1_0.model, t, use_jacobian=True)
+    sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
     sol.run()
 

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -1,0 +1,9 @@
+from pysb.integrate import Solver
+from pysb.examples.robertson import model
+import numpy as np
+
+def test_robertson_integration():
+    t = np.linspace(0, 100)
+    sol = Solver(model, t)
+    sol.run()
+    assert sol.y.shape[0] == t.shape[0]


### PR DESCRIPTION
This feature uses Sympy to analytically calculate the Jacobian of the ODEs. Like the RHS function, the Jacobian is implemented as a callable that returns a matrix, and like the RHS it can also be inlined using scipy.weave. When the Jacobian is not explicitly supplied to the integrator (e.g., VODE), it is approximated by finite-differences calculations. Using the analytical Jacobian, inlined, results in small but consistent speedups for simulations of the EARM and Robertson models. Hopefully it will also help minimize convergence failures during parameter estimation runs!

More comments on specific changes can be found in the commit messages.