### PR TITLE
Python 3 support v2

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -29,7 +29,7 @@ sampled at intervals of 10 seconds::
     >>> t = [0, 10, 20, 30, 40, 50, 60]
     >>> solver = Solver(model, t)
     >>> solver.run()
-    >>> print solver.y[:, 1]
+    >>> print(solver.y[:, 1])
     [   0.   30.   60.   90.  120.  150.  180.]
 
 Creating a model

--- a/pysb/anneal_mod.py
+++ b/pysb/anneal_mod.py
@@ -3,6 +3,7 @@
 # Bug-fixes and changes by Carlos Lopez 2012
 #
 
+from __future__ import print_function
 import numpy
 from numpy import asarray, tan, exp, ones, squeeze, sign, \
      all, log, sqrt, pi, shape, array, minimum, where
@@ -51,9 +52,9 @@ class base_schedule(object):
         x0 : array
             The starting parameters vector.
         """
-        print "============================================================"
-        print "FINDING INITIAL TEMPERATURE WITH A COEFF OF VARIANCE OF", self.cvar
-        print "============================================================"
+        print("============================================================")
+        print("FINDING INITIAL TEMPERATURE WITH A COEFF OF VARIANCE OF", self.cvar)
+        print("============================================================")
 
         assert(not self.dims is None)
         lrange = self.lower
@@ -63,7 +64,7 @@ class base_schedule(object):
         fmin = _double_max
         x0 = best_state.x
         for _ in range(self.Ninit):
-            print "sampling T step:", _
+            print("sampling T step:", _)
             samp = squeeze(random.uniform(0, 1, size=self.dims)) - 0.5
             samp = samp/0.5
             varx0 = x0 * samp * cvar # random number within the cvar range
@@ -78,9 +79,9 @@ class base_schedule(object):
                 best_state.x = array(x0)
 
         self.T0 = (fmax-fmin)*1.5
-        print "================================="
-        print "SET INITIAL TEMPERATURE TO:", self.T0
-        print "================================="
+        print("=================================")
+        print("SET INITIAL TEMPERATURE TO:", self.T0)
+        print("=================================")
         return best_state.x
 
     def accept_test(self, dE):
@@ -295,9 +296,9 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 0
             if abs(af[-1]-best_state.cost) > feps*10:
                 retval = 5
-                print "Warning: Cooled to %f at %s but this is not" \
-                      % (squeeze(last_state.cost), str(squeeze(last_state.x))) \
-                      + " the smallest point found."
+                print("Warning: Cooled to %f at %s but this is not "
+                      "the smallest point found."
+                      % (squeeze(last_state.cost), squeeze(last_state.x)))
             break
         if (Tf is not None) and (schedule.T < Tf):
             retval = 1
@@ -306,7 +307,7 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 2
             break
         if (iters > maxiter):
-            print "Warning: Maximum number of iterations exceeded."
+            print("Warning: Maximum number of iterations exceeded.")
             retval = 3
             break
         if (maxaccept is not None) and (schedule.accepted > maxaccept):
@@ -325,12 +326,12 @@ if __name__ == "__main__":
     from numpy import cos
     # minimum expected at ~-0.195
     func = lambda x: cos(14.5*x-0.3) + (x+0.2)*x
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='cauchy')
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='fast')
-    print anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='boltzmann')
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='cauchy'))
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='fast'))
+    print(anneal(func,1.0,full_output=1,upper=3.0,lower=-3.0,feps=1e-4,maxiter=2000,schedule='boltzmann'))
 
     # minimum expected at ~[-0.195, -0.1]
     func = lambda x: cos(14.5*x[0]-0.3) + (x[1]+0.2)*x[1] + (x[0]+0.2)*x[0]
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='cauchy')
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='fast')
-    print anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='boltzmann')
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='cauchy'))
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='fast'))
+    print(anneal(func,[1.0, 1.0],full_output=1,upper=[3.0, 3.0],lower=[-3.0, -3.0],feps=1e-4,maxiter=2000,schedule='boltzmann'))

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -11,7 +11,10 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-
+try:
+    from future_builtins import zip
+except ImportError:
+    pass
 
 # Cached value of BNG path
 _bng_path = None
@@ -112,7 +115,7 @@ def _parse_bng_outfile(out_filename):
         column_names = [raw_name for raw_name in raw_names if not raw_name == '']
 
         # Create the dtype argument for the numpy record array
-        dt = zip(column_names, ('float',)*len(column_names))
+        dt = list(zip(column_names, ('float',)*len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
         arr = numpy.loadtxt(out_filename, dtype=dt, skiprows=1)

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -7,7 +7,10 @@ import re
 import itertools
 import sympy
 import numpy
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 # Cached value of BNG path

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -272,20 +272,20 @@ def generate_equations(model):
         return
     lines = iter(generate_network(model).split('\n'))
     try:
-        while 'begin species' not in lines.next():
+        while 'begin species' not in next(lines):
             pass
         model.species = []
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end species' in line: break
             _parse_species(model, line)
 
-        while 'begin reactions' not in lines.next():
+        while 'begin reactions' not in next(lines):
             pass
         model.odes = [sympy.numbers.Zero()] * len(model.species)
         reaction_cache = {}
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end reactions' in line: break
             (number, reactants, products, rate, rule) = line.strip().split(' ', 4)
             # the -1 is to switch from one-based to zero-based indexing
@@ -332,10 +332,10 @@ def generate_equations(model):
             # now the 'reverse' value is no longer needed
             del r['reverse']
 
-        while 'begin groups' not in lines.next():
+        while 'begin groups' not in next(lines):
             pass
         while True:
-            line = lines.next()
+            line = next(lines)
             if 'end groups' in line: break
             _parse_group(model, line)
 

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -241,7 +241,8 @@ def generate_network(model, cleanup=True, append_stdout=False):
         bng_file.write(_generate_network_code)
         bng_file.close()
         p = subprocess.Popen(['perl', _get_bng_path(), bng_filename],
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             universal_newlines=True)
         (p_out, p_err) = p.communicate()
         if p.returncode:
             raise GenerateNetworkError(p_out.rstrip()+"\n"+p_err.rstrip())

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -1,3 +1,4 @@
+from __future__ import print_function as _
 import pysb.core
 from pysb.generator.bng import BngGenerator
 import os
@@ -165,7 +166,7 @@ def run_ssa(model, t_end=10, n_steps=100, output_dir='/tmp',
                                 os.getpid(), random.randint(0, 100000))
 
     if os.path.exists(output_file_basename + '.bngl'):
-        print "WARNING! File %s already exists!" % (output_file_basename + '.bngl')
+        print("WARNING! File %s.bngl already exists!" % output_file_basename)
         output_file_basename += '_1'
 
     bng_filename = output_file_basename + '.bngl'
@@ -187,7 +188,7 @@ def run_ssa(model, t_end=10, n_steps=100, output_dir='/tmp',
         (p_out, p_err) = p.communicate()
         if p.returncode:
             raise GenerateNetworkError(p_out.rstrip("at line")+"\n"+p_err.rstrip())
-        print "Wrote " + gdat_filename # FIXME
+        print("Wrote " + gdat_filename) # FIXME
         output_arr = _parse_bng_outfile(gdat_filename)
         #ssa_file = open(ssa_filename, 'r')
         #output.write(ssa_file.read())

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -101,7 +101,7 @@ class SelfExporter(object):
             SelfExporter.default_model.add_component(obj)
 
         # load obj into target namespace under obj.name
-        if SelfExporter.target_globals.has_key(export_name):
+        if export_name in SelfExporter.target_globals:
             warnings.warn("'%s' already defined" % (export_name), SymbolExistsWarning, stacklevel)
         SelfExporter.target_globals[export_name] = obj
 
@@ -429,7 +429,7 @@ class MonomerPattern(object):
         value += ', '.join([
                 k + '=' + repr(self.site_conditions[k])
                 for k in self.monomer.sites
-                if self.site_conditions.has_key(k)
+                if k in self.site_conditions
                 ])
         value += ')'
         if self.compartment is not None:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -504,10 +504,11 @@ class ComplexPattern(object):
         #   so some sort of canonicalization of that numbering is necessary.
         if not isinstance(other, ComplexPattern):
             raise Exception("Can only compare ComplexPattern to another ComplexPattern")
-        return \
-            self.compartment == other.compartment and \
-            sorted((mp.monomer, mp.site_conditions, mp.compartment) for mp in self.monomer_patterns) == \
-            sorted((mp.monomer, mp.site_conditions, mp.compartment) for mp in other.monomer_patterns)
+        return (self.compartment == other.compartment and
+                sorted((repr(mp.monomer), mp.site_conditions, mp.compartment)
+                       for mp in self.monomer_patterns) ==
+                sorted((repr(mp.monomer), mp.site_conditions, mp.compartment)
+                       for mp in other.monomer_patterns))
 
     def copy(self):
         """

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -13,6 +13,12 @@ try:
     reload
 except NameError:
     from imp import reload
+try:
+    basestring
+except NameError:
+    # Under Python 3, do not pretend that bytes are a valid string
+    basestring = str
+    long = int
 
 def Initial(*args):
     """Declare an initial condition (see Model.initial)."""

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -9,7 +9,10 @@ import weakref
 import copy
 import itertools
 import sympy
-
+try:
+    reload
+except NameError:
+    from imp import reload
 
 def Initial(*args):
     """Declare an initial condition (see Model.initial)."""

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1374,7 +1374,7 @@ class Model(object):
         """
         # FIXME I don't even want to think about the inefficiency of this, but at least it works
         try:
-            return (i for i, s_cp in enumerate(self.species) if s_cp.is_equivalent_to(complex_pattern)).next()
+            return next((i for i, s_cp in enumerate(self.species) if s_cp.is_equivalent_to(complex_pattern)))
         except StopIteration:
             return None
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -240,12 +240,12 @@ class Monomer(Component):
         for site in sites:
             sites_seen.setdefault(site, 0)
             sites_seen[site] += 1
-        sites_dup = [site for site in sites_seen.keys() if sites_seen[site] > 1]
+        sites_dup = [site for site, count in sites_seen.items() if count > 1]
         if sites_dup:
             raise Exception("Duplicate sites specified: " + str(sites_dup))
 
         # ensure site_states keys are all known sites
-        unknown_sites = [site for site in site_states.keys() if not site in sites_seen]
+        unknown_sites = [site for site in site_states if not site in sites_seen]
         if unknown_sites:
             raise Exception("Unknown sites in site_states: " + str(unknown_sites))
         # ensure site_states values are all strings
@@ -322,7 +322,7 @@ class MonomerPattern(object):
 
     def __init__(self, monomer, site_conditions, compartment):
         # ensure all keys in site_conditions are sites in monomer
-        unknown_sites = [site for site in site_conditions.keys() if site not in monomer.sites]
+        unknown_sites = [site for site in site_conditions if site not in monomer.sites]
         if unknown_sites:
             raise Exception("MonomerPattern with unknown sites in " + str(monomer) + ": " + str(unknown_sites))
 

--- a/pysb/deprecated/anneal_sundials.py
+++ b/pysb/deprecated/anneal_sundials.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -93,7 +94,7 @@ def annlinit(model, abstol=1.0e-3, reltol=1.0e-3, nsteps = 1000, itermaxstep = N
     yout = numpy.zeros([nsteps, odesize])
 
     #initialize the arrays
-    #print "Initial parameter values:", y
+    #print("Initial parameter values:", y)
     xout[0] = 0.0 #CHANGE IF NEEDED
     #first step in yout
     for i in range(0, odesize):
@@ -158,15 +159,15 @@ def annlodesolve(model, tfinal, envlist, params, tinit = 0.0, ic=True):
     t = cvode.realtype(tinit)
     tout = tinit + tadd
     
-    #print "Beginning integration"
-    #print "TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize
-    #print "Integrating Parameters:\n", params
-    #print "y0:", yzero
+    #print("Beginning integration")
+    #print("TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize)
+    #print("Integrating Parameters:\n", params)
+    #print("y0:", yzero)
 
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -175,7 +176,7 @@ def annlodesolve(model, tfinal, envlist, params, tinit = 0.0, ic=True):
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     yobs = numpy.zeros([len(model.observables), nsteps])
@@ -214,7 +215,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = 0
@@ -223,9 +224,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # create a b-spline of the sim data and fit it to desired range
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -245,7 +246,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
         # assume a default variance
@@ -263,14 +264,14 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         objout += objarray.sum()
-        #print "OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
+        #print("OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
 
-    print "OBJOUT(total):", objout
+    print("OBJOUT(total):", objout)
     return objout
 
 def logparambounds(params, omag=1, useparams=[], usemag=None, initparams=[], initmag=None):
@@ -382,7 +383,7 @@ def tenninetycomp(outlistnorm, arglist, xpsamples=1.0):
     obj = ((1./varTdxp) * (Tdsim - Tdxp)**2.) + ((1./varTsxp) * (Tssim - Tsxp)**2.)
     #obj *= xpsamples
     
-    print "OBJOUT-10-90:(%g,%g):%g"%(Tdsim, Tssim, obj)
+    print("OBJOUT-10-90:(%g,%g):%g"%(Tdsim, Tssim, obj))
 
     return obj    
 
@@ -408,17 +409,17 @@ def annealfxn(zoparams, time, model, envlist, xpdata, xspairlist, lb, ub, tn = [
     paramarr = mapprms(zoparams, lb, ub, scaletype="log")
 
     #debug
-    #print "ZOPARAMS:\n", zoparams,"\n"
-    #print paramarr
+    #print("ZOPARAMS:\n", zoparams,"\n")
+    #print(paramarr)
 
     # eliminate values outside the boundaries, i.e. those outside [0,1)
     if numpy.greater_equal(paramarr, lb).all() and numpy.less_equal(paramarr, ub).all():
-        print "integrating... "
+        print("integrating... ")
         outlist = annlodesolve(model, time, envlist, paramarr)
 
         # normalized data needs a bit more tweaking before objfxn calculation
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -429,18 +430,18 @@ def annealfxn(zoparams, time, model, envlist, xpdata, xspairlist, lb, ub, tn = [
             if tn:
                 tn = tenninetycomp(outlistnorm, tn, len(xpdata[0]))
                 objout += tn 
-            print "NORM objout TOT:", objout
+            print("NORM objout TOT:", objout)
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
             if tn:
                 tn = tenninetycomp(outlist[0], tn)
                 objout += tn 
-            print "objout TOT:", objout
+            print("objout TOT:", objout)
     else:
-        print "======> VALUE OUT OF BOUNDS NOTED"
+        print("======> VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(paramarr, lb), numpy.less_equal(paramarr, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i,"\n======", paramarr[i],"\n", zoparams[i],"\n"
+            print("======>",i,"\n======", paramarr[i],"\n", zoparams[i],"\n")
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
 
     # save the params and temps for analysis

--- a/pysb/deprecated/anneal_sundials_OLD.py
+++ b/pysb/deprecated/anneal_sundials_OLD.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -152,7 +153,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
     else:
         #only a subset of parameters are used for annealing
         for i in range(len(useparams)):
-            #print "changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i]
+            #print("changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i])
             data.p[useparams[i]] = params[i]
 
     # update yzero if initial conditions are being modified as part of the parameters
@@ -177,7 +178,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -186,7 +187,7 @@ def annlodesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     obs_names = [name for name, rp in model.observable_patterns]
@@ -226,7 +227,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = 0
@@ -237,9 +238,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # code.interact(local=locals())
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -259,7 +260,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
         # assume a default variance
@@ -278,17 +279,17 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         #import code
         #code.interact(local=locals())
 
         objout += objarray.sum()
-        print "OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
+        print("OBJOUT(%d,%d):%f  |\t\tOBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
 
-    print "OBJOUT(total):", objout
+    print("OBJOUT(total):", objout)
     return objout
 
 def getgenparambounds(params, omag=1, N=1000., useparams=[], usemag=None, useN=None ):
@@ -322,7 +323,7 @@ def getgenparambounds(params, omag=1, N=1000., useparams=[], usemag=None, useN=N
             ub[i] = params[i] * pow(10, omag)
             lb[i] = params[i] / pow(10, omag)
             dx[i] = (ub[i] - lb[i])/N
-    #print dx
+    #print(dx)
     lower = params - dx/2
     lower[numpy.where(lower<0.)] = 0.0 #make sure we don't go negative on parameters
     upper = params + dx/2
@@ -351,11 +352,11 @@ def annealfxn(params, useparams, time, model, envlist, xpdata, xspairlist, lb, u
 
     
     if numpy.greater_equal(params, lb).all() and numpy.less_equal(params, ub).all():
-        print "Integrating..."
+        print("Integrating...")
         outlist = annlodesolve(model, time, envlist, params, useparams)
         # specify that this is normalized data
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -366,10 +367,10 @@ def annealfxn(params, useparams, time, model, envlist, xpdata, xspairlist, lb, u
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
     else:
-        print "======>VALUE OUT OF BOUNDS NOTED"
+        print("======>VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(params, lb), numpy.less_equal(params, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i, params[i]
+            print("======>",i, params[i])
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
 
     # save the params and temps for analysis
@@ -448,7 +449,7 @@ def tenninetycomp(outlistnorm, arglist, xpsamples=1.0):
     obj = ((1./varTdxp) * (Tdsim - Tdxp)**2.) + ((1./varTsxp) * (Tssim - Tsxp)**2.)
     obj *= xpsamples
     
-    print "OBJOUT-10-90:(%f,%f):%f"%(Tdsim, Tssim, obj)
+    print("OBJOUT-10-90:(%f,%f):%f"%(Tdsim, Tssim, obj))
 
     return obj    
 
@@ -465,11 +466,11 @@ def annealfxncust(params, useparams, time, model, envlist, xpdata, xspairlist, t
     #
 
     if numpy.greater_equal(params, lb).all() and numpy.less_equal(params, ub).all():
-        print "Integrating..."
+        print("Integrating...")
         outlist = annlodesolve(model, time, envlist, params, useparams)
         # specify that this is normalized data
         if norm is True:
-            print "Normalizing data"
+            print("Normalizing data")
             datamax = numpy.max(outlist[0], axis = 1)
             datamin = numpy.min(outlist[0], axis = 1)
             outlistnorm = ((outlist[0].T - datamin)/(datamax-datamin)).T
@@ -481,16 +482,16 @@ def annealfxncust(params, useparams, time, model, envlist, xpdata, xspairlist, t
             # Now SMAC
             tn = tenninetycomp(outlistnorm, tenninetylist,len(xpdata[0]))
             objout += tn 
-            print "objout TOT:", objout
+            print("objout TOT:", objout)
         else:
             objout = compare_data(xpdata, outlist[0], xspairlist, vardata)
             tn = tenninetycomp(outlistnorm, tenninetylist)
             objout += tn 
     else:
-        print "======>VALUE OUT OF BOUNDS NOTED"
+        print("======>VALUE OUT OF BOUNDS NOTED")
         temp = numpy.where((numpy.logical_and(numpy.greater_equal(params, lb), numpy.less_equal(params, ub)) * 1) == 0)
         for i in temp:
-            print "======>",i, params[i]
+            print("======>",i, params[i])
         objout = 1.0e300 # the largest FP in python is 1.0e308, otherwise it is just Inf
     return objout
 

--- a/pysb/deprecated/bng_parser.py
+++ b/pysb/deprecated/bng_parser.py
@@ -10,7 +10,7 @@ reserved_list = [
     'reaction_rules',
     'observables',
     ]
-reserved = dict([r, r.upper()] for r in reserved_list)
+reserved = dict((r, r.upper()) for r in reserved_list)
 
 tokens = [
     'ID',
@@ -29,7 +29,7 @@ tokens = [
     'LPAREN',
     'RPAREN',
     'NEWLINE',
-    ] + reserved.values()
+    ] + list(reserved.values())
 
 t_COMMA       = r','
 t_PLUS        = r'\+'

--- a/pysb/deprecated/bng_parser.py
+++ b/pysb/deprecated/bng_parser.py
@@ -1,4 +1,5 @@
-from ply import lex, yacc;
+from __future__ import print_function
+from ply import lex, yacc
 
 
 reserved_list = [
@@ -53,7 +54,7 @@ def t_FLOAT(t):
     try:
         t.value = float(t.value)    
     except ValueError:
-        print "Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value)
+        print("Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value))
         t.value = float("nan")
     return t
 
@@ -62,7 +63,7 @@ def t_INTEGER(t):
     try:
         t.value = int(t.value)    
     except ValueError:
-        print "Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value)
+        print("Line %d: Number '%s' has some kind of problem (ValueError)!" % (t.lineno,t.value))
         t.value = 0
     return t
 
@@ -80,7 +81,7 @@ t_ignore  = ' \t'
 
 # Error handling rule
 def t_error(t):
-    print "Illegal character '%s' on line %d" % (t.value[0], t.lineno)
+    print("Illegal character '%s' on line %d" % (t.value[0], t.lineno))
     t.lexer.skip(1)
 
 
@@ -101,7 +102,7 @@ def list_helper(p):
 def p_model(p):
     'model : block_list'
     p[0] = p[1]
-    print "model:", p[0]
+    print("model:", p[0])
 
 def p_block_list(p):
     '''block_list : block_list block
@@ -122,27 +123,27 @@ def p_block_empty(p):
 def p_parameter_block(p):
     'parameter_block : BEGIN PARAMETERS NEWLINE parameter_st_list END PARAMETERS NEWLINE'
     p[0] = p[4]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_molecule_type_block(p):
     'molecule_type_block : BEGIN MOLECULE_TYPES NEWLINE END MOLECULE_TYPES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_species_block(p):
     'species_block : BEGIN SPECIES NEWLINE END SPECIES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_reaction_rules_block(p):
     'reaction_rules_block : BEGIN REACTION_RULES NEWLINE END REACTION_RULES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_observables_block(p):
     'observables_block : BEGIN OBSERVABLES NEWLINE END OBSERVABLES NEWLINE'
     p[0] = p[2]
-    print "block:", p[2]
+    print("block:", p[2])
 
 def p_parameter_st_list(p):
     '''parameter_st_list : parameter_st_list parameter_st
@@ -164,52 +165,52 @@ def p_number(p):
 # def p_statement_list(p):
 #     '''statement_list : statement_list statement'''
 #     p[0] = p[1] + [p[2]]
-#     #print "statement_list:", p[0]
+#     #print("statement_list:", p[0])
 
 # def p_statement_list_trivial(p):
 #     '''statement_list : statement'''
 #     p[0] = [p[1]]
-#     #print "statement_list_trivial:", p[0]
+#     #print("statement_list_trivial:", p[0])
 
 # def p_statement_empty(p):
 #     'statement : NEWLINE'
-#     #print "statement_empty:", p[0]
+#     #print("statement_empty:", p[0])
 
 # def p_statement(p):
 #     'statement : rule NEWLINE'
 #     p[0] = p[1]
-#     #print "statement:", p[0]
+#     #print("statement:", p[0])
 
 # def p_rule(p):
 #     '''rule : irr_rule
 #             | rev_rule'''
 #     p[0] = p[1]
-#     #print "rule:", p[0]
+#     #print("rule:", p[0])
 
 # def p_irr_rule(p):
 #     'irr_rule : expression IRRARROW expression LPAREN FLOAT RPAREN'
-#     #print "irr_rule"
+#     #print("irr_rule")
 #     p[0] = RuleIrreversible(reactants=p[1], products=p[3], rate=p[5])
 
 # def p_rev_rule(p):
 #     'rev_rule : expression REVARROW expression LPAREN FLOAT COMMA FLOAT RPAREN'
-#     #print "rev_rule"
+#     #print("rev_rule")
 #     p[0] = RuleReversible(reactants=p[1], products=p[3], rates=[p[5], p[7]])
 
 # def p_expression_plus(p):
 #     'expression : expression PLUS expression'
 #     p[0] = p[1] + p[3]
-#     #print "expression_plus:", p[0]
+#     #print("expression_plus:", p[0])
 
 # def p_expression_species(p):
 #     'expression : SPECIES'
-#     #print "expression_species:", p[1]
+#     #print("expression_species:", p[1])
 #     p[0] = [Species(name=p[1])]
 
 # Error rule for syntax errors
 def p_error(p):
-    print "Syntax error in input:"
-    print p
+    print("Syntax error in input:")
+    print(p)
 
 precedence = (
     ('left', 'PLUS'),

--- a/pysb/deprecated/pysundials_helpers.py
+++ b/pysb/deprecated/pysundials_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from scipy.integrate._ode import IntegratorBase
 from pysundials import cvode as _cvode, nvecserial
 import ctypes
@@ -64,7 +65,7 @@ class cvode(IntegratorBase):
         flag = _cvode.CVode(self.cvode_mem, t1, self.y, tret, _cvode.CV_NORMAL)
         if flag < 0:
             self.success = 0
-            print "cvodes error: %d (see SUNDIALS manual for more information)" % flag
+            print("cvodes error: %d (see SUNDIALS manual for more information)" % flag)
         return (self.y, t1)
 
 IntegratorBase.integrator_classes.append(cvode)

--- a/pysb/deprecated/varsens_sundials.py
+++ b/pysb/deprecated/varsens_sundials.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pysb.bng
 import numpy 
 import sympy 
@@ -13,7 +14,7 @@ from pysundials import cvode
 
 def spinner(i):
     spin = ("|", "/","-", "\\")
-    print "\r[%s] %d"%(spin[i%4],i),
+    print("\r[%s] %d"%(spin[i%4],i), end=' ')
     sys.stdout.flush()
 
 # reltol of 1.0e-3, relative error of ~1%. abstol of 1.0e-3, enough for values that oscillate in the hundreds to thousands
@@ -90,7 +91,7 @@ def odeinit(model, reltol=1.0e-3, abstol=1.0e-3, nsteps = 1000, itermaxstep = No
     yout = numpy.zeros([nsteps, odesize])
 
     #initialize the arrays
-    #print "Initial parameter values:", y
+    #print("Initial parameter values:", y)
     xout[0] = 0.0 #CHANGE IF NEEDED
     #first step in yout
     for i in range(0, odesize):
@@ -121,7 +122,7 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
     else:
         #only a subset of parameters are used for annealing
         for i in range(len(useparams)):
-            #print "changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i]
+            #print("changing parameter", model.parameters[useparams[i]],"data.p", data.p[useparams[i]],"to", params[i])
             data.p[useparams[i]] = params[i]
 
     # FIXME:
@@ -148,15 +149,15 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
     t = cvode.realtype(tinit)
     tout = tinit + tadd
     
-    #print "Beginning integration"
-    #print "TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize
-    #print "Integrating Parameters:\n", params
-    #print "y0:", yzero
+    #print("Beginning integration")
+    #print("TINIT:", tinit, "TFINAL:", tfinal, "TADD:", tadd, "ODESIZE:", odesize)
+    #print("Integrating Parameters:\n", params)
+    #print("y0:", yzero)
 
     for step in range(1, nsteps):
         ret = cvode.CVode(cvode_mem, tout, y, ctypes.byref(t), cvode.CV_NORMAL)
         if ret !=0:
-            print "CVODE ERROR %i"%(ret)
+            print("CVODE ERROR %i"%(ret))
             break
 
         xout[step]= tout
@@ -165,7 +166,7 @@ def odesolve(model, tfinal, envlist, params, useparams=None, tinit = 0.0, ic=Tru
 
         # increase the time counter
         tout += tadd
-    #print "Integration finished"
+    #print("Integration finished")
 
     #now deal with observables
     #obs_names = [name for name, rp in model.observable_patterns]
@@ -203,7 +204,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
     #rngmax = min(xparray[0].max(), simarray[0].max())
     #rngmin = round(rngmin, -1)
     #rngmax = round(rngmax, -1)
-    #print "Time overlap range:", rngmin,"to", rngmax
+    #print("Time overlap range:", rngmin,"to", rngmax)
     
     ipsimarray = numpy.zeros(xparray.shape[1])
     objout = []
@@ -214,9 +215,9 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # code.interact(local=locals())
         
         #some error checking
-        #print "xspairlist length:", len(xspairlist[i])
-        #print "xspairlist element type:", type(xspairlist[i])
-        #print "xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1]
+        #print("xspairlist length:", len(xspairlist[i]))
+        #print("xspairlist element type:", type(xspairlist[i]))
+        #print("xspairlist[i] elements:", xspairlist[i][0], xspairlist[i][1])
         assert type(xspairlist[i]) is tuple
         assert len(xspairlist[i]) == 2
         
@@ -236,7 +237,7 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         diffsqarray = diffarray * diffarray
 
         if vardata is True:
-            #print "using XP VAR",xparrayaxis+1
+            #print("using XP VAR",xparrayaxis+1)
             xparrayvar = xparray[xparrayaxis+1] # variance data provided in xparray in next column
         else:
             # assume a default variance
@@ -251,16 +252,16 @@ def compare_data(xparray, simarray, xspairlist, vardata=False):
         # check for inf in objarray, they creep up when there are near zero or zero values in xparrayvar
         for i in range(len(objarray)):
             if numpy.isinf(objarray[i]) or numpy.isnan(objarray[i]):
-                #print "CORRECTING NAN OR INF. IN ARRAY"
-                # print objarray
+                #print("CORRECTING NAN OR INF. IN ARRAY")
+                #print(objarray)
                 objarray[i] = 1e-100 #zero enough
 
         #import code
         #code.interact(local=locals())
 
         objout.append(objarray.sum())
-        #print "OBJOUT(%d,%d):%f  OBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout)
-    #print "OBJOUT(total):", objout
+        #print("OBJOUT(%d,%d):%f  OBJOUT(CUM):%f"%(xparrayaxis, simarrayaxis, objarray.sum(), objout))
+    #print("OBJOUT(total):", objout)
     return numpy.asarray(objout)
 
 def getlog(sobolarr, params, omag=1, useparams=[], usemag=None):
@@ -320,7 +321,7 @@ def getlin(sobolarr, params, CV =.25, useparams=[], useCV=None):
         for i in range(sobprmarr.shape[0]):
             sobprmarr[i] = (sobolarr[i]*(ub-lb)) + lb
     else:
-        print "array shape not allowed... "
+        print("array shape not allowed... ")
         
 
     # sobprmarr is the N x len(params) array for sobol analysis
@@ -361,7 +362,7 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
     # specify that this is normalized data
     if norm is True:
         # First process the A and B matrices
-        print "processing matrix A, %d iterations:", sobmtxA.shape[0]
+        print("processing matrix A, %d iterations:", sobmtxA.shape[0])
         for i in range(sobmtxA.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxA[i], useparams, ic)
             datamax = numpy.max(outlist[0], axis = 1)
@@ -371,7 +372,7 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
             yA[i] = compare_data(xpdata, outlistnorm, xspairlist, vardata)
             spinner(i)
 
-        print "\nprocessing matrix B, %d iterations:", sobmtxB.shape[0]
+        print("\nprocessing matrix B, %d iterations:", sobmtxB.shape[0])
         for i in range(sobmtxB.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxB[i], useparams, ic)
             datamax = numpy.max(outlist[0], axis = 1)
@@ -383,9 +384,9 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
             spinner(i)
 
         # now the C matrix, a bit more complicated b/c it is of size params x samples
-        print "\nprocessing matrix C_n, %d parameters:"%(sobmtxC.shape[0])
+        print("\nprocessing matrix C_n, %d parameters:"%(sobmtxC.shape[0]))
         for i in range(sobmtxC.shape[0]):
-            print "\nprocessing processing parameter %d, %d iterations"%(i,sobmtxC.shape[1])
+            print("\nprocessing processing parameter %d, %d iterations"%(i,sobmtxC.shape[1]))
             for j in range(sobmtxC.shape[1]):
                 outlist = odesolve(model, time, envlist, sobmtxC[i][j], useparams, ic)
                 datamax = numpy.max(outlist[0], axis = 1)
@@ -397,21 +398,21 @@ def parmeval(model, sobmtxA, sobmtxB, sobmtxC, time, envlist, xpdata, xspairlist
                 spinner(j)
     else:
         # First process the A and B matrices
-        print "processing matrix A:"
+        print("processing matrix A:")
         for i in range(sobmtxA.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxA[i], useparams, ic)
             yA[i] = compare_data(xpdata, outlist[0], xspairlist, vardata)
             spinner(i)
 
-        print "processing matrix B:"
+        print("processing matrix B:")
         for i in range(sobmtxB.shape[0]):
             outlist = odesolve(model, time, envlist, sobmtxB[i], useparams, ic)
             yB[i] = compare_data(xpdata, outlistnorm, xspairlist, vardata)
             spinner(i)
 
-        print "processing matrix C_n"
+        print("processing matrix C_n")
         for i in range(sobmtxC.shape[0]):
-            print "processing processing parameter %d"%i
+            print("processing processing parameter %d"%i)
             for j in range(sobmtxC.shape[1]):
                 outlist = odesolve(model, time, envlist, sobmtxC[i][j], useparams, ic)
                 yC[i][j] = compare_data(xpdata, outlistnorm, xspairlist, vardata)

--- a/pysb/examples/bax_pore.py
+++ b/pysb/examples/bax_pore.py
@@ -4,6 +4,7 @@ bax_pore_sequential.py). Inhibition of pore formation by Mcl-1 is also
 implemented.
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -61,8 +62,8 @@ Observable('BAX4_inh', BAX(inh=ANY, t1=1, t2=3) % BAX(t1=4, t2=1) % BAX(t1=2, t2
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_bax_pore.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_bax_pore.py for example usage.""")

--- a/pysb/examples/bax_pore_sequential.py
+++ b/pysb/examples/bax_pore_sequential.py
@@ -3,6 +3,7 @@ complex one at a time (contrast with bax_pore.py). Also implements cargo
 transport (Smac).
 """
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import assemble_pore_sequential, pore_transport, pore_species
 
@@ -50,8 +51,9 @@ Observable('cSmac', Smac(loc='c'))
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_bax_pore_sequential.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_bax_pore_sequential.py for example
+usage.""")

--- a/pysb/examples/bngwiki_egfr_simple.py
+++ b/pysb/examples/bngwiki_egfr_simple.py
@@ -3,6 +3,7 @@
 http://bionetgen.org/index.php/Egfr_simple
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -93,7 +94,8 @@ Rule('egfr_dimer_degrade',
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/bngwiki_simple.py
+++ b/pysb/examples/bngwiki_simple.py
@@ -3,6 +3,7 @@
 http://bionetgen.org/index.php/Simple
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -40,7 +41,8 @@ Observable('Lbound', EGF(R=ANY))  # Molecules
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/earm_1_0.py
+++ b/pysb/examples/earm_1_0.py
@@ -7,6 +7,7 @@ Cell Death. PLoS Biol 6(12): e299. doi:10.1371/journal.pbio.0060299
 http://www.plosbiology.org/article/info:doi/10.1371/journal.pbio.0060299
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -294,8 +295,8 @@ for m in model.monomers:
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_earm_1_0.py for example usage."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_earm_1_0.py for example usage.""")

--- a/pysb/examples/earm_1_3.py
+++ b/pysb/examples/earm_1_3.py
@@ -12,6 +12,7 @@ http://www.ploscompbiol.org/article/info:doi/10.1371/journal.pcbi.1002482
 # duplicating the body of that model here, we'll start this model off as a copy
 # of that one then modify and add components as necessary.
 
+from __future__ import print_function
 import re
 from pysb import *
 import pysb.bng
@@ -145,9 +146,9 @@ for species in all_species:
 
 def show_species():
     """Print a table of species like Table S2"""
-    print '   | %-12s %8s %20s %10s' \
-        % ('species', 'initial', 'synth rate', 'deg rate')
-    print '-' * (5 + 12 + 1 + 8 + 1 + 20 + 1 + 10)
+    print('   | %-12s %8s %20s %10s' %
+          ('species', 'initial', 'synth rate', 'deg rate'))
+    print('-' * (5 + 12 + 1 + 8 + 1 + 20 + 1 + 10))
     for i, species in enumerate(all_species, 1):
         mp_names = [mp.monomer.name for mp in species.monomer_patterns]
         name = '_'.join(mp_names)
@@ -165,39 +166,43 @@ def show_species():
         else:
             ks_expr = '0'
         values = (i, display_name, ic_value, ks_expr, kdeg.value)
-        print '%2d | %-12s %8d %20s %10g' % values
+        print('%2d | %-12s %8d %20s %10g' % values)
 
 def show_rates():
     """Print a table of rate parameters like Table S4"""
     # FIXME kf14-kf21 need to be un-scaled by v to make the table look right
-    print ("%-20s        " * 3) % ('forward', 'reverse', 'catalytic')
-    print '-' * (9 + 11 + 7) * 3
+    print(("%-20s        " * 3) % ('forward', 'reverse', 'catalytic'))
+    print('-' * (9 + 11 + 7) * 3)
     for i in list(range(1,29)) + [31]:
         for t in ('f', 'r', 'c'):
             n = 'k%s%d' % (t,i)
             p = model.parameters.get(n)
             if p is not None:
-                print "%-9s%11g       " % (p.name, p.value),
-        print
+                print("%-9s%11g       " % (p.name, p.value), end=' ')
+        print()
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\n"
-    print "Initial species concentrations and synthesis/degradation rates\n" \
-        "==========\n" \
-        "(compare to supporting text S3, table S2 from Gaudet et al., " \
-        "however note that\nthe numbering and ordering is different)\n" 
+    print(__doc__, "\n", model)
+    print("""
+Initial species concentrations and synthesis/degradation rates
+==========
+(compare to supporting text S3, table S2 from Gaudet et al.,
+however note that the numbering and ordering is different.)""")
     show_species()
-    print "\n"
+    print("\n")
 
-    print "Kinetic rate parameters\n" \
-        "==========\n" \
-        "(compare to supporting text S3, table S4 from Gaudet et al., " \
-        "however note that\nkf14-kf21 are off by a factor of 'v' (%g) as " \
-        "this volume scaling factor has\nbeen moved from the ODEs to the " \
-        "rate values in this implementation)\n" % v
+    print("""
+Kinetic rate parameters
+==========
+(compare to supporting text S3, table S4 from Gaudet et al.,
+however note that kf14-kf21 are off by a factor of 'v' (%g) as
+this volume scaling factor has been moved from the ODEs to the
+rate values in this implementation)
+""" % v)
     show_rates()
-    print "\n\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print("""
+
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/earm_1_3.py
+++ b/pysb/examples/earm_1_3.py
@@ -172,7 +172,7 @@ def show_rates():
     # FIXME kf14-kf21 need to be un-scaled by v to make the table look right
     print ("%-20s        " * 3) % ('forward', 'reverse', 'catalytic')
     print '-' * (9 + 11 + 7) * 3
-    for i in range(1,29) + [31]:
+    for i in list(range(1,29)) + [31]:
         for t in ('f', 'r', 'c'):
             n = 'k%s%d' % (t,i)
             p = model.parameters.get(n)

--- a/pysb/examples/explicit.py
+++ b/pysb/examples/explicit.py
@@ -1,6 +1,7 @@
 """Example of how to write a model without using SelfExporter.
 """
 
+from __future__ import print_function
 from pysb import *
 import pysb.core
 
@@ -27,7 +28,8 @@ model.initial(L(r=None), L_0)
 model.initial(R(l=None), R_0)
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/fricker_2010_apoptosis.py
+++ b/pysb/examples/fricker_2010_apoptosis.py
@@ -10,6 +10,7 @@ http://jcb.rupress.org/content/190/3/377.long
 Implemented by: Jeremie Roux, Will Chen, Jeremy Muhlich
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -169,10 +170,11 @@ for m in model.monomers:
 ####
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")
 
 
 ####

--- a/pysb/examples/hello_pysb.py
+++ b/pysb/examples/hello_pysb.py
@@ -3,6 +3,7 @@
 (This is the example shown on the pysb.org home page.)
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -30,10 +31,10 @@ Observable('LR', L(s=1) % R(s=1))
 if __name__ == '__main__':
     from pylab import linspace, plot, xlabel, ylabel, show
     from pysb.integrate import odesolve
-    print __doc__
+    print(__doc__)
     # Simulate the model through 40 seconds
     time = linspace(0, 40, 100)
-    print "Simulating..."
+    print("Simulating...")
     x = odesolve(model, time)
     # Plot the trajectory of LR
     plot(time, x['LR'])

--- a/pysb/examples/kinase_cascade.py
+++ b/pysb/examples/kinase_cascade.py
@@ -10,6 +10,7 @@ http://www.nature.com/msb/journal/v5/n1/full/msb200874.html
 Implemented by: Jeremy Muhlich
 """
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import catalyze_state
 
@@ -83,7 +84,8 @@ Observable('ppERK', ERK(t185='p', y187='p'))
 
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/move_connected.py
+++ b/pysb/examples/move_connected.py
@@ -1,6 +1,7 @@
 """Demonstration of the move_connected keyword for Rules
 """
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -35,7 +36,8 @@ Parameter('ABx_0', 1)
 Initial(A(b=1)**X % B(a=1)**X, ABx_0)
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/paper_figures/fig2a.py
+++ b/pysb/examples/paper_figures/fig2a.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2A from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.bng import generate_network, generate_equations
 import re
@@ -42,18 +43,18 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
+print("BNGL Rules")
+print("==========")
 for line in bng_code.split("\n"):
     for rule in model.rules:
         match = re.match(r'^\s*%s:\s*(.*)' % rule.name, line)
         if match:
-            print match.group(1)
-print
-print "ODEs"
-print "===="
+            print(match.group(1))
+print()
+print("ODEs")
+print("====")
 for species, ode in zip(model.species, model.odes):
-    print "%s: %s" % (species, ode)
+    print("%s: %s" % (species, ode))
 
 def test_fig2a():
     assert num_rules == 2, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig2b.py
+++ b/pysb/examples/paper_figures/fig2b.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2B from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import *
 from pysb.bng import generate_equations
@@ -19,13 +20,13 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
-print num_rules, "rules"
-print
-print "ODEs"
-print "===="
-print num_odes, "ODEs"
+print("BNGL Rules")
+print("==========")
+print(num_rules, "rules")
+print()
+print("ODEs")
+print("====")
+print(num_odes, "ODEs")
 
 def test_fig2c():
     assert num_rules == 5, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig2c.py
+++ b/pysb/examples/paper_figures/fig2c.py
@@ -1,5 +1,6 @@
 """Elements for Figure 2C from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import bind_table
 from pysb.bng import generate_network, generate_equations
@@ -53,13 +54,13 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
-print num_rules, "rules"
-print
-print "ODEs"
-print "===="
-print num_odes, "ODEs"
+print("BNGL Rules")
+print("==========")
+print(num_rules, "rules")
+print()
+print("ODEs")
+print("====")
+print(num_odes, "ODEs")
 
 def test_fig2c():
     assert num_rules == 28, "number of rules not as expected"

--- a/pysb/examples/paper_figures/fig5c.py
+++ b/pysb/examples/paper_figures/fig5c.py
@@ -1,9 +1,10 @@
 """Reaction graph for Figure 5C from the PySB publication"""
 
+from __future__ import print_function
 import pysb.tools.render_reactions
 
 from earm.mito.lopez_embedded import model
 
 # print out the graphviz representation of the contact map
-print pysb.tools.render_reactions.run(model)
+print(pysb.tools.render_reactions.run(model))
 

--- a/pysb/examples/paper_figures/fig5d.py
+++ b/pysb/examples/paper_figures/fig5d.py
@@ -1,5 +1,6 @@
 """Produce contact map for Figure 5D from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from earm import lopez_modules
 from earm import albeck_modules
@@ -38,5 +39,5 @@ try:
     os.unlink('fig5d_cm.jpg')
 except OSError:
     pass
-print
-print "Generated fig5d_cm.dot in", output_dir
+print()
+print("Generated fig5d_cm.dot in", output_dir)

--- a/pysb/examples/paper_figures/fig6.py
+++ b/pysb/examples/paper_figures/fig6.py
@@ -1,5 +1,6 @@
 """Produce contact map for Figure 5D from the PySB publication"""
 
+from __future__ import print_function
 import pysb.integrate
 import pysb.util
 import numpy as np
@@ -58,11 +59,11 @@ def objective_func(x, rate_mask, lb, ub):
     if caller_func in {'anneal', '_minimize_anneal'}:
         caller_locals = caller_frame.f_locals
         if caller_locals['n'] == 1:
-            print caller_locals['best_state'].cost, caller_locals['current_state'].cost
+            print(caller_locals['best_state'].cost, caller_locals['current_state'].cost)
         
     # Apply hard bounds
     if np.any((x < lb) | (x > ub)):
-        print "bounds-check failed"
+        print("bounds-check failed")
         return np.inf
 
     # Simulate model with rates taken from x (which is log transformed)
@@ -167,7 +168,7 @@ def estimate(start_values=None):
 
     # Display annealing results
     for v in ('xmin', 'Jmin', 'Tfinal', 'feval', 'iters', 'accept', 'retval'):
-        print "%s: %s" % (v, locals()[v])
+        print("%s: %s" % (v, locals()[v]))
 
     return params_estimated
 

--- a/pysb/examples/paper_figures/figS1b.py
+++ b/pysb/examples/paper_figures/figS1b.py
@@ -1,5 +1,6 @@
 """Elements for Figure S1B from the PySB publication"""
 
+from __future__ import print_function
 from pysb import *
 from pysb.macros import catalyze_one_step
 from pysb.bng import generate_network, generate_equations
@@ -27,18 +28,18 @@ generate_equations(model)
 num_rules = len(model.rules)
 num_odes = len(model.odes)
 
-print "BNGL Rules"
-print "=========="
+print("BNGL Rules")
+print("==========")
 for line in bng_code.split("\n"):
     for rule in model.rules:
         match = re.match(r'^\s*%s:\s*(.*)' % rule.name, line)
         if match:
-            print match.group(1)
-print
-print "ODEs"
-print "===="
+            print(match.group(1))
+print()
+print("ODEs")
+print("====")
 for species, ode in zip(model.species, model.odes):
-    print "%s: %s" % (species, ode)
+    print("%s: %s" % (species, ode))
 
 def test_figs1b():
     assert num_rules == 1, "number of rules not as expected"

--- a/pysb/examples/robertson.py
+++ b/pysb/examples/robertson.py
@@ -32,6 +32,7 @@ Analysis: An Introduction, J. Walsh, ed., Academic Press, 1966, pp. 178-182.
 # which integrates the system and plots the trajectories.
 
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -75,7 +76,7 @@ if __name__ == '__main__':
     substitutions.update(('s%d' % i, 'y%d' % (i+1))
                          for i in range(len(model.odes)))
 
-    print __doc__, "\n", model, "\n"
+    print(__doc__, "\n", model, "\n")
 
     # Iterate over each equation
     for i, eq in enumerate(model.odes):
@@ -83,9 +84,9 @@ if __name__ == '__main__':
         # mappings we built above
         eq_sub = eq.subs(substitutions)
         # Display the equation
-        print 'y%d\' = %s' % (i+1, eq_sub)
+        print('y%d\' = %s' % (i+1, eq_sub))
 
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid. Please see\n" \
-        "run_robertson.py for example usage."
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid. Please see run_robertson.py for example usage.""")

--- a/pysb/examples/run_bax_pore.py
+++ b/pysb/examples/run_bax_pore.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Simulate the bax_pore model and plot the results."""
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -8,7 +9,7 @@ from bax_pore import model
 
 
 t = linspace(0, 100)
-print "Simulating..."
+print("Simulating...")
 x = odesolve(model, t)
 
 p = plot(t, c_[x['BAX4'], x['BAX4_inh']])

--- a/pysb/examples/run_bax_pore_sequential.py
+++ b/pysb/examples/run_bax_pore_sequential.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Simulate the bax_pore_sequential model and plot the results."""
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -10,7 +11,7 @@ from bax_pore_sequential import model, max_size
 # System is very stiff, and using logspace instead of linspace to produce the
 # vector of time points happens to help with the integration
 t = logspace(-3, 5) # 1e-3 to 1e5
-print "Simulating..."
+print("Simulating...")
 x = odesolve(model, t)
 
 # Plot trajectory of each pore

--- a/pysb/examples/run_earm_1_0.py
+++ b/pysb/examples/run_earm_1_0.py
@@ -2,6 +2,7 @@
 """Reproduce figures 4A and 4B from the EARM 1.0 publication (Albeck et
 al. 2008)."""
 
+from __future__ import print_function
 from pysb.integrate import odesolve
 from pylab import *
 
@@ -18,7 +19,7 @@ L_0_baseline = model.parameters['L_0'].value
 
 
 def fig_4a():
-    print "Simulating model for figure 4A..."
+    print("Simulating model for figure 4A...")
     t = linspace(0, 20*3600, 20*60+1)  # 20 hours, in seconds, 1 min sampling
     dt = t[1] - t[0]
 
@@ -35,11 +36,11 @@ def fig_4a():
     fs = empty_like(Ls)
     Ts = empty_like(Ls)
     Td = empty_like(Ls)
-    print "Scanning over %d values of L_0" % len(Ls)
+    print("Scanning over %d values of L_0" % len(Ls))
     for i in range(len(Ls)):
         model.parameters['L_0'].value = Ls[i]
 
-        print "  L_0 = %g" % Ls[i]
+        print("  L_0 = %g" % Ls[i])
         x = odesolve(model, t)
 
         fs[i] = (x['PARP_unbound'][0] - x['PARP_unbound'][-1]) / x['PARP_unbound'][0]
@@ -63,7 +64,7 @@ def fig_4a():
 
 
 def fig_4b():
-    print "Simulating model for figure 4B..."
+    print("Simulating model for figure 4B...")
 
     t = linspace(0, 6*3600, 6*60+1)  # 6 hours
     x = odesolve(model, t)

--- a/pysb/examples/run_kinase_cascade.py
+++ b/pysb/examples/run_kinase_cascade.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from pysb.integrate import odesolve
 from pylab import linspace, plot, legend, show
 
@@ -7,7 +8,7 @@ from kinase_cascade import model
 
 
 tspan = linspace(0, 1200)
-print "Simulating..."
+print("Simulating...")
 yfull = odesolve(model, tspan)
 plot(tspan, yfull['ppMEK'], label='ppMEK')
 plot(tspan, yfull['ppERK'], label='ppERK')

--- a/pysb/examples/run_robertson.py
+++ b/pysb/examples/run_robertson.py
@@ -3,6 +3,7 @@
 trajectories.
 """
 
+from __future__ import print_function
 from pylab import *
 from pysb.integrate import odesolve
 
@@ -11,7 +12,7 @@ from robertson import model
 # We will integrate from t=0 to t=40
 t = linspace(0, 40)
 # Simulate the model
-print "Simulating..."
+print("Simulating...")
 y = odesolve(model, t, rtol=1e-4, atol=[1e-8, 1e-14, 1e-6])
 # Gather the observables of interest into a matrix
 yobs = array([y[obs] for obs in ('A_total', 'B_total', 'C_total')]).T

--- a/pysb/examples/run_tutorial_a.py
+++ b/pysb/examples/run_tutorial_a.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from pysb.integrate import Solver
 from tutorial_a import model
 
 t = [0, 10, 20, 30, 40, 50, 60]
 solver = Solver(model, t)
 solver.run()
-print solver.y[:, 1]
+print(solver.y[:, 1])

--- a/pysb/examples/synth_deg.py
+++ b/pysb/examples/synth_deg.py
@@ -1,5 +1,6 @@
 """A trivial example of synthesis and degradation rules"""
 
+from __future__ import print_function
 from pysb import *
 
 Model()
@@ -17,7 +18,8 @@ Initial(A(), A_0)
 Observable('A_total', A())
 
 if __name__ == '__main__':
-    print __doc__, "\n", model
-    print "\nNOTE: This model code is designed to be imported and programatically " \
-        "manipulated,\nnot executed directly. The above output is merely a " \
-        "diagnostic aid."
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/export/__main__.py
+++ b/pysb/export/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import re
@@ -10,7 +11,7 @@ def validate_argv(argv):
 
 def main(argv):
     if not validate_argv(argv):
-        print pysb.export.__doc__,
+        print(pysb.export.__doc__, end=' ')
         return 1
 
     model_filename = argv[1]
@@ -35,7 +36,7 @@ def main(argv):
         # as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
@@ -44,7 +45,7 @@ def main(argv):
         raise Exception("File '%s' isn't a model file" % model_filename)
 
     # Export the model
-    print pysb.export.export(model, format, model_module.__doc__)
+    print(pysb.export.export(model, format, model_module.__doc__))
 
     return 0
 

--- a/pysb/export/__main__.py
+++ b/pysb/export/__main__.py
@@ -34,7 +34,7 @@ def main(argv):
         # which we use, there will be trouble (use the imp package and import
         # as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/export/mathematica.py
+++ b/pysb/export/mathematica.py
@@ -104,7 +104,10 @@ import pysb
 import pysb.bng
 import sympy
 import re
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from math import floor, log
 from pysb.export import Exporter
 

--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -163,7 +163,10 @@ import pysb
 import pysb.bng
 import sympy
 import re
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from pysb.export import Exporter, pad
 
 class MatlabExporter(Exporter):

--- a/pysb/export/potterswheel.py
+++ b/pysb/export/potterswheel.py
@@ -65,7 +65,10 @@ import sympy
 import re
 import sys
 import os
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from pysb.export import Exporter
 
 class PottersWheelExporter(Exporter):

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -72,7 +72,10 @@ import pysb.bng
 import sympy
 import textwrap
 from pysb.export import Exporter, pad
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import re
 
 class PythonExporter(Exporter):

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -14,7 +14,10 @@ import sympy
 from sympy.printing.mathml import MathMLPrinter
 import itertools
 import textwrap
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 def indent(text, n=0):
     """Re-indent a multi-line string, stripping leading newlines and trailing

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -138,7 +138,7 @@ class BngGenerator(object):
 
 def format_monomer_site(monomer, site):
     ret = site
-    if monomer.site_states.has_key(site):
+    if site in monomer.site_states:
         for state in monomer.site_states[site]:
             ret += '~' + state
     return ret

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -108,7 +108,7 @@ class KappaGenerator(object):
 
 def format_monomer_site(monomer, site):
     ret = site
-    if monomer.site_states.has_key(site):
+    if site in monomer.site_states:
         for state in monomer.site_states[site]:
             ret += '~' + state
     return ret

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -391,7 +391,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> from numpy import linspace
     >>> numpy.set_printoptions(precision=4)
     >>> yfull = odesolve(model, linspace(0, 40, 10))
-    >>> print yfull['A_total']   #doctest: +NORMALIZE_WHITESPACE
+    >>> print(yfull['A_total'])            #doctest: +NORMALIZE_WHITESPACE
     [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
@@ -399,21 +399,21 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     integer indexing (note that the view's data buffer is shared with the
     original array so there is no extra memory cost):
 
-    >>> print yfull.shape
+    >>> print(yfull.shape)
     (10,)
-    >>> print yfull.dtype   #doctest: +NORMALIZE_WHITESPACE
+    >>> print(yfull.dtype)                 #doctest: +NORMALIZE_WHITESPACE
     [('__s0', '<f8'), ('__s1', '<f8'), ('__s2', '<f8'), ('A_total', '<f8'),
     ('B_total', '<f8'), ('C_total', '<f8')]
-    >>> print yfull[0:4, 1:3]   #doctest: +ELLIPSIS
+    >>> print(yfull[0:4, 1:3])             #doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
     IndexError: too many indices...
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
-    >>> print yarray.shape
+    >>> print(yarray.shape)
     (10, 6)
-    >>> print yarray.dtype
+    >>> print(yarray.dtype)
     float64
-    >>> print yarray[0:4, 1:3]
+    >>> print(yarray[0:4, 1:3])
     [[  0.0000e+00   0.0000e+00]
      [  2.1672e-05   1.0093e-01]
      [  1.6980e-05   1.4943e-01]

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     pass
 
+def _exec(code, locals):
+    # This is function call under Python 3, and a statement with a
+    # tuple under Python 2. The effect should be the same.
+    exec(code, locals)
+
 # some sane default options for a few well-known integrators
 default_integrator_options = {
     'vode': {
@@ -142,7 +147,7 @@ class Solver(object):
             if Solver._use_inline:
                 inline(code_eqs, ['ydot', 't', 'y', 'p']);
             else:
-                exec code_eqs_py in locals()
+                _exec(code_eqs_py, locals())
             return ydot
 
         # JACOBIAN -----------------------------------------------
@@ -194,7 +199,7 @@ class Solver(object):
             if Solver._use_inline:
                 inline(jac_eqs, ['jac', 't', 'y', 'p']);
             else:
-                exec jac_eqs_py in locals()
+                _exec(jac_eqs_py, locals())
             return jac
 
         # build integrator options list from our defaults and any kwargs passed

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -96,7 +96,7 @@ class Solver(object):
             Solver._use_inline = False
             try:
                 if weave_inline is not None:
-                    weave_inline('int i;', force=1)
+                    weave_inline('int i=0; i=i;', force=1)
                     Solver._use_inline = True
             except (scipy.weave.build_tools.CompileError,
                     distutils.errors.CompileError, ImportError):

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -8,6 +8,10 @@ import distutils.errors
 import sympy
 import re
 import itertools
+try:
+    from future_builtins import zip
+except ImportError:
+    pass
 
 # some sane default options for a few well-known integrators
 default_integrator_options = {
@@ -211,8 +215,8 @@ class Solver(object):
         self.jac = numpy.zeros((len(model.odes), len(model.species)))
         # Initialize record array for observable timecourses
         if len(model.observables):
-            self.yobs = numpy.ndarray(len(tspan), zip(model.observables.keys(),
-                                                      itertools.repeat(float)))
+            self.yobs = numpy.ndarray(len(tspan), list(zip(model.observables.keys(),
+                                                      itertools.repeat(float))))
         else:
             self.yobs = numpy.ndarray((len(tspan), 0))
         # Initialize view of observables record array
@@ -220,8 +224,8 @@ class Solver(object):
         # Initialize array for expression timecourses
         exprs = model.expressions_dynamic()
         if len(exprs):
-            self.yexpr = numpy.ndarray(len(tspan), zip(exprs.keys(),
-                                                       itertools.repeat(float)))
+            self.yexpr = numpy.ndarray(len(tspan), list(zip(exprs.keys(),
+                                                       itertools.repeat(float))))
         else:
             self.yexpr = numpy.ndarray((len(tspan), 0))
 
@@ -421,7 +425,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     solver.run(param_values, y0)
 
     species_names = ['__s%d' % i for i in range(solver.y.shape[1])]
-    yfull_dtype = zip(species_names, itertools.repeat(float))
+    yfull_dtype = list(zip(species_names, itertools.repeat(float)))
     if len(solver.yobs.dtype):
         yfull_dtype += solver.yobs.dtype.descr
     yfull = numpy.ndarray(len(solver.y), yfull_dtype)

--- a/pysb/jacobian.py
+++ b/pysb/jacobian.py
@@ -131,7 +131,7 @@ class JacobianGenerator(object):
 
     def make_groups(self, elements, size):
         groups = []
-        offsets = range(0, len(elements), size) + [None]
+        offsets = list(range(0, len(elements), size)) + [None]
         for i in range(0, len(offsets) - 1):
             groups.append(elements[offsets[i]:offsets[i+1]])
         return groups

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -11,8 +11,7 @@ The other functions are used internally and manage the execution of the Kappa
 software and the parsing of the data into a Numpy format.
 """
 
-__author__ = "johnbachman"
-
+from __future__ import print_function as _
 import pysb
 from pysb.generator.kappa import KappaGenerator
 import os
@@ -25,6 +24,9 @@ try:
     from future_builtins import zip
 except ImportError:
     pass
+
+__author__ = "johnbachman"
+
 
 def run_simulation(model, **kwargs):
     """Runs the given model using KaSim and returns the parsed results.
@@ -163,7 +165,7 @@ def run_complx(gen, kappa_filename, args):
         kappa_file.write(gen.get_content())
         kappa_file.close()
         cmd = 'complx ' + ' '.join(args) + ' ' + kappa_filename
-        print "Command: " + cmd
+        print("Command: " + cmd)
         p = subprocess.Popen(['complx'] + args + [kappa_filename],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         #p.communicate()
@@ -265,7 +267,7 @@ def run_kasim(model, time=10000, points=200, output_dir='.', cleanup=False,
 
         kappa_file.close()
 
-        print "Running kasim"
+        print("Running kasim")
         p = subprocess.Popen(['KaSim'] + args)
                            #stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         p.communicate()

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -21,6 +21,10 @@ import random
 import re
 import sympy
 import numpy as np
+try:
+    from future_builtins import zip
+except ImportError:
+    pass
 
 def run_simulation(model, **kwargs):
     """Runs the given model using KaSim and returns the parsed results.
@@ -321,7 +325,7 @@ def parse_kasim_outfile(out_filename):
             else: column_names.append(raw_name)
 
         # Create the dtype argument for the numpy record array
-        dt = zip(column_names, ('float',)*len(column_names))
+        dt = list(zip(column_names, ('float',)*len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
         arr = np.loadtxt(out_filename, dtype=dt, skiprows=1)

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -789,9 +789,9 @@ def bind_table_complex(bindtable, row_site, col_site, m1=None, m2=None, kf=None)
          Parameter('bind_R1_R2_kf', 1000.0),
          Parameter('bind_R1_R2_kr', 0.1),
          ])
-        >>> bind_table_complex([[                     C1(y=1) % C2(y=1), C2],\
-                                [R1,                  (1e-4, 1e-1),      (2e-4, 2e-1)],\
-                                [R1(c1=1) % R2(x=1),  (3e-4, 3e-1),      None]], 'x', 'c2', m1=R1, m2=C2)
+        >>> bind_table_complex([[                     C1(y=1) % C2(y=1), C2],
+        ...                     [R1,                  (1e-4, 1e-1),      (2e-4, 2e-1)],
+        ...                     [R1(c1=1) % R2(x=1),  (3e-4, 3e-1),      None]], 'x', 'c2', m1=R1, m2=C2)
         ComponentSet([
          Rule('bind_C2C1_R1', C2(y=1, c2=None) % C1(y=2) + R1(x=None) <> C2(y=1, c2=50) % C1(y=2) % R1(x=50), bind_C2C1_R1_kf, bind_C2C1_R1_kr),
          Parameter('bind_C2C1_R1_kf', 0.0001),

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -250,7 +250,7 @@ def _verify_sites_complex(c, *site_list):
         allsitesdict[mon] = mon.monomer.sites
     for site in site_list:
         specsitesdict = {}
-        for monomer, li in allsitesdict.iteritems():
+        for monomer, li in allsitesdict.items():
             for s in li:
                 if site in li:
                     specsitesdict[monomer] = site
@@ -512,13 +512,14 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
     else:
         _verify_sites_complex(s1, site1)
         _verify_sites_complex(s2, site2)
-        #Retrieve a dictionary specifiying the MonomerPattern within the complex that contains the given binding site.
-        specsitesdict1 = _verify_sites_complex(s1, site1)
-        specsitesdict2 = _verify_sites_complex(s2, site2)
+        #Retrieve a dictionary specifiying the MonomerPattern within
+        #the complex that contains the given binding site. Convert to list.
+        specsites1 = list(_verify_sites_complex(s1, site1))
+        specsites2 = list(_verify_sites_complex(s2, site2))
         #Return error if binding site exists on multiple monomers and a monomer for binding (m1/m2) hasn't been specified.
-        if len(specsitesdict1) > 1 and m1==None:
+        if len(specsites1) > 1 and m1==None:
             raise ValueError("Binding site '%s' present in more than one monomer in complex '%s'.  Specify variable m1, the monomer used for binding within the complex." % (site1, s1))
-        if len(specsitesdict2) > 1 and m2==None:
+        if len(specsites2) > 1 and m2==None:
             raise ValueError("Binding site '%s' present in more than one monomer in complex '%s'.  Specify variable m2, the monomer used for binding within the complex." % (site2, s2))
         if not s1.is_concrete:
             raise ValueError("Complex '%s' must be concrete." % (s1))
@@ -527,7 +528,7 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         #To avoid creating rules with multiple bonds to the same site when combining the two complexes, check for the maximum bond integer in s1 and add to all s2 bond integers.
         maxint = 0
         for monomer in s1.monomer_patterns:
-            for stateint in monomer.site_conditions.itervalues():
+            for stateint in monomer.site_conditions.values():
                 if isinstance(stateint, int):
                     if stateint > maxint:
                         maxint = stateint
@@ -538,10 +539,10 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         #If the given binding site is only present in one monomer in the complex:
         if m1==None:
           #Build up ComplexPattern for use in rule (with state of given binding site specified).
-            s1complexpatub = specsitesdict1.keys()[0]({site1:None})
-            s1complexpatb = specsitesdict1.keys()[0]({site1:50})
+            s1complexpatub = specsites1[0]({site1:None})
+            s1complexpatb = specsites1[0]({site1:50})
             for monomer in s1.monomer_patterns:
-                if monomer not in specsitesdict1.keys():
+                if monomer not in specsites1:
                     s1complexpatub %= monomer
                     s1complexpatb %= monomer
         else:
@@ -557,10 +558,10 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
                     s1complexpatb %= mon
         if m2==None:
           #Build up ComplexPattern for use in rule (with state of given binding site specified).
-            s2complexpatub = specsitesdict2.keys()[0]({site2:None})
-            s2complexpatb = specsitesdict2.keys()[0]({site2:50})
+            s2complexpatub = specsites2[0]({site2:None})
+            s2complexpatb = specsites2[0]({site2:50})
             for monomer in s2.monomer_patterns:
-                if monomer not in specsitesdict2.keys():
+                if monomer not in specsites2:
                     s2complexpatub %= monomer
                     s2complexpatb %= monomer
         #If the binding site is present on more than one monomer in the complex, the monomer must be specified by the user.  Use specified m2 to build ComplexPattern.

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -26,7 +26,7 @@ def serialize_component_list(model, filename):
     """
 
     f = open(filename, 'w')
-    pickle.dump(model.all_components().values(), f)
+    pickle.dump(list(model.all_components().values()), f)
     f.close()
 
 def check_model_against_component_list(model, component_list):
@@ -48,8 +48,9 @@ def check_model_against_component_list(model, component_list):
            "%d components." % \
            (model.name, len(model.all_components().values()), len(component_list))
 
+    model_components = list(model.all_components().values())
     for i, comp in enumerate(component_list):
-        model_comp_str = repr(model.all_components().values()[i])
+        model_comp_str = repr(model_components[i])
         comp_str = repr(comp) 
         assert comp_str == model_comp_str, \
                "Model %s does not match reference version: " \

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -5,11 +5,11 @@ import pickle
 def with_model(func):
     """Decorate a test to set up and tear down a Model."""
     def inner(*args, **kwargs):
-        model = Model(func.func_name, _export=False)
+        model = Model(func.__name__, _export=False)
         # manually set up SelfExporter, targeting func's globals
         SelfExporter.default_model = model
         SelfExporter.target_module = func.__module__
-        SelfExporter.target_globals = func.func_globals
+        SelfExporter.target_globals = func.__globals__
         SelfExporter.target_globals['model'] = model
         try:
             # call the actual test function

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -41,12 +41,12 @@ def check_model_against_component_list(model, component_list):
     To serialize the list of components to create a record of a
     validated state, see :py:func:`serialize_component_list`.
     """
-    assert len(model.all_components().values()) == len(component_list), \
+    assert len(model.all_components()) == len(component_list), \
            "Model %s does not have the same " \
            "number of components as the previously validated version. " \
            "The validated model has %d components, current model has " \
            "%d components." % \
-           (model.name, len(model.all_components().values()), len(component_list))
+           (model.name, len(model.all_components()), len(component_list))
 
     model_components = list(model.all_components().values())
     for i, comp in enumerate(component_list):

--- a/pysb/tests/jacobian_runtimes.py
+++ b/pysb/tests/jacobian_runtimes.py
@@ -13,9 +13,9 @@ def check_runtime(model, tspan, iterations, use_inline, use_analytic_jacobian):
     for i in range(iterations):
         sol.run()
     elapsed = timeit.default_timer() - start_time
-    print "use_inline=%s, use_analytic_jacobian=%s, %d iterations" % \
-          (use_inline, use_analytic_jacobian, iterations)
-    print "Time: %f sec\n" % elapsed
+    print("use_inline=%s, use_analytic_jacobian=%s, %d iterations" %
+          (use_inline, use_analytic_jacobian, iterations))
+    print("Time: %f sec\n" % elapsed)
 
 if __name__ == '__main__':
     arg_list = [(0, 0), (0, 1), (1, 0), (1, 1)]

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -4,23 +4,27 @@ import numpy as np
 
 def test_robertson_integration():
     t = np.linspace(0, 100)
-    # Run with and without inline
-    Solver._use_inline = False
+    # Run with or without inline
     sol = Solver(robertson.model, t, use_analytic_jacobian=True)
     sol.run()
     assert sol.y.shape[0] == t.shape[0]
-    # Run with and without inline
-    Solver._use_inline = True
-    sol = Solver(robertson.model, t, use_analytic_jacobian=True)
-    sol.run()
+
+    if Solver._use_inline:
+        # Also run without inline
+        Solver._use_inline = False
+        sol = Solver(robertson.model, t, use_analytic_jacobian=True)
+        sol.run()
+        assert sol.y.shape[0] == t.shape[0]
+        Solver._use_inline = True
 
 def test_earm_integration():
     t = np.linspace(0, 1e4, 1000)
-    # Run with and without inline
-    Solver._use_inline = False
+    # Run with or without inline
     sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
     sol.run()
-    Solver._use_inline = True
-    sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
-    sol.run()
-
+    if Solver._use_inline:
+        # Also run without inline
+        Solver._use_inline = False
+        sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
+        sol.run()
+        Solver._use_inline = True

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -6,7 +6,7 @@ import sympy
 import re
 import sys
 import os
-from StringIO import StringIO
+from io import StringIO
 
 
 def run(model):

--- a/pysb/tools/export_hoda.py
+++ b/pysb/tools/export_hoda.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import pysb
 import pysb.bng
 import sympy
@@ -129,14 +130,14 @@ if __name__ == '__main__':
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    # print run(model)
+    # print(run(model))
     run(model)
 
 

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -51,6 +51,7 @@ as a "modifier" (enzyme or catalyst).
 
 """
 
+from __future__ import print_function
 import pysb
 import pysb.bng
 import sympy
@@ -129,7 +130,7 @@ usage = usage[1:]  # strip leading newline
 if __name__ == '__main__':
     # sanity checks on filename
     if len(sys.argv) <= 1:
-        print usage,
+        print(usage, end=' ')
         exit()
     model_filename = sys.argv[1]
     if not os.path.exists(model_filename):
@@ -145,14 +146,14 @@ if __name__ == '__main__':
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    print run(model)
+    print(run(model))
 
 
 

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble
         # (use the imp package and import as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -95,7 +95,7 @@ def render_species_as_dot(species_list, graph_name=""):
                             label=monomer_label, shape="none", fontname="Arial",
                             fontsize=8)
         for bi, sites in bonds.items():
-            node_names, port_names = zip(*sites)
+            node_names, port_names = list(zip(*sites))
             sgraph.add_edge(node_names, tailport=port_names[0],
                             headport=port_names[1], label=str(bi))
     return graph.string()

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -23,6 +23,7 @@ Note that some PDF viewers will auto-reload a changed PDF, so you may not even
 need to manually reopen it every time you rerun the tool.
 """
 
+from __future__ import print_function
 import sys
 import os
 import re
@@ -106,7 +107,7 @@ usage = usage[1:]  # strip leading newline
 if __name__ == '__main__':
     # sanity checks on filename
     if len(sys.argv) <= 1:
-        print usage,
+        print(usage, end=' ')
         exit()
     model_filename = sys.argv[1]
     if not os.path.exists(model_filename):
@@ -122,11 +123,11 @@ if __name__ == '__main__':
         # as some safe name?)
         model_module = __import__(model_name)
     except Exception as e:
-        print "Error in model script:\n"
+        print("Error in model script:\n")
         raise
     # grab the 'model' variable from the module
     try:
         model = model_module.__dict__['model']
     except KeyError:
         raise Exception("File '%s' isn't a model file" % model_filename)
-    print run(model)
+    print(run(model))

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
         # which we use, there will be trouble (use the imp package and import
         # as some safe name?)
         model_module = __import__(model_name)
-    except StandardError as e:
+    except Exception as e:
         print "Error in model script:\n"
         raise
     # grab the 'model' variable from the module

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -1,3 +1,4 @@
+from __future__ import print_function as _
 from pysb import ComponentSet
 import pysb.core
 import inspect
@@ -43,7 +44,7 @@ def synthetic_data(model, tspan, obs_list=None, sigma=0.1):
 def get_param_num(model, name):
     for i in range(len(model.parameters)):
         if model.parameters[i].name == name:
-            print i, model.parameters[i]
+            print(i, model.parameters[i])
             break
     return i
 

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -2,7 +2,7 @@ from pysb import ComponentSet
 import pysb.core
 import inspect
 import numpy
-import cStringIO
+import io
 
 __all__ = ['alias_model_components', 'rules_using_parameter']
 
@@ -56,7 +56,7 @@ def write_params(model,paramarr, name=None):
     if name is not None:
         fobj = open(name, 'w')
     else:
-        fobj = cStringIO.StringIO()
+        fobj = io.StringIO()
     for i in range(len(model.parameters)):
         fobj.write("%s, %.17g\n"%(model.parameters[i].name, paramarr[i]))
     if name is None:

--- a/scripts/pysb_export
+++ b/scripts/pysb_export
@@ -1,5 +1,6 @@
 #!python
 
+from __future__ import print_function
 import os
 import sys
 from pysb.export.__main__ import main, validate_argv
@@ -16,7 +17,7 @@ Supported formats:
   %s""" % (script_name, format_list)
 
 if not validate_argv(sys.argv):
-   print usage
+   print(usage)
    sys.exit(1)
 sys.exit(main(sys.argv))
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-import distutils.cmd
-import sys, os, subprocess, traceback, re
+import sys, os, subprocess, re
+
+extra = {}
+if sys.version_info >= (3,):
+    from distutils.command.build_py import build_py_2to3
+    class build_py(build_py_2to3):
+        # http://marc.info/?l=python-distutils-sig&m=127205216610290&w=2
+        fixer_names = ['lib2to3.fixes.fix_ne']
+
+    extra['use_2to3'] = True
+    extra['cmdclass'] = {'build_py': build_py}
+    # extra['convert_2to3_doctests'] = ['src/your/module/README.txt']
 
 def main():
 
@@ -29,10 +39,12 @@ def main():
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 3',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',
             ],
+          **extra
           )
 
 def get_version():


### PR DESCRIPTION
This is v2 of #112. Changes from previous version:
- ne fixer is not applied (<> is not changed to !=)
- patches are updated to the new jacobian code that was added in the meanwhile
- 2to3 is integrated in setup.py so that 2to3 with the ne fixer is run automatically on installation under python3.

This should fix #101.

The change to full Python3 compatiblity is in branch py3-ne.