### PR TITLE
Change stringification of Expressions to allow expressions with one Parameter (or Observable)

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1060,7 +1060,7 @@ class Expression(Component, sympy.Symbol):
                    (isinstance(a, Expression) and a.is_constant_expression()) or
                    isinstance(a, sympy.Number)
                    for a in self.expr.atoms())
-        
+
     def get_value(self):
         return self.expr.evalf()
 
@@ -1074,12 +1074,28 @@ class Expression(Component, sympy.Symbol):
         ret = '%s(%s, %s)' % (self.__class__.__name__, repr(self.name),
                               repr(self.expr))
         return ret
-    
-    def __str__(self):
-        ret = '%s(%s, %s)' % (self.__class__.__name__, repr(self.name),
-                              repr(self.expr))
-        return ret
 
+    def __str__(self):
+        return repr(self)
+
+    def formula_to_str(self):
+        """Get the formula for the expression as a string.
+
+        For the case where the Expression's expression (i.e., self.expr) is
+        simply a Parameter (or an Observable) and not an algebraic expression,
+        we need to explicitly call the repr of sympy.Symbol, because otherwise
+        we will get the repr of the Parameter or Observable object, which is
+        not what we want in the string representation for the formula and which
+        causes errors for the BNG generator downstream (see issue 151).
+        """
+
+        if isinstance(self.expr, sympy.Symbol):
+            expr_repr = super(sympy.Symbol, self.expr).__repr__()
+        # If the expression is not a sympy.Symbol then it's presumably some
+        # other kind of sympy formula so calling repr directly will work.
+        else:
+            expr_repr = repr(self.expr)
+        return expr_repr
 
 
 class Model(object):

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -39,7 +39,7 @@ class BngGenerator(object):
                                (p.name, p.value))
         for e in exprs:
             self.__content += (("  %-" + str(max_length) + "s   %s\n") %
-                               (e.name, sympy_to_muparser(e.expr)))
+                               (e.name, sympy_to_muparser(e)))
         self.__content += "end parameters\n\n"
 
     def generate_compartments(self):
@@ -121,7 +121,7 @@ class BngGenerator(object):
         for i, e in enumerate(exprs):
             signature = e.name + '()'
             self.__content += ("  %-" + str(max_length) + "s   %s\n") % \
-                (signature, sympy_to_muparser(e.expr))
+                (signature, sympy_to_muparser(e))
         self.__content += "end functions\n\n"
 
     def generate_species(self):
@@ -211,9 +211,7 @@ def warn_caller(message):
     warnings.warn(message, stacklevel=stacklevel)
 
 def sympy_to_muparser(expr):
-#     code = sympy.fcode(expr)
-#     code = sympy.ccode(expr)
-    code = str(expr)
+    code = expr.formula_to_str()
     code = code.replace('\n     @', '')
     code = code.replace('**', '^')
     return code

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -42,3 +42,13 @@ def test_bidirectional_rules():
     ok_(len(model.reactions_bidirectional[0]['rule'])==3)
     ok_(model.reactions_bidirectional[0]['reversible'])
     #TODO Check that 'rate' has 4 terms
+
+@with_model
+def test_expressions_with_one_parameter():
+    Monomer('A')
+    Parameter('k1', 1)
+    Expression('e1', k1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), k1)
+    generate_equations(model)
+

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -52,3 +52,13 @@ def test_expressions_with_one_parameter():
     Initial(A(), k1)
     generate_equations(model)
 
+@with_model
+def test_expressions_with_one_observable():
+    Monomer('A')
+    Parameter('k1', 1)
+    Observable('o1', A())
+    Expression('e1', o1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), k1)
+    generate_equations(model)
+


### PR DESCRIPTION
This fixes issue #151. The problem was that sympy_to_muparser in pysb.generator.bng was calling the str() function on Expression.expr directly, which works when the Expression is some kind of algebraic formula, but not when it's a single Parameter or Observable (because the Parameter/Observable's own repr method supersedes sympy.Symbol). To fix this I added a function that is explicitly for getting the string representation of the Expression formula.

Added two new tests to test_bng.py, which pass as a result of this patch.