### PR TITLE
Fix expressions

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -786,9 +786,9 @@ class Parameter(Component, sympy.Symbol):
 
     def __repr__(self):
         return  '%s(%s, %s)' % (self.__class__.__name__, repr(self.name), repr(self.value))
-    
+
     def __str__(self):
-        return  '%s(%s, %s)' % (self.__class__.__name__, repr(self.name), repr(self.value))
+        return  repr(self)
 
 
 
@@ -842,7 +842,6 @@ class Compartment(Component):
     def __repr__(self):
         return  '%s(name=%s, parent=%s, dimension=%s, size=%s)' % \
             (self.__class__.__name__, repr(self.name), repr(self.parent), repr(self.dimension), repr(self.size))
-
 
 
 class Rule(Component):
@@ -1010,15 +1009,9 @@ class Observable(Component, sympy.Symbol):
             ret += ', match=%s' % repr(self.match)
         ret += ')'
         return ret
-    
-    def __str__(self):
-        ret = '%s(%s, %s' % (self.__class__.__name__, repr(self.name),
-                              repr(self.reaction_pattern))
-        if self.match != 'molecules':
-            ret += ', match=%s' % repr(self.match)
-        ret += ')'
-        return ret
 
+    def __str__(self):
+        return repr(self)
 
 
 class Expression(Component, sympy.Symbol):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1078,25 +1078,6 @@ class Expression(Component, sympy.Symbol):
     def __str__(self):
         return repr(self)
 
-    def formula_to_str(self):
-        """Get the formula for the expression as a string.
-
-        For the case where the Expression's expression (i.e., self.expr) is
-        simply a Parameter (or an Observable) and not an algebraic expression,
-        we need to explicitly call the repr of sympy.Symbol, because otherwise
-        we will get the repr of the Parameter or Observable object, which is
-        not what we want in the string representation for the formula and which
-        causes errors for the BNG generator downstream (see issue 151).
-        """
-
-        if isinstance(self.expr, sympy.Symbol):
-            expr_repr = super(sympy.Symbol, self.expr).__repr__()
-        # If the expression is not a sympy.Symbol then it's presumably some
-        # other kind of sympy formula so calling repr directly will work.
-        else:
-            expr_repr = repr(self.expr)
-        return expr_repr
-
 
 class Model(object):
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1060,7 +1060,7 @@ class Expression(Component, sympy.Symbol):
                    (isinstance(a, Expression) and a.is_constant_expression()) or
                    isinstance(a, sympy.Number)
                    for a in self.expr.atoms())
-        
+
     def get_value(self):
         return self.expr.evalf()
 
@@ -1074,12 +1074,28 @@ class Expression(Component, sympy.Symbol):
         ret = '%s(%s, %s)' % (self.__class__.__name__, repr(self.name),
                               repr(self.expr))
         return ret
-    
-    def __str__(self):
-        ret = '%s(%s, %s)' % (self.__class__.__name__, repr(self.name),
-                              repr(self.expr))
-        return ret
 
+    def __str__(self):
+        return repr(self)
+
+    def formula_to_str(self):
+        """Get the formula for the expression as a string.
+
+        For the case where the Expression's expression (i.e., self.expr) is
+        simply a Parameter (or an Observable) and not an algebraic expression,
+        we need to explicitly call the repr of sympy.Symbol, because otherwise
+        we will get the repr of the Parameter or Observable object, which is
+        not what we want in the string representation for the formula and which
+        causes errors for the BNG generator downstream (see issue 151).
+        """
+
+        if isinstance(self.expr, sympy.Symbol):
+            expr_repr = super(sympy.Symbol, self.expr).__repr__()
+        # If the expression is not a sympy.Symbol then it's presumably some
+        # other kind of sympy formula so calling repr directly will work.
+        else:
+            expr_repr = repr(self.expr)
+        return expr_repr
 
 
 class Model(object):

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -39,7 +39,7 @@ class BngGenerator(object):
                                (p.name, p.value))
         for e in exprs:
             self.__content += (("  %-" + str(max_length) + "s   %s\n") %
-                               (e.name, sympy_to_muparser(e.expr)))
+                               (e.name, sympy_to_muparser(e)))
         self.__content += "end parameters\n\n"
 
     def generate_compartments(self):
@@ -121,7 +121,7 @@ class BngGenerator(object):
         for i, e in enumerate(exprs):
             signature = e.name + '()'
             self.__content += ("  %-" + str(max_length) + "s   %s\n") % \
-                (signature, sympy_to_muparser(e.expr))
+                (signature, sympy_to_muparser(e))
         self.__content += "end functions\n\n"
 
     def generate_species(self):
@@ -211,9 +211,7 @@ def warn_caller(message):
     warnings.warn(message, stacklevel=stacklevel)
 
 def sympy_to_muparser(expr):
-#     code = sympy.fcode(expr)
-#     code = sympy.ccode(expr)
-    code = str(expr)
+    code = expr.formula_to_str()
     code = code.replace('\n     @', '')
     code = code.replace('**', '^')
     return code

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -39,7 +39,7 @@ class BngGenerator(object):
                                (p.name, p.value))
         for e in exprs:
             self.__content += (("  %-" + str(max_length) + "s   %s\n") %
-                               (e.name, sympy_to_muparser(e)))
+                               (e.name, expression_to_muparser(e)))
         self.__content += "end parameters\n\n"
 
     def generate_compartments(self):
@@ -121,7 +121,7 @@ class BngGenerator(object):
         for i, e in enumerate(exprs):
             signature = e.name + '()'
             self.__content += ("  %-" + str(max_length) + "s   %s\n") % \
-                (signature, sympy_to_muparser(e))
+                (signature, expression_to_muparser(e))
         self.__content += "end functions\n\n"
 
     def generate_species(self):
@@ -210,8 +210,14 @@ def warn_caller(message):
         module = inspect.getmodule(caller_frame)
     warnings.warn(message, stacklevel=stacklevel)
 
-def sympy_to_muparser(expr):
-    code = expr.formula_to_str()
+def expression_to_muparser(expression):
+    """Render the Expression as a muparser-compatible string."""
+
+    # sympy.printing.sstr is the preferred way to render an Expressions as a
+    # string (rather than, e.g., str(Expression.expr) or repr(Expression.expr).
+    # Note: "For large expressions where speed is a concern, use the setting
+    # order='none'"
+    code = sympy.printing.sstr(expression.expr, order='none')
     code = code.replace('\n     @', '')
     code = code.replace('**', '^')
     return code

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -213,7 +213,7 @@ def warn_caller(message):
 def expression_to_muparser(expression):
     """Render the Expression as a muparser-compatible string."""
 
-    # sympy.printing.sstr is the preferred way to render an Expressions as a
+    # sympy.printing.sstr is the preferred way to render an Expression as a
     # string (rather than, e.g., str(Expression.expr) or repr(Expression.expr).
     # Note: "For large expressions where speed is a concern, use the setting
     # order='none'"

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -335,8 +335,9 @@ class Solver(object):
                     raise IndexError("param_values dictionary has unknown "
                                      "parameter name (%s)" % key)
                 param_values[pi] = param_values_dict[key]
-                
-        subs = dict((p.name, param_values[i]) for i, p in
+
+        # The substitution dict must have Symbols as keys, not strings
+        subs = dict((p, param_values[i]) for i, p in
                     enumerate(self.model.parameters))
 
         if y0 is not None:

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -356,7 +356,7 @@ class Solver(object):
                     pi = self.model.parameters.index(value_obj)
                     value = param_values[pi]
                 elif value_obj in self.model.expressions:
-                    value = value_obj.expand_expr(self.model).evalf(subs=subs)
+                    value = value_obj.expand_expr().evalf(subs=subs)
                 else:
                     raise ValueError("Unexpected initial condition value type")
                 si = self.model.get_species_index(cp)

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -42,3 +42,13 @@ def test_bidirectional_rules():
     ok_(len(model.reactions_bidirectional[0]['rule'])==3)
     ok_(model.reactions_bidirectional[0]['reversible'])
     #TODO Check that 'rate' has 4 terms
+
+@with_model
+def test_expressions_with_one_parameter():
+    Monomer('A')
+    Parameter('k1', 1)
+    Expression('e1', k1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), k1)
+    generate_equations(model)
+

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -43,22 +43,3 @@ def test_bidirectional_rules():
     ok_(model.reactions_bidirectional[0]['reversible'])
     #TODO Check that 'rate' has 4 terms
 
-@with_model
-def test_expressions_with_one_parameter():
-    Monomer('A')
-    Parameter('k1', 1)
-    Expression('e1', k1)
-    Rule('A_deg', A() >> None, k1)
-    Initial(A(), k1)
-    generate_equations(model)
-
-@with_model
-def test_expressions_with_one_observable():
-    Monomer('A')
-    Parameter('k1', 1)
-    Observable('o1', A())
-    Expression('e1', o1)
-    Rule('A_deg', A() >> None, k1)
-    Initial(A(), k1)
-    generate_equations(model)
-

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -52,3 +52,13 @@ def test_expressions_with_one_parameter():
     Initial(A(), k1)
     generate_equations(model)
 
+@with_model
+def test_expressions_with_one_observable():
+    Monomer('A')
+    Parameter('k1', 1)
+    Observable('o1', A())
+    Expression('e1', o1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), k1)
+    generate_equations(model)
+

--- a/pysb/tests/test_expressions.py
+++ b/pysb/tests/test_expressions.py
@@ -1,0 +1,43 @@
+from pysb import *
+from pysb.testing import *
+from pysb.bng import *
+from pysb.integrate import Solver
+import numpy as np
+
+@with_model
+def test_ic_expression_with_two_parameters():
+    Monomer('A')
+    Parameter('k1', 1)
+    Parameter('k2', 2)
+    Expression('e1', k1*k2)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), e1)
+    generate_equations(model)
+    t = np.linspace(0, 1000, 100)
+    sol = Solver(model, t, use_analytic_jacobian=True)
+    sol.run()
+
+@with_model
+def test_ic_expression_with_one_parameter():
+    Monomer('A')
+    Parameter('k1', 1)
+    Expression('e1', k1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), e1)
+    generate_equations(model)
+    t = np.linspace(0, 1000, 100)
+    sol = Solver(model, t, use_analytic_jacobian=True)
+    sol.run()
+
+@with_model
+def test_expressions_with_one_observable():
+    Monomer('A')
+    Parameter('k1', 1)
+    Observable('o1', A())
+    Expression('e1', o1)
+    Rule('A_deg', A() >> None, k1)
+    Initial(A(), k1)
+    generate_equations(model)
+    t = np.linspace(0, 1000, 100)
+    sol = Solver(model, t, use_analytic_jacobian=True)
+    sol.run()

--- a/pysb/tests/test_expressions.py
+++ b/pysb/tests/test_expressions.py
@@ -41,3 +41,19 @@ def test_expressions_with_one_observable():
     t = np.linspace(0, 1000, 100)
     sol = Solver(model, t, use_analytic_jacobian=True)
     sol.run()
+
+@with_model
+def test_nested_expression():
+    Monomer('A')
+    Monomer('B')
+    Parameter('k1', 1)
+    Observable('o1', B())
+    Expression('e1', o1*10)
+    Expression('e2', e1+5)
+    Initial(A(), Parameter('A_0', 1000))
+    Initial(B(), Parameter('B_0', 1))
+    Rule('A_deg', A() >> None, e2)
+    generate_equations(model)
+    t = np.linspace(0, 1000, 100)
+    sol = Solver(model, t, use_analytic_jacobian=True)
+    sol.run()

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -125,7 +125,7 @@ def test_integrate_with_expression():
     Observable('s16_obs', s16())
     Observable('s20_obs', s20())
 
-    Expression('keff', sympify("ka*ka20/(ka20+s9_obs)"))
+    Expression('keff', (ka*ka20)/(ka20+s9_obs))
 
     Rule('R1', None >> s16(), ka)
     Rule('R2', None >> s20(), ka)


### PR DESCRIPTION
This fixes issues #147 and #151. There were two problems: the first was that sympy_to_muparser in pysb.generator.bng was calling the str() function on Expression.expr directly, which works when the Expression is some kind of algebraic formula, but not when it's a single Parameter or Observable (because the Parameter/Observable's own repr method supersedes sympy.Symbol). To fix this I added a function that is explicitly for getting the string representation of the Expression formula.

The other problem was that the call to expand_expr(self.model).evalf(subs=subs) in integrate.py had a syntax error--the argument self.model was erroneous (issue #147). Also this call was using the wrong substitution dict--the substitution dict was keyed by parameter name, rather than by symbol (Parameter object).

The new file test_expressions.py checks that Expressions of 1 or 2 Parameters or Observables can both be generated by BNG and integrated correctly by integrate.py.