### PR TITLE
Allow models with no initial conditions if synthesis rule(s) are present

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -240,10 +240,11 @@ def generate_network(model, cleanup=True, append_stdout=False, verbose=False):
 
     """
     gen = BngGenerator(model)
-    if not model.initial_conditions:
-        raise NoInitialConditionsError()
     if not model.rules:
         raise NoRulesError()
+    if not model.initial_conditions and not any(r.is_synth() for r in
+                                                model.rules):
+        raise NoInitialConditionsError()
     bng_filename = '%s_%d_%d_temp.bngl' % (model.name, os.getpid(), random.randint(0, 10000))
     net_filename = bng_filename.replace('.bngl', '.net')
     output = StringIO()
@@ -459,7 +460,9 @@ def _parse_group(model, line):
 class NoInitialConditionsError(RuntimeError):
     """Model initial_conditions is empty."""
     def __init__(self):
-        RuntimeError.__init__(self, "Model has no initial conditions")
+        RuntimeError.__init__(self, "Model has no initial conditions or "
+                                    "zero-order synthesis rules")
+
 
 class NoRulesError(RuntimeError):
     """Model rules is empty."""

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -6,7 +6,8 @@ from pysb.core import as_complex_pattern
 @with_model
 def test_generate_network():
     Monomer('A')
-    assert_raises(NoInitialConditionsError, generate_network, model)
+    assert_raises((NoInitialConditionsError, NoRulesError),
+                  generate_network, model)
     Parameter('A_0', 1)
     Initial(A(), A_0)
     assert_raises(NoRulesError, generate_network, model)
@@ -43,3 +44,11 @@ def test_bidirectional_rules():
     ok_(model.reactions_bidirectional[0]['reversible'])
     #TODO Check that 'rate' has 4 terms
 
+
+@with_model
+def test_zero_order_synth_no_initials():
+    Monomer('A')
+    Monomer('B')
+    Rule('Rule1', None >> A(), Parameter('ksynth', 100))
+    Rule('Rule2', A() <> B(), Parameter('kf', 20), Parameter('kr', 2))
+    generate_equations(model)

--- a/pysb/tests/test_examples.py
+++ b/pysb/tests/test_examples.py
@@ -1,13 +1,15 @@
-from pysb.bng import generate_network, NoInitialConditionsError
+from pysb.bng import generate_network, NoInitialConditionsError, NoRulesError
 from pysb.core import SelfExporter
 import traceback
 import os
 import importlib
 
+
 def test_generate_network():
     """Run network generation on all example models"""
     for model in get_example_models():
         yield (check_generate_network, model)
+
 
 def get_example_models():
     """Generator that yields the model objects for all example models"""
@@ -25,9 +27,10 @@ def get_example_models():
             yield module.model
 
 expected_exceptions = {
-    'tutorial_b': NoInitialConditionsError,
-    'tutorial_c': NoInitialConditionsError,
+    'tutorial_b': (NoInitialConditionsError, NoRulesError),
+    'tutorial_c': (NoInitialConditionsError, NoRulesError),
     }
+
 
 def check_generate_network(model):
     """Tests that network generation runs without error for the given model"""
@@ -36,11 +39,11 @@ def check_generate_network(model):
         generate_network(model)
         success = True
     except Exception as e:
-        # Some example models are deliberately incomplete, so here we will treat
-        # any of these "expected" exceptions as a success.
+        # Some example models are deliberately incomplete, so here we will
+        # treat any of these "expected" exceptions as a success.
         model_base_name = model.name.rsplit('.', 1)[1]
-        exception_class = expected_exceptions.get(model_base_name)
-        if exception_class and isinstance(e, exception_class):
+        exception_classes = expected_exceptions.get(model_base_name)
+        if exception_classes and isinstance(e, exception_classes):
             success = True
     assert success, "Network generation failed on model %s:\n-----\n%s" % \
                 (model.name, traceback.format_exc())


### PR DESCRIPTION
BioNetGen allows models without initial conditions, provided a zero-order synthesis rule is specified. This PR implements that feature in PySB.