### PR TITLE
Fix miniconda prefix in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
-- "./miniconda.sh -b"
+- bash miniconda.sh -b -p $HOME/miniconda
 - export PATH=/home/travis/miniconda/bin:$PATH
 - conda update --yes conda
 - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
-- export PATH=/home/travis/miniconda/bin:$PATH
+- export PATH="/home/travis/miniconda/bin:$PATH"
 - conda update --yes conda
-- conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx
-  nose h5py pexpect
+- conda install --yes python="$TRAVIS_PYTHON_VERSION" numpy scipy matplotlib sympy networkx
+    nose h5py pexpect
 - pip install -i https://pypi.binstar.org/pypi/simple pygraphviz==1.3rc1
 - pip install python-coveralls
 - wget "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=142"
-  -O BioNetGen-2.2.6-stable.tar.gz
+    -O BioNetGen-2.2.6-stable.tar.gz
 - tar xzf BioNetGen-2.2.6-stable.tar.gz
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
 install:


### PR DESCRIPTION
miniconda.sh unpacks to ~/miniconda2 now which broke our travis setup. This explicitly tells it to use ~/miniconda again. I am self-:+1:'ing this one as it's pretty trivial and our travis integration is totally busted without it.