### PR TITLE
Treat BNG symmetry/stoichiometry factors as numbers

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -627,7 +627,7 @@ def _parse_reaction(model, line):
     rule_name, is_reverse = zip(*[re.subn('^_reverse_|\(reverse\)$', '', r) for r in rule_list])
     is_reverse = tuple(bool(i) for i in is_reverse)
     r_names = ['__s%d' % r for r in reactants]
-    combined_rate = sympy.Mul(*[sympy.Symbol(t) for t in r_names + rate])
+    combined_rate = sympy.Mul(*[sympy.S(t) for t in r_names + rate])
     reaction = {
         'reactants': reactants,
         'products': products,


### PR DESCRIPTION
We were accidentally converting all factors from the "rate" in BNG net-file
reactions to sympy.Symbol, even the constant numeric scaling factors (2, 0.5,
etc). Somehow this all worked out properly in the end but it's certainly
better to convert the constants to sympy.numbers.Float instead.