### PR TITLE
Improved BNG temp file handling & support for sequential BNG simulations

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -11,6 +11,7 @@ import tempfile
 from pkg_resources import parse_version
 import abc
 from warnings import warn
+import shutil
 
 try:
     from cStringIO import StringIO
@@ -120,9 +121,7 @@ class BngBaseInterface(object):
         return
 
     def _delete_tmpdir(self):
-        for f in os.listdir(self.base_directory):
-            os.unlink(os.path.join(self.base_directory, f))
-        os.rmdir(self.base_directory)
+        shutil.rmtree(self.base_directory)
 
     def _check_model(self):
         """

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -101,7 +101,7 @@ class BngBaseInterface(object):
 
     @abc.abstractmethod
     def __init__(self, model, verbose=False, cleanup=False,
-                 output_prefix=None):
+                 output_prefix=None, output_dir=None):
         self.verbose = verbose
         self.cleanup = cleanup
         self.output_prefix = 'tmpBNG' if output_prefix is None else \
@@ -109,12 +109,21 @@ class BngBaseInterface(object):
         self.generator = BngGenerator(model)
         self._check_model()
 
+        self.base_directory = tempfile.mkdtemp(prefix=output_prefix,
+                                               dir=output_dir)
+        self.bng_filename = self.base_filename + '.bngl'
+
     def __enter__(self):
         return self
 
     @abc.abstractmethod
     def __exit__(self):
         return
+
+    def _delete_tmpdir(self):
+        for f in os.listdir(self.base_directory):
+            os.unlink(os.path.join(self.base_directory, f))
+        os.rmdir(self.base_directory)
 
     def _check_model(self):
         """
@@ -191,7 +200,7 @@ class BngBaseInterface(object):
         """
         Returns the base filename (without extension) for BNG output files
         """
-        return os.path.splitext(self.bng_filename)[0]
+        return os.path.join(self.base_directory, 'pysb')
 
 
 class BngConsole(BngBaseInterface):
@@ -200,7 +209,7 @@ class BngConsole(BngBaseInterface):
                  output_dir=None, output_prefix=None, timeout=30,
                  suppress_warnings=False):
         super(BngConsole, self).__init__(model, verbose, cleanup,
-                                         output_prefix)
+                                         output_prefix, output_dir)
 
         try:
             import pexpect
@@ -213,37 +222,28 @@ class BngConsole(BngBaseInterface):
 
         try:
             # Generate BNGL file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.bngl',
-                                             prefix=self.output_prefix,
-                                             dir=output_dir,
-                                             delete=False) as bng_file:
-                self.bng_filename = bng_file.name
+            with open(self.bng_filename, mode='w') as bng_file:
                 bng_file.write(self.generator.get_content())
 
             # Start BNG Console and load BNGL
             self.console = pexpect.spawn('perl %s --console' % _get_bng_path(),
-                                         cwd=os.path.dirname(
-                                             self.bng_filename),
+                                         cwd=self.base_directory,
                                          timeout=timeout)
             self._console_wait()
-            self.console.sendline('load %s' % bng_file.name)
+            self.console.sendline('load %s' % self.bng_filename)
             self._console_wait()
         except Exception as e:
             raise BngInterfaceError(e)
-        finally:
-            if self.bng_filename:
-                try:
-                    os.unlink(self.bng_filename)
-                except OSError:
-                    pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         In console mode, commands have already been executed, so we simply
-        close down the console when down.
+        close down the console and erase the temporary directory if applicable.
         """
         self.console.sendline('done')
         self.console.close()
+        if self.cleanup:
+            self._delete_tmpdir()
 
     def _console_wait(self):
         """
@@ -274,13 +274,6 @@ class BngConsole(BngBaseInterface):
                 bng_network = net_file.read()
         except Exception as e:
             raise BngInterfaceError(e)
-        finally:
-            if self.cleanup:
-                try:
-                    os.unlink(net_filename)
-                except OSError:
-                    # File may have been deleted already, or be open elsewhere
-                    pass
         return bng_network
 
     def action(self, action, **kwargs):
@@ -309,21 +302,29 @@ class BngFileInterface(BngBaseInterface):
     def __init__(self, model, verbose=False, output_dir=None,
                  output_prefix=None, cleanup=True):
         super(BngFileInterface, self).__init__(model, verbose, cleanup,
-                                               output_prefix)
+                                               output_prefix, output_dir)
+        self._init_command_queue()
+
+    def _init_command_queue(self):
+        """
+        Initializes the BNG command queue
+        """
         self.command_queue = StringIO()
         self.command_queue.write('begin actions\n')
 
-        # Create the BNGL file now so we know where to find it
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.bngl',
-                                         prefix=self.output_prefix,
-                                         dir=output_dir,
-                                         delete=False) as bng_file:
-            self.bng_filename = bng_file.name
-
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
-        In file mode, we execute all the queued commands when leaving the
-        context manager (i.e. now) by adding them to the BNGL
+        In file interface mode, we close the command queue buffer (whether
+        or not it's been executed) and erase the temporary directory if
+        applicable.
+        """
+        self.command_queue.close()
+        if self.cleanup:
+            self._delete_tmpdir()
+
+    def execute(self):
+        """
+        Executes all BNG commands in the command queue
         """
         self.command_queue.write('end actions\ndone\n')
         try:
@@ -332,8 +333,12 @@ class BngFileInterface(BngBaseInterface):
                 bng_file.write(self.generator.get_content())
                 bng_file.write(self.command_queue.getvalue())
 
+            # Reset the command queue
+            self.command_queue.close()
+            self._init_command_queue()
+
             p = subprocess.Popen(['perl', _get_bng_path(), self.bng_filename],
-                                 cwd=os.path.dirname(self.bng_filename),
+                                 cwd=self.base_directory,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             if self.verbose:
@@ -346,11 +351,6 @@ class BngFileInterface(BngBaseInterface):
                                            p_err.rstrip())
         except Exception as e:
             raise BngInterfaceError(e)
-        finally:
-            try:
-                os.unlink(self.bng_filename)
-            except OSError:
-                pass
 
     def action(self, action, **kwargs):
         """
@@ -418,17 +418,19 @@ def run_ssa(model, t_end=10, n_steps=100, param_values=None, output_dir=None,
         for i in range(len(param_values)):
             model.parameters[i].value = param_values[i]
 
-    try:
-        with BngFileInterface(model, verbose=verbose, output_dir=output_dir,
-                              output_prefix=output_file_basename,
-                              cleanup=cleanup) as bngfile:
-            output_file_basename = bngfile.base_filename
-            gdat_filename = output_file_basename + '.gdat'
-            cdat_filename = output_file_basename + '.cdat'
-            net_filename = output_file_basename + '.net'
+    with BngFileInterface(model, verbose=verbose, output_dir=output_dir,
+                          output_prefix=output_file_basename,
+                          cleanup=cleanup) as bngfile:
+        bng_tmpdir = bngfile.base_directory
+        output_file_basename = bngfile.base_filename
+        gdat_filename = output_file_basename + '.gdat'
+        cdat_filename = output_file_basename + '.cdat'
+        net_filename = output_file_basename + '.net'
 
-            bngfile.action('generate_network', overwrite=True, verbose=verbose)
-            bngfile.action('simulate', **additional_args)
+        bngfile.action('generate_network', overwrite=True, verbose=verbose)
+        bngfile.action('simulate', **additional_args)
+
+        bngfile.execute()
 
         # Read in the network file
         with open(net_filename, 'r') as net_file:
@@ -444,25 +446,16 @@ def run_ssa(model, t_end=10, n_steps=100, param_values=None, output_dir=None,
         else:
             gdat_arr = numpy.ndarray((len(cdat_arr), 0))
 
-        names = ['time'] + ['__s%d' % i for i in range(cdat_arr.shape[1]-1)] # -1 for time column
-        yfull_dtype = list(zip(names, itertools.repeat(float)))
-        if len(model.observables):
-            yfull_dtype += list(zip(model.observables.keys(),
-                                    itertools.repeat(float)))
-        yfull = numpy.ndarray(len(cdat_arr), yfull_dtype)
-        
-        yfull_view = yfull.view(float).reshape(len(yfull), -1)
-        yfull_view[:, :len(names)] = cdat_arr 
-        yfull_view[:, len(names):] = gdat_arr
+    names = ['time'] + ['__s%d' % i for i in range(cdat_arr.shape[1]-1)] # -1 for time column
+    yfull_dtype = list(zip(names, itertools.repeat(float)))
+    if len(model.observables):
+        yfull_dtype += list(zip(model.observables.keys(),
+                                itertools.repeat(float)))
+    yfull = numpy.ndarray(len(cdat_arr), yfull_dtype)
 
-    finally:
-        if cleanup:
-            for filename in [gdat_filename,
-                             cdat_filename, net_filename]:
-                try:
-                    os.unlink(filename)
-                except OSError:
-                    pass
+    yfull_view = yfull.view(float).reshape(len(yfull), -1)
+    yfull_view[:, :len(names)] = cdat_arr
+    yfull_view[:, len(names):] = gdat_arr
 
     return yfull
 
@@ -492,8 +485,9 @@ def generate_network(model, cleanup=True, append_stdout=False, verbose=False):
     with BngFileInterface(model, verbose=verbose, cleanup=cleanup) as bngfile:
         net_filename = bngfile.base_filename + '.net'
         bngfile.action('generate_network', overwrite=True, verbose=verbose)
+        bngfile.execute()
 
-    with open(net_filename, 'r') as net_file:
+        with open(net_filename, 'r') as net_file:
             output = net_file.read()
 
     return output

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -27,6 +27,27 @@ def test_simulate_network_console():
         bng.action('simulate', method='ssa', t_end=20000, n_steps=100)
 
 @with_model
+def test_sequential_simulations():
+    Monomer('A')
+    Parameter('A_0', 1)
+    Initial(A(), A_0)
+    Parameter('k', 1)
+    Rule('degrade', A() >> None, k)
+    # Suppress network overwrite warning from simulate command
+    with BngFileInterface(model) as bng:
+        bng.action('generate_network')
+        bng.action('simulate', method='ssa', t_end=20000, n_steps=100)
+        bng.execute()
+        yfull1 = bng.read_simulation_results()
+        ok_(yfull1.size == 101)
+
+        # Run another simulation by reloading the existing network file
+        bng.action('simulate', method='ssa', t_end=10000, n_steps=50)
+        bng.execute(reload_netfile=True)
+        yfull2 = bng.read_simulation_results()
+        ok_(yfull2.size == 51)
+
+@with_model
 def test_compartment_species_equivalence():
     Parameter('p', 1)
     Monomer('Q', ['x'])


### PR DESCRIPTION
This PR improves BioNetGen temp file handling by securely creating a temporary directory for each interface instance to BNG with python's `tempfile.mkdtemp` (fixes #179). This required adding in an explicit `execute()` step to `BngFileInterface`, in order to allow the user to read in files within the interface's `with(...)` context before it exits, when cleanup (deleting the temp directory) is done.

As a side effect, this enables sequential sets of actions to be run in multiple `execute()` steps. Since network generation can be costly for large networks, I also added an `execute(reload_netfile=True)` option, which is useful for e.g. sequential simulations in BNG using the same reaction network (see the new unit test in pysb/tests/test_bng.py).