### PR TITLE
Fix species name fixup in matlab exporter

### DIFF
--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -256,9 +256,9 @@ class MatlabExporter(Exporter):
         # Flatten to a string and add correct indentation
         odes_str = ('\n'+' '*12).join(odes_species_list)
 
-        # Change species names from, e.g., 's(0)' to 'y0(1)' (note change
+        # Change species names from, e.g., '__s(0)' to 'y0(1)' (note change
         # from zero-based indexing to 1-based indexing)
-        odes_str = re.sub(r's(\d+)', \
+        odes_str = re.sub(r'__s(\d+)', \
                           lambda m: 'y0(%s)' % (int(m.group(1))+1), odes_str)
         # Change C code 'pow' function to MATLAB 'power' function
         odes_str = re.sub(r'pow\(', 'power(', odes_str)


### PR DESCRIPTION
This wasn't updated when our internal species symbols gained the "__"
prefix, so the prefixes were left out of the regex that matches species
terms. The result was terms like "__y(0)" in the resulting matlab code
which is both incorrect (should be "y(0)") and also invalid matlab syntax
(no leading underscores on symbol names).

Closes #170.