### PR TITLE
Kappa updates (ANY/WILD, Expressions, KaSa, tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-- opam install ocamlfind
+- opam install ocamlfind --yes
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
-- git checkout last-KaSim3
 - make all
 - export PATH=$PATH:`pwd`
 - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
+- git checkout last-KaSim3
 - make all
 - export PATH=$PATH:`pwd`
 - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 python:
 - '2.7'
 - '3.4'
+addons:
+    apt:
+        packages:
+            ocaml-native-compilers
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
@@ -17,6 +21,11 @@ before_install:
     -O BioNetGen-2.2.6-stable.tar.gz
 - tar xzf BioNetGen-2.2.6-stable.tar.gz
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
+- wget https://github.com/Kappa-Dev/KaSim/archive/KaSim3.zip
+- unzip KaSim3.zip
+- cd KaSim-KaSim3
+- make
+- export KAPPA_HOME=`pwd`/KaSim
 install:
   python setup.py build --build-lib=build/lib
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ python:
 - '3.4'
 addons:
     apt:
+        sources:
+            - avsm
         packages:
-            ocaml-native-compilers
+            - ocaml-nox
+            - opam
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
@@ -21,11 +24,14 @@ before_install:
     -O BioNetGen-2.2.6-stable.tar.gz
 - tar xzf BioNetGen-2.2.6-stable.tar.gz
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
-- wget https://github.com/Kappa-Dev/KaSim/archive/KaSim3.zip
-- unzip KaSim3.zip
-- cd KaSim-KaSim3
-- make
-- export KAPPA_HOME=`pwd`/KaSim
+# First install ocamlfind via opam (needed to build KaSim/KaSa)
+- opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
+- opam install ocamlfind
+# Install KaSim/KaSa
+- git clone https://github.com/Kappa-Dev/KaSim.git
+- cd KaSim
+- make all
+- export PATH=$PATH:`pwd`
 - cd ../
 install:
   python setup.py build --build-lib=build/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 - cd KaSim-KaSim3
 - make
 - export KAPPA_HOME=`pwd`/KaSim
+- cd ../
 install:
   python setup.py build --build-lib=build/lib
 script:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -321,8 +321,9 @@ class MonomerPattern(object):
     * *list of int* : multi-bond (not valid in Kappa)
     * ``ANY`` : \"any\" bond (bound to something, but don't care what)
     * ``WILD`` : \"wildcard\" bond (bound or not bound)
-    * *tuple of (str, int)* : state with bond
+    * *tuple of (str, int)* : state with specified bond
     * *tuple of (str, WILD)* : state with wildcard bond
+    * *tuple of (str, ANY)* : state with any bond
 
     If a site is not listed in site_conditions then the pattern will match any
     state for that site, i.e. \"don't write, don't care\".
@@ -348,7 +349,7 @@ class MonomerPattern(object):
                 continue
             elif type(state) == str:
                 continue
-            elif type(state) == tuple and type(state[0]) == str and (type(state[1]) == int or state[1] == WILD):
+            elif type(state) == tuple and type(state[0]) == str and (type(state[1]) == int or state[1] is WILD or state[1] is ANY):
                 continue
             elif state is ANY:
                 continue

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -186,6 +186,8 @@ def format_site_condition(site, state):
         # bond is wildcard (zero or more unspecified bonds)
         if state[1] == pysb.WILD:
             state = (state[0], '?')
+        elif state[1] == pysb.ANY:
+            state = (state[0], '+')
         state_code = '~%s!%s' % state
     # one or more unspecified bonds
     elif state is pysb.ANY:

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -1,6 +1,7 @@
 import pysb
 import sympy
 from re import sub
+import warnings
 
 class KappaGenerator(object):
 
@@ -119,7 +120,8 @@ class KappaGenerator(object):
 
     def generate_species(self):
         if not self.model.initial_conditions:
-            raise KappaException("Kappa generator requires initial conditions.")
+            warnings.warn("Warning: No initial conditions.")
+
         species_codes = [format_complexpattern(cp)
                          for cp, param in self.model.initial_conditions]
         #max_length = max(len(code) for code in species_codes)

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -204,6 +204,9 @@ def format_site_condition(site, state):
     # Site bound to ANY
     elif state == pysb.ANY:
         state_code = '!_'
+    # Site bound to WILD
+    elif state == pysb.WILD:
+        state_code = '?'
     # Something else
     else:
         raise KappaException("Kappa generator has encountered an unknown "

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -219,13 +219,18 @@ def format_site_condition(site, state):
                         "element in a rule pattern site condition.")
     return '%s%s' % (site, state_code)
 
-def sympy_to_muparser(expr):
-    code = sympy.fcode(expr)
+def sympy_to_kasim_expression(expr):
+    """Render the Expression as a Kappa compatible string."""
+    # sympy.printing.sstr is the preferred way to render an Expression as a
+    # string (rather than, e.g., str(Expression.expr) or repr(Expression.expr).
+    # Note: "For large expressions where speed is a concern, use the setting
+    # order='none'"
+    code = sympy.printing.sstr(expression.expr, order='none')
     code = code.replace('\n @', '')
     code = code.replace('**', '^')
     # kasim syntax cannot handle Fortran scientific notation (must use 'e'
     # instead of 'd')
-    code = sub('(?<=[0-9])d','e',code)
+    code = sub('(?<=[0-9])d', 'e', code)
     return code
 
 class KappaException(Exception):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -108,7 +108,13 @@ class KappaGenerator(object):
         for obs in self.model.observables:
             name = '\'' + obs.name + '\''
             observable_code = format_reactionpattern(obs.reaction_pattern)
-            self.__content += ("%%obs: %s %s\n") % (name, observable_code)
+            # In the newer KaSim syntax, observables are simply variables
+            # defined to match Kappa expressions
+            if self.dialect == 'kasim':
+                self.__content += ("%%obs: %s |%s|\n") % (name, observable_code)
+            else:
+                self.__content += ("%%obs: %s %s\n") % (name, observable_code)
+
         self.__content += "\n"
 
     def generate_species(self):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -23,16 +23,16 @@ class KappaGenerator(object):
         # but prohibited in complx
         if (self.dialect == 'kasim'):
             self.generate_molecule_types() 
-            self.generate_parameters() # parameters/variables/expressions allowed in kasim
+            # Parameters, variables, and expressions are allowed in kasim
+            self.generate_parameters()
 
         self.generate_reaction_rules()
         self.generate_observables()
         self.generate_species()
 
     def generate_parameters(self):
-        #self.__content += "begin parameters\n"
-        #max_length = max(len(p.name) for p in self.model.parameters)
-        names = [x.name for x in self.model.parameters] + [x.name for x in self.model.expressions]
+        names = [x.name for x in self.model.parameters] + \
+                [x.name for x in self.model.expressions]
         for p in self.model.parameters:
             self.__content += ("%%var: \'%s\' %e\n") % (p.name, p.value)
         for e in self.model.expressions:
@@ -40,8 +40,8 @@ class KappaGenerator(object):
             str_expr = str(sympy_to_muparser(e.expr))
             for n in sym_names:
                 str_expr = str_expr.replace(n,"\'%s\'"%n)
-            self.__content += ("%%var: \'%s\' %s\n") % (e.name, str_expr.replace('**','^'))
-        #self.__content += "end parameters\n\n"
+            self.__content += ("%%var: \'%s\' %s\n") % \
+                              (e.name, str_expr.replace('**','^'))
         self.__content += "\n"
 
     #def generate_compartments(self):
@@ -51,8 +51,9 @@ class KappaGenerator(object):
     #            parent_name = ''
     #        else:
     #            parent_name = c.parent.name
-    #        self.__content += ("  %s  %d  %f  %s\n") % (c.name, c.dimension, c.size, parent_name)
-    #    self.__content += "end compartments\n\n"        
+    #        self.__content += ("  %s  %d  %f  %s\n") % \
+    #                          (c.name, c.dimension, c.size, parent_name)
+    #    self.__content += "end compartments\n\n"
 
     def generate_molecule_types(self):
         for m in self.model.monomers:
@@ -61,65 +62,77 @@ class KappaGenerator(object):
         self.__content += "\n"
 
     def generate_reaction_rules(self):
-        #self.__content += "begin reaction rules\n"
-        #max_length = max(len(r.name) for r in self.model.rules) + 1  # +1 for the colon
+        # +1 for the colon
+        #max_length = max(len(r.name) for r in self.model.rules) + 1
         for r in self.model.rules:
             label = '\'' + r.name + '\''
             reactants_code = format_reactionpattern(r.reactant_pattern)
             products_code  = format_reactionpattern(r.product_pattern)
             arrow = '->'
-            
-            if isinstance(r.rate_forward,pysb.core.Expression) and self.dialect == 'complx':
-              raise InvalidExpressionException
-            f_rate_code = ("\'" + r.rate_forward.name + "\'" if self.dialect == 'kasim' 
-                else float(r.rate_forward.value))
+
+            if isinstance(r.rate_forward,pysb.core.Expression) and \
+               self.dialect == 'complx':
+                raise KappaException("Expressions are not supported by complx.")
+            # Get the rate code depending on the dialect
+            if self.dialect == 'kasim':
+                f_rate_code = "\'" + r.rate_forward.name + "\'"
+            else:
+                f_rate_code = float(r.rate_forward.value)
+
             self.__content += ("%s %s %s %s @ %s") % \
                 (label, reactants_code, arrow, products_code, f_rate_code)
             self.__content += "\n"
 
+            # Add the reverse reaction
             if r.is_reversible:
-              if isinstance(r.rate_reverse,pysb.core.Expression) and self.dialect == 'complx':
-                  raise InvalidExpressionException
-              r_rate_code = ("\'" + r.rate_reverse.name + "\'" if self.dialect == 'kasim' 
-                  else float(r.rate_reverse.value))
-              label = '\'' + r.name + '_rev' + '\''
-              self.__content += ("%s %s %s %s @ %s") % \
-                (label, products_code, arrow, reactants_code, r_rate_code)
-              self.__content += "\n"
+                if isinstance(r.rate_reverse,pysb.core.Expression) and \
+                   self.dialect == 'complx':
+                    raise KappaException("Expressions are not supported by "
+                                         "complx.")
+                # Get the rate code depending on the dialect
+                if self.dialect == 'kasim':
+                    r_rate_code = "\'" + r.rate_reverse.name + "\'"
+                else:
+                    r_rate_code = float(r.rate_reverse.value)
+
+                label = '\'' + r.name + '_rev' + '\''
+                self.__content += ("%s %s %s %s @ %s") % \
+                      (label, products_code, arrow, reactants_code, r_rate_code)
+                self.__content += "\n"
 
         self.__content += "\n"
 
     def generate_observables(self):
         if not self.model.observables:
             return
-        #self.__content += "begin observables\n"
         for obs in self.model.observables:
             name = '\'' + obs.name + '\''
             observable_code = format_reactionpattern(obs.reaction_pattern)
             self.__content += ("%%obs: %s %s\n") % (name, observable_code)
         self.__content += "\n"
-        #self.__content += "end observables\n\n"
 
     def generate_species(self):
         if not self.model.initial_conditions:
-            raise Exception("Kappa generator requires initial conditions.")
-        species_codes = [format_complexpattern(cp) for cp, param in self.model.initial_conditions]
+            raise KappaException("Kappa generator requires initial conditions.")
+        species_codes = [format_complexpattern(cp)
+                         for cp, param in self.model.initial_conditions]
         #max_length = max(len(code) for code in species_codes)
-        #self.__content += "begin species\n"
         for i, code in enumerate(species_codes):
             param = self.model.initial_conditions[i][1]
-            #self.__content += ("%%init:  %-" + str(max_length) + "s   %s\n") % (code, param.name)
+            #self.__content += ("%%init:  %-" + str(max_length) + \
+            #                  "s   %s\n") % (code, param.name)
             if (self.dialect == 'kasim'):
-                # Switched from %g (float) to %d (int) because kappa didn't like scientific notation
-                # for large integers
+                # Switched from %g (float) to %d (int) because kappa didn't
+                # like scientific notation for large integers
                 self.__content += ("%%init: \'%s\' %s\n") % (param.name, code)
                 #self.__content += ("%%init: %10g %s\n") % (param.value, code)
             else:
                 if isinstance(param,pysb.core.Expression):
-                  raise InvalidExpressionException
-                # Switched from %g (float) to %d (int) because kappa didn't like scientific notation
-                # for large integers
-                self.__content += ("%%init: %10d * %s\n") % (float(param.value), code)
+                    raise KappaException("complx does not support Expressions.")
+                # Switched from %g (float) to %d (int) because kappa didn't
+                # like scientific notation for large integers
+                self.__content += ("%%init: %10d * %s\n") % \
+                                  (float(param.value), code)
                 #self.__content += ("%%init: %10g * %s\n") % (param.value, code)
 
         self.__content += "\n"
@@ -145,39 +158,60 @@ def format_monomerpattern(mp):
     # sort sites in the same order given in the original Monomer
     site_conditions = sorted(mp.site_conditions.items(),
                              key=lambda x: mp.monomer.sites.index(x[0]))
-    site_pattern_code = ','.join([format_site_condition(site, state) for (site, state) in site_conditions])
+    site_pattern_code = ','.join([format_site_condition(site, state)
+                                  for (site, state) in site_conditions])
     ret = '%s(%s)' % (mp.monomer.name, site_pattern_code)
     if mp.compartment is not None:
         ret = '%s@%s' % (ret, mp.compartment.name)
     return ret
 
 def format_site_condition(site, state):
+    # If the state/bond is unspecified
     if state == None:
         state_code = ''
+    # If there is a bond number
     elif type(state) == int:
         state_code = '!' + str(state)
+    # If there is a lists of bonds to the site (not supported by Kappa)
     elif type(state) == list:
-        raise Exception("Kappa generator does not support multiple bonds to a single site.")
+        raise KappaException("Kappa generator does not support multiple bonds "
+                              "to a single site.")
+    # Site with state
     elif type(state) == str:
         state_code = '~' + state
+    # Site with state and a bond
     elif type(state) == tuple:
-        if state[1] == pysb.core.ANY:
-            state = (state[0], '_')
-        state_code = '~%s!%s' % state if state[1] != pysb.WILD else '~%s?' % state[0]
+        # If the bond is ANY
+        if state[1] == pysb.ANY:
+            state_code = '~%s!_' % state[0]
+        # If the bond is WILD
+        elif state[1] == pysb.WILD:
+            state_code = '~%s?' % state[0]
+        # If the bond is a number
+        elif type(state[1]) == int:
+            state_code = '~%s!%s' % state
+        # If it's something else, raise an Exception
+        else:
+            raise KappaException("Kappa generator has encountered an unknown "
+                                 "element in a site state/bond tuple: (%s, %s)"
+                                 % state)
+    # Site bound to ANY
     elif state == pysb.ANY:
         state_code = '!_'
+    # Something else
     else:
-        raise Exception("Kappa generator has encountered an unknown element in a rule pattern site condition.")
+        raise KappaException("Kappa generator has encountered an unknown "
+                        "element in a rule pattern site condition.")
     return '%s%s' % (site, state_code)
 
 def sympy_to_muparser(expr):
     code = sympy.fcode(expr)
     code = code.replace('\n @', '')
     code = code.replace('**', '^')
-    # kasim syntax cannot handle Fortran scientific notation (must use 'e' instead of 'd')
+    # kasim syntax cannot handle Fortran scientific notation (must use 'e'
+    # instead of 'd')
     code = sub('(?<=[0-9])d','e',code)
     return code
 
-class InvalidExpressionException(Exception):
-    """complx syntax does not allow Expressions"""
+class KappaException(Exception):
     pass

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -139,8 +139,7 @@ class KappaGenerator(object):
                     raise KappaException("complx does not support Expressions.")
                 # Switched from %g (float) to %d (int) because kappa didn't
                 # like scientific notation for large integers
-                self.__content += ("%%init: %10d * %s\n") % \
-                                  (float(param.value), code)
+                self.__content += "%%init: %10d * %s\n" % (param.value, code)
         self.__content += "\n"
 
 

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -6,10 +6,11 @@ import warnings
 class KappaGenerator(object):
 
     # Dialect can be either 'complx' or 'kasim' (default)
-    def __init__(self, model, dialect='kasim'):
+    def __init__(self, model, dialect='kasim', _warn_no_ic=True):
         self.model = model
         self.__content = None
         self.dialect = dialect
+        self._warn_no_ic = _warn_no_ic
 
     def get_content(self):
         if self.__content == None:
@@ -122,7 +123,7 @@ class KappaGenerator(object):
         self.__content += "\n"
 
     def generate_species(self):
-        if not self.model.initial_conditions:
+        if self._warn_no_ic and not self.model.initial_conditions:
             warnings.warn("Warning: No initial conditions.")
 
         species_codes = [format_complexpattern(cp)

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -102,7 +102,7 @@ class KappaGenerator(object):
 
     def generate_species(self):
         if not self.model.initial_conditions:
-            raise Exception("BNG generator requires initial conditions.")
+            raise Exception("Kappa generator requires initial conditions.")
         species_codes = [format_complexpattern(cp) for cp, param in self.model.initial_conditions]
         #max_length = max(len(code) for code in species_codes)
         #self.__content += "begin species\n"

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -35,7 +35,7 @@ class KappaGenerator(object):
         names = [x.name for x in self.model.parameters] + \
                 [x.name for x in self.model.expressions]
         for p in self.model.parameters:
-            self.__content += ("%%var: '%s' %e\n") % (p.name, p.value)
+            self.__content += "%%var: '%s' %e\n" % (p.name, p.value)
         for e in self.model.expressions:
             sym_names = [x.name for x in e.expr.atoms(sympy.Symbol)]
             str_expr = str(expression_to_muparser(e))
@@ -51,8 +51,8 @@ class KappaGenerator(object):
     #            parent_name = ''
     #        else:
     #            parent_name = c.parent.name
-    #        self.__content += ("  %s  %d  %f  %s\n") % \
-    #                          (c.name, c.dimension, c.size, parent_name)
+    #        self.__content += ("  %s  %d  %f  %s\n" %
+    #                          (c.name, c.dimension, c.size, parent_name))
     #    self.__content += "end compartments\n\n"
 
     def generate_molecule_types(self):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -38,11 +38,10 @@ class KappaGenerator(object):
             self.__content += ("%%var: \'%s\' %e\n") % (p.name, p.value)
         for e in self.model.expressions:
             sym_names = [x.name for x in e.expr.atoms(sympy.Symbol)]
-            str_expr = str(sympy_to_muparser(e.expr))
+            str_expr = str(expression_to_muparser(e))
             for n in sym_names:
                 str_expr = str_expr.replace(n,"\'%s\'"%n)
-            self.__content += ("%%var: \'%s\' %s\n") % \
-                              (e.name, str_expr.replace('**','^'))
+            self.__content += "%%var: \'%s\' %s\n" % (e.name, str_expr)
         self.__content += "\n"
 
     #def generate_compartments(self):
@@ -219,7 +218,7 @@ def format_site_condition(site, state):
                         "element in a rule pattern site condition.")
     return '%s%s' % (site, state_code)
 
-def sympy_to_kasim_expression(expr):
+def expression_to_muparser(expression):
     """Render the Expression as a Kappa compatible string."""
     # sympy.printing.sstr is the preferred way to render an Expression as a
     # string (rather than, e.g., str(Expression.expr) or repr(Expression.expr).

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -142,9 +142,9 @@ def format_site_condition(site, state):
     elif type(state) == str:
         state_code = '~' + state
     elif type(state) == tuple:
-        if state[1] == pysb.WILD:
-            state = (state[0], '?')
-        state_code = '~%s!%s' % state
+        if state[1] == pysb.ANY:
+            state = (state[1], '_')
+        state_code = '~%s!%s' % state if state[1] != pysb.WILD else '~%s?' % state[0]
     elif state == pysb.ANY:
         state_code = '!_'
     else:

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -133,10 +133,7 @@ class KappaGenerator(object):
             #self.__content += ("%%init:  %-" + str(max_length) + \
             #                  "s   %s\n") % (code, param.name)
             if (self.dialect == 'kasim'):
-                # Switched from %g (float) to %d (int) because kappa didn't
-                # like scientific notation for large integers
                 self.__content += ("%%init: '%s' %s\n") % (param.name, code)
-                #self.__content += ("%%init: %10g %s\n") % (param.value, code)
             else:
                 if isinstance(param,pysb.core.Expression):
                     raise KappaException("complx does not support Expressions.")
@@ -144,8 +141,6 @@ class KappaGenerator(object):
                 # like scientific notation for large integers
                 self.__content += ("%%init: %10d * %s\n") % \
                                   (float(param.value), code)
-                #self.__content += ("%%init: %10g * %s\n") % (param.value, code)
-
         self.__content += "\n"
 
 

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -35,13 +35,13 @@ class KappaGenerator(object):
         names = [x.name for x in self.model.parameters] + \
                 [x.name for x in self.model.expressions]
         for p in self.model.parameters:
-            self.__content += ("%%var: \'%s\' %e\n") % (p.name, p.value)
+            self.__content += ("%%var: '%s' %e\n") % (p.name, p.value)
         for e in self.model.expressions:
             sym_names = [x.name for x in e.expr.atoms(sympy.Symbol)]
             str_expr = str(expression_to_muparser(e))
             for n in sym_names:
-                str_expr = str_expr.replace(n,"\'%s\'"%n)
-            self.__content += "%%var: \'%s\' %s\n" % (e.name, str_expr)
+                str_expr = str_expr.replace(n,"'%s'"%n)
+            self.__content += "%%var: '%s' %s\n" % (e.name, str_expr)
         self.__content += "\n"
 
     #def generate_compartments(self):
@@ -65,7 +65,7 @@ class KappaGenerator(object):
         # +1 for the colon
         #max_length = max(len(r.name) for r in self.model.rules) + 1
         for r in self.model.rules:
-            label = '\'' + r.name + '\''
+            label = "'" + r.name + "'"
             reactants_code = format_reactionpattern(r.reactant_pattern)
             products_code  = format_reactionpattern(r.product_pattern)
             arrow = '->'
@@ -75,7 +75,7 @@ class KappaGenerator(object):
                 raise KappaException("Expressions are not supported by complx.")
             # Get the rate code depending on the dialect
             if self.dialect == 'kasim':
-                f_rate_code = "\'" + r.rate_forward.name + "\'"
+                f_rate_code = "'" + r.rate_forward.name + "'"
             else:
                 f_rate_code = float(r.rate_forward.value)
 
@@ -91,11 +91,11 @@ class KappaGenerator(object):
                                          "complx.")
                 # Get the rate code depending on the dialect
                 if self.dialect == 'kasim':
-                    r_rate_code = "\'" + r.rate_reverse.name + "\'"
+                    r_rate_code = "'" + r.rate_reverse.name + "'"
                 else:
                     r_rate_code = float(r.rate_reverse.value)
 
-                label = '\'' + r.name + '_rev' + '\''
+                label = "'" + r.name + '_rev' + "'"
                 self.__content += ("%s %s %s %s @ %s") % \
                       (label, products_code, arrow, reactants_code, r_rate_code)
                 self.__content += "\n"
@@ -106,7 +106,7 @@ class KappaGenerator(object):
         if not self.model.observables:
             return
         for obs in self.model.observables:
-            name = '\'' + obs.name + '\''
+            name = "'" + obs.name + "'"
             observable_code = format_reactionpattern(obs.reaction_pattern)
             # In the near future (KaSim 4.0), the observable syntax will
             # require pipe characters around the expression. However, for the
@@ -135,7 +135,7 @@ class KappaGenerator(object):
             if (self.dialect == 'kasim'):
                 # Switched from %g (float) to %d (int) because kappa didn't
                 # like scientific notation for large integers
-                self.__content += ("%%init: \'%s\' %s\n") % (param.name, code)
+                self.__content += ("%%init: '%s' %s\n") % (param.name, code)
                 #self.__content += ("%%init: %10g %s\n") % (param.value, code)
             else:
                 if isinstance(param,pysb.core.Expression):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -109,12 +109,16 @@ class KappaGenerator(object):
         for obs in self.model.observables:
             name = '\'' + obs.name + '\''
             observable_code = format_reactionpattern(obs.reaction_pattern)
-            # In the newer KaSim syntax, observables are simply variables
-            # defined to match Kappa expressions
-            if self.dialect == 'kasim':
-                self.__content += ("%%obs: %s |%s|\n") % (name, observable_code)
-            else:
-                self.__content += ("%%obs: %s %s\n") % (name, observable_code)
+            # In the near future (KaSim 4.0), the observable syntax will
+            # require pipe characters around the expression. However, for the
+            # time being we'll stick with the old syntax for backwards
+            # compatibility
+            #if self.dialect == 'kasim':
+            #    self.__content += ("%%obs: %s |%s|\n") % \
+            #                      (name, observable_code)
+            #else:
+            #    self.__content += ("%%obs: %s %s\n") % (name, observable_code)
+            self.__content += ("%%obs: %s %s\n") % (name, observable_code)
 
         self.__content += "\n"
 

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -161,8 +161,8 @@ def format_site_condition(site, state):
     elif type(state) == str:
         state_code = '~' + state
     elif type(state) == tuple:
-        if state[1] == pysb.ANY:
-            state = (state[1], '_')
+        if state[1] == pysb.core.ANY:
+            state = (state[0], '_')
         state_code = '~%s!%s' % state if state[1] != pysb.WILD else '~%s?' % state[0]
     elif state == pysb.ANY:
         state_code = '!_'

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -207,8 +207,6 @@ def influence_map(model, do_open=False, **kwargs):
                                     contact_map=False, **kwargs)
     return kasa_result.influence_map
 
-    #if do_open:
-    #    open_file(im_filename)
 
 def contact_map(model, do_open=False, **kwargs):
     """Generates the contact map via KaSa.
@@ -236,12 +234,6 @@ def contact_map(model, do_open=False, **kwargs):
                                     contact_map=True, **kwargs)
     return kasa_result.contact_map
 
-    #if do_open:
-    #    open_file(cm_filename)
-
-
-
-### "PRIVATE" Functions ###############################################
 
 def run_static_analysis(model, influence_map=False, contact_map=False,
                         cleanup=True, output_prefix=None, output_dir=None,
@@ -365,6 +357,8 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
 
     return StaticAnalysisResult(cmap, imap)
 
+### "PRIVATE" Functions ###############################################
+
 def parse_kasim_outfile(out_filename):
     """
     Parses the KaSim .out file into a Numpy ndarray.
@@ -413,21 +407,3 @@ def parse_kasim_outfile(out_filename):
 
     return arr
 
-
-def open_file(filename):
-    """Utility function for opening files for display on Mac OS X.
-
-    Uses the 'open' command to open the given file using the default program
-    associated with the file's filetype. Ultimately this should be rewritten to
-    auto-detect the operating system and use the appropriate system call.
-    """
-
-    try:
-        p = subprocess.Popen(['open'] + [filename],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        #p.communicate()
-        p.wait()
-        if p.returncode:
-            raise Exception(p.stderr.read())
-    except Exception as e:
-        raise Exception("Problem opening file: ", e)

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -342,7 +342,7 @@ def run_kasa(model, influence_map=False, contact_map=False, output_dir='.',
         kappa_file.write(gen.get_content())
         kappa_file.close()
 
-        print "Running KaSa"
+        print("Running KaSa")
         p = subprocess.Popen(['KaSa'] + args)
                            #stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         p.communicate()

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -55,10 +55,7 @@ def run_simulation(model, **kwargs):
     return parse_kasim_outfile(outs['out'])
 
 def influence_map(model, do_open=False, **kwargs):
-    """Generates the influence map.
-
-    Runs KaSim with no events or points and sets the dump_influence_map
-    argument to True.
+    """Generates the influence map via KaSa.
 
     Parameters
     ----------
@@ -66,79 +63,58 @@ def influence_map(model, do_open=False, **kwargs):
         The model for generating the influence map.
     do_open : boolean
         If do_open is set to True, then calls the :py:func:`open_file` method
-        to display the influence map using the default program for opening .gv
+        to display the influence map using the default program for opening .dot
         files (e.g., GraphViz).
     **kwargs : other keyword arguments
         Any other keyword arguments are passed to the function
-        :py:func:`run_kasim`.
+        :py:func:`run_kasa`.
 
     Returns
     -------
     string
-        Returns the name of the .gv (GraphViz) file where the influence map
-        has been stored. This can subsequently be used to build a networkx or
-        PyGraphViz graph.
+        Returns the name of the .dot file where the influence map
+        has been stored.
     """
 
-    kasim_dict = run_kasim(model, time=0, points=0, dump_influence_map=True,
-                           **kwargs)
-    im_filename = kasim_dict['im']
+    kasa_dict = run_kasa(model, influence_map=True, contact_map=False,
+                         **kwargs)
+    im_filename = kasa_dict['im']
 
     if do_open:
         open_file(im_filename)
 
     return im_filename
 
-def contact_map(model, output_dir='.', base_filename=None, do_open=False, 
-                **kwargs):
-    """Runs complx with arguments for generating the contact map.
+def contact_map(model, do_open=False, **kwargs):
+    """Generates the contact map via KaSa.
 
     Parameters
     ----------
     model : pysb.core.Model
-        The model for generating the contact map.
-    output_dir : string
-        The subdirectory in which to generate the Kappa (.ka) file for the
-        model and all output files produced by complx. Default value is '.'
-        Note that only relative paths can be specified; paths are relative
-        to the directory where the current Python instance is running.
-        If the specified directory does not exist, an Exception is thrown.
-    base_filename : string
-        The base filename to be used for generation of the Kappa (.ka) file and
-        all output files produced by complx. Defaults to a string of the form::
-
-            '%s_%d_%d_temp' % (model.name, os.getpid(), random.randint(0,10000))
-
-        The contact map filenames append '_cm.jpg' and '_cm.dot' to this base
-        filename; the reachable complexes filename appends '_rch.dot'.
+        The model for generating the influence map.
     do_open : boolean
         If do_open is set to True, then calls the :py:func:`open_file` method
-        to display the contact map using the default program for opening .jpg
-        files.
+        to display the influence map using the default program for opening .dot
+        files (e.g., GraphViz).
     **kwargs : other keyword arguments
-        Any other keyword arguments are passed through to the function
-        :py:func:`run_complx`.
+        Any other keyword arguments are passed to the function
+        :py:func:`run_kasa`.
 
+    Returns
+    -------
+    string
+        Returns the name of the .dot file where the contact map
+        has been stored.
     """
 
-    gen = KappaGenerator(model, dialect='complx')
-
-    if not base_filename:
-        base_filename = '%s/%s_%d_%d_temp' % (output_dir,
-                         model.name, os.getpid(), random.randint(0, 10000))
-
-    kappa_filename = base_filename + '.ka'
-    jpg_filename = base_filename + '_cm.jpg'
-    dot_filename = base_filename + '_cm.dot'
-    reachables_filename = base_filename + '_rch.dot'
-
-    args = ['--output-high-res-contact-map-jpg', jpg_filename,
-            '--output-high-res-contact-map-dot', dot_filename,
-            '--output-reachable-complexes', reachables_filename]
-    run_complx(gen, kappa_filename, args, **kwargs)
+    kasa_dict = run_kasa(model, influence_map=False, contact_map=True,
+                         **kwargs)
+    cm_filename = kasa_dict['cm']
 
     if do_open:
-        open_file(jpg_filename)
+        open_file(cm_filename)
+
+    return cm_filename
 
 
 ### "PRIVATE" Functions ###############################################

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -139,6 +139,9 @@ def run_complx(gen, kappa_filename, args):
             ['--output-high-res-contact-map-jpg', jpg_filename]
     """
 
+    warnings.warn("Complx is no longer supported, please use run_kasa instead",
+                  DeprecationWarning, stacklevel=2)
+
     try:
         kappa_file = open(kappa_filename, 'w')
         kappa_file.write(gen.get_content())

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -136,7 +136,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
                 kappa_file.write('\n%s\n' % perturbation)
 
         # Run KaSim
-        p = subprocess.Popen(['kasim'] + args,
+        p = subprocess.Popen(['KaSim'] + args,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if verbose:
             for line in iter(p.stdout.readline, b''):

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -243,48 +243,6 @@ def contact_map(model, do_open=False, **kwargs):
 
 ### "PRIVATE" Functions ###############################################
 
-def run_complx(gen, kappa_filename, args):
-    """Generalized method for passing arguments to the complx executable.
-
-    *DEPRECATED* because complx itself is deprecated. Switching over to using
-    KaSa for static analysis.
-
-    Parameters
-    ----------
-    gen : :py:class:`pysb.generator.KappaGenerator`
-        A KappaGenerator object that is used to produce the Kappa content
-        for writing to a file.
-    kappa_filename : string
-        The name of the file to write the generated Kappa to.
-    args : list of strings
-        List of command line arguments to pass to complx, with one entry for
-        each argument, for example::
-
-            ['--output-high-res-contact-map-jpg', jpg_filename]
-    """
-
-    warnings.warn("Complx is no longer supported, please use run_kasa instead",
-                  DeprecationWarning, stacklevel=2)
-
-    try:
-        kappa_file = open(kappa_filename, 'w')
-        kappa_file.write(gen.get_content())
-        kappa_file.close()
-        cmd = 'complx ' + ' '.join(args) + ' ' + kappa_filename
-        print("Command: " + cmd)
-        p = subprocess.Popen(['complx'] + args + [kappa_filename],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        #p.communicate()
-        p.wait()
-
-        if p.returncode:
-            raise Exception(p.stderr.read())
-
-    except Exception as e:
-        raise Exception("problem running complx: " + str(e))
-
-
-
 def run_static_analysis(model, influence_map=False, contact_map=False,
                         cleanup=True, output_prefix=None, output_dir=None,
                         verbose=False):

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -74,6 +74,11 @@ def test_monomer_as_complex_pattern():
     as_complex_pattern(A)
 
 @with_model
+def test_monomerpattern():
+    A = Monomer('A',sites=['a'],site_states={'a':['u','p']},_export=False)
+    Aw = A({'a':('u',ANY)})
+
+@with_model
 def test_observable_constructor_with_monomer():
     A = Monomer('A', _export=False)
     o = Observable('o', A, _export=False)

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -76,7 +76,7 @@ def test_monomer_as_complex_pattern():
 @with_model
 def test_monomerpattern():
     A = Monomer('A',sites=['a'],site_states={'a':['u','p']},_export=False)
-    Aw = A({'a':('u',ANY)})
+    Aw = A(a=('u', ANY))
 
 @with_model
 def test_observable_constructor_with_monomer():

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -4,6 +4,7 @@ from pysb.kappa import *
 from pysb.bng import generate_network
 import subprocess 
 from re import split
+import pygraphviz as pgv
 
 @with_model
 def test_kappa_expressions():
@@ -19,12 +20,56 @@ def test_kappa_expressions():
          A(site=('u', 1)) % A(site=('u',1)) >>
          A(site='u') + A(site='u'), kr)
     # Accommodates Expression in kappa simulation
-    ok_(run_kasim(model, time=0, cleanup=True))
+    run_simulation(model, time=0)
 
     Rule('degrade_dimer', A(site=('u', ANY)) >> None, kr)
     Observable('dimer', A(site=('u', ANY)))
     # Accommodates site with explicit state and arbitrary bond
-    ok_(run_kasim(model, time=0, cleanup=True))
+    run_simulation(model, time=0)
+
+@with_model
+def test_kappa_simulation_results():
+    Monomer('A', ['b'])
+    Monomer('B', ['b'])
+    Initial(A(b=None), Parameter('A_0', 100))
+    Initial(B(b=None), Parameter('B_0', 100))
+    Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=1),
+         Parameter('kf', 1))
+    Rule('A_binds_B_rev', A(b=1) % B(b=1) >> A(b=None) + B(b=None),
+         Parameter('kr', 1))
+    Observable('AB', A(b=1) % B(b=1))
+    npts = 200
+    kres = run_simulation(model, time=100, points=npts)
+    ok_(len(kres['time']) == npts + 1)
+    ok_(len(kres['AB']) == npts + 1)
+    ok_(kres['time'][0] == 0)
+    ok_(sorted(kres['time'])[-1] == 100)
+
+@with_model
+def test_flux_map():
+    """Test kappa simulation with flux map (returns tuple with graph)"""
+    #from pysb.examples.robertson import model
+    #model.parameters['A_0'].value = 100
+    Monomer('A', ['b'])
+    Monomer('B', ['a', 'c'])
+    Monomer('C', ['b'])
+    Parameter('k', 0.001)
+    Rule('A_binds_B', A(b=None) + B(a=None) >> A(b=1) % B(a=1), k)
+    Rule('C_binds_B', C(b=None) + B(c=None) >> C(b=1) % B(c=1), k)
+    Observable('ABC', A(b=1) % B(a=1, c=2) % C(b=2))
+    Initial(A(b=None), Parameter('A_0', 100))
+    Initial(B(a=None, c=None), Parameter('B_0', 100))
+    Initial(C(b=None), Parameter('C_0', 100))
+    kasim_result = run_simulation(model, time=10, points=100, flux_map=True,
+                                  output_dir='.', cleanup=True, verbose=False)
+    ok_(len(kasim_result) == 2)
+    simdata = kasim_result[0]
+    ok_(len(simdata['time']) == 101)
+    ok_(len(simdata['ABC']) == 101)
+    ok_(simdata['time'][0] == 0)
+    ok_(sorted(simdata['time'])[-1] == 10)
+    fluxmap = kasim_result[1]
+    ok_(isinstance(fluxmap, pgv.AGraph))
 
 @with_model
 def test_kappa_wild():
@@ -34,7 +79,8 @@ def test_kappa_wild():
     Initial(B(site=None), Parameter('B_0', 100))
     Initial(A(site=1) % B(site=1), Parameter('AB_0', 1000))
     Rule('deg_A', A(site=pysb.WILD) >> None, Parameter('k', 1))
-    ok_(run_kasim(model, time=0, cleanup=True))
+    Observable('A_', A())
+    run_simulation(model, time=0)
 
 @with_model
 def test_contact_map_kasa():
@@ -42,8 +88,8 @@ def test_contact_map_kasa():
     Monomer('B', ['b'])
     Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=1),
          Parameter('k_A_binds_B', 1))
-    ok_(contact_map(model, cleanup=True, base_filename='test1'))
-    subprocess.call('rm influence.dot', shell=True)
+    Observable('AB', A(b=1) % B(b=1))
+    contact_map(model, cleanup=True, base_filename='test1')
 
 @with_model
 def test_influence_map_kasa():
@@ -59,5 +105,5 @@ def test_influence_map_kasa():
     Rule('B_activates_C',
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
-    ok_(influence_map(model, cleanup=True, base_filename='test2'))
-    subprocess.call('rm contact.dot', shell=True)
+    influence_map(model, cleanup=True, base_filename='test2')
+

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -61,7 +61,7 @@ def test_contact_map_kasa():
     Monomer('B', ['b'])
     Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=1),
          Parameter('k_A_binds_B', 1))
-    ok_(run_kasa(model, contact_map=True, cleanup=True, base_filename='test1'))
+    ok_(contact_map(model, cleanup=True, base_filename='test1'))
     subprocess.call('rm influence.dot', shell=True)
 
 @with_model
@@ -78,6 +78,5 @@ def test_influence_map_kasa():
     Rule('B_activates_C',
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
-    ok_(run_kasa(model, influence_map=True, cleanup=True,
-                 base_filename='test2'))
+    ok_(influence_map(model, cleanup=True, base_filename='test2'))
     subprocess.call('rm contact.dot', shell=True)

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -7,22 +7,33 @@ from re import split
 
 @with_model
 def test_kappa_expressions():
-    
     Monomer('A',['site'],{'site': ['u']})
     Parameter('two',2)
     Parameter('kr',0.1)
     Parameter('num_A',1000)
     Expression('kf',1e-5/two)
     Initial(A(site=('u')),num_A)
-    Rule('dimerize',A(site='u')+A(site='u') <> A(site=('u',1))%A(site=('u',1)),kf,kr)
-    # accommodates Expression in kappa simulation
-    ok_(run_kasim(model,time=0,cleanup=True))
-    
-    Rule('degrade_dimer',A(site=('u',ANY)) >> None,kr)
-    Observable('dimer',A(site=('u',ANY)))
-    # accommodates site with explicit state and arbitrary bond
-    ok_(run_kasim(model,time=0,cleanup=True))
-    
+    Rule('dimerize',
+         A(site='u') + A(site='u') <> A(site=('u', 1)) % A(site=('u',1)),
+         kf, kr)
+    # Accommodates Expression in kappa simulation
+    ok_(run_kasim(model, time=0, cleanup=True))
+
+    Rule('degrade_dimer', A(site=('u', ANY)) >> None, kr)
+    Observable('dimer', A(site=('u', ANY)))
+    # Accommodates site with explicit state and arbitrary bond
+    ok_(run_kasim(model, time=0, cleanup=True))
+
+@with_model
+def test_kappa_wild():
+    Monomer('A',['site'])
+    Monomer('B',['site'])
+    Initial(A(site=None), Parameter('A_0', 100))
+    Initial(B(site=None), Parameter('B_0', 100))
+    Initial(A(site=1) % B(site=1), Parameter('AB_0', 1000))
+    Rule('deg_A', A(site=pysb.WILD) >> None, Parameter('k', 1))
+    ok_(run_kasim(model, time=0, cleanup=True))
+
 def test_exported_kappa_file():
     m = """from pysb import *
 Model()
@@ -41,7 +52,5 @@ Observable('total_A_patterns',A(site=('u',WILD)))"""
     wf.close()
     commands = 'python -m pysb.export test.py kappa > test.ka; KaSim -i test.ka -e 0'
     # tests kappa WILD pattern and kappa syntax generation
-    ok_(subprocess.check_call(commands,shell=True) == 0)
-    subprocess.call('rm test.ka; rm test.py*',shell=True)
-    
-    
+    ok_(subprocess.check_call(commands, shell=True) == 0)
+    subprocess.call('rm test.ka; rm test.py*', shell=True)

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -36,29 +36,6 @@ def test_kappa_wild():
     Rule('deg_A', A(site=pysb.WILD) >> None, Parameter('k', 1))
     ok_(run_kasim(model, time=0, cleanup=True))
 
-def test_exported_kappa_file():
-    m = """from pysb import *
-Model()
-Monomer('A',['site'],{'site': ['u']})
-Parameter('two',2)
-Parameter('kr',0.1)
-Parameter('num_A',1000)
-Expression('kf',1e-5/two)
-Initial(A(site=('u')),num_A)
-Rule('dimerize_f',A(site='u')+A(site='u')>>A(site=('u',1))%A(site=('u',1)), kf)
-Rule('dimerize_r',A(site=('u',1))%A(site=('u',1))>>A(site='u')+A(site='u'), kr)
-Rule('degrade_dimer',A(site=('u',ANY)) >> None,kr)
-Observable('dimer',A(site=('u',ANY)))
-Observable('total_A_patterns',A(site=('u',WILD)))"""
-    wf = open('test.py','w')
-    wf.write(m)
-    wf.close()
-    commands =\
-           'python -m pysb.export test.py kappa > test.ka; KaSim -i test.ka -e 0'
-    # tests kappa WILD pattern and kappa syntax generation
-    ok_(subprocess.check_call(commands, shell=True) == 0)
-    subprocess.call('rm test.ka; rm test.py*', shell=True)
-
 @with_model
 def test_contact_map_kasa():
     Monomer('A', ['b'])

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -89,7 +89,7 @@ def test_contact_map_kasa():
     Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=1),
          Parameter('k_A_binds_B', 1))
     Observable('AB', A(b=1) % B(b=1))
-    contact_map(model, cleanup=True, base_filename='test1')
+    contact_map(model, cleanup=False, output_dir='.')
 
 @with_model
 def test_influence_map_kasa():
@@ -105,5 +105,5 @@ def test_influence_map_kasa():
     Rule('B_activates_C',
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
-    influence_map(model, cleanup=True, base_filename='test2')
+    influence_map(model, cleanup=True)
 

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -54,3 +54,30 @@ Observable('total_A_patterns',A(site=('u',WILD)))"""
     # tests kappa WILD pattern and kappa syntax generation
     ok_(subprocess.check_call(commands, shell=True) == 0)
     subprocess.call('rm test.ka; rm test.py*', shell=True)
+
+@with_model
+def test_contact_map_kasa():
+    Monomer('A', ['b'])
+    Monomer('B', ['b'])
+    Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=1),
+         Parameter('k_A_binds_B', 1))
+    ok_(run_kasa(model, contact_map=True, cleanup=True, base_filename='test1'))
+    subprocess.call('rm influence.dot', shell=True)
+
+@with_model
+def test_influence_map_kasa():
+    Monomer('A', [])
+    Monomer('B', ['active'], {'active': ['y', 'n']})
+    Monomer('C', ['active'], {'active': ['y', 'n']})
+    Initial(A(), Parameter('A_0', 100))
+    Initial(B(active='n'), Parameter('B_0', 100))
+    Initial(C(active='n'), Parameter('C_0', 100))
+    Rule('A_activates_B',
+         A() + B(active='n') >> A() + B(active='y'),
+         Parameter('k_A_activates_B', 1))
+    Rule('B_activates_C',
+         B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
+         Parameter('k_B_activates_C', 1))
+    ok_(run_kasa(model, influence_map=True, cleanup=True,
+                 base_filename='test2'))
+    subprocess.call('rm contact.dot', shell=True)

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -13,9 +13,11 @@ def test_kappa_expressions():
     Parameter('num_A',1000)
     Expression('kf',1e-5/two)
     Initial(A(site=('u')),num_A)
-    Rule('dimerize',
-         A(site='u') + A(site='u') <> A(site=('u', 1)) % A(site=('u',1)),
-         kf, kr)
+    Rule('dimerize_fwd',
+         A(site='u') + A(site='u') >> A(site=('u', 1)) % A(site=('u',1)), kf)
+    Rule('dimerize_rev',
+         A(site=('u', 1)) % A(site=('u',1)) >>
+         A(site='u') + A(site='u'), kr)
     # Accommodates Expression in kappa simulation
     ok_(run_kasim(model, time=0, cleanup=True))
 
@@ -43,14 +45,16 @@ Parameter('kr',0.1)
 Parameter('num_A',1000)
 Expression('kf',1e-5/two)
 Initial(A(site=('u')),num_A)
-Rule('dimerize',A(site='u')+A(site='u') <> A(site=('u',1))%A(site=('u',1)),kf,kr)
+Rule('dimerize_f',A(site='u')+A(site='u')>>A(site=('u',1))%A(site=('u',1)), kf)
+Rule('dimerize_r',A(site=('u',1))%A(site=('u',1))>>A(site='u')+A(site='u'), kr)
 Rule('degrade_dimer',A(site=('u',ANY)) >> None,kr)
 Observable('dimer',A(site=('u',ANY)))
 Observable('total_A_patterns',A(site=('u',WILD)))"""
     wf = open('test.py','w')
     wf.write(m)
     wf.close()
-    commands = 'python -m pysb.export test.py kappa > test.ka; KaSim -i test.ka -e 0'
+    commands =\
+           'python -m pysb.export test.py kappa > test.ka; KaSim -i test.ka -e 0'
     # tests kappa WILD pattern and kappa syntax generation
     ok_(subprocess.check_call(commands, shell=True) == 0)
     subprocess.call('rm test.ka; rm test.py*', shell=True)

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -1,0 +1,47 @@
+from pysb.testing import *
+from pysb import *
+from pysb.kappa import *
+from pysb.bng import generate_network
+import subprocess 
+from re import split
+
+@with_model
+def test_kappa_expressions():
+    
+    Monomer('A',['site'],{'site': ['u']})
+    Parameter('two',2)
+    Parameter('kr',0.1)
+    Parameter('num_A',1000)
+    Expression('kf',1e-5/two)
+    Initial(A(site=('u')),num_A)
+    Rule('dimerize',A(site='u')+A(site='u') <> A(site=('u',1))%A(site=('u',1)),kf,kr)
+    # accommodates Expression in kappa simulation
+    ok_(run_kasim(model,time=0,cleanup=True))
+    
+    Rule('degrade_dimer',A(site=('u',ANY)) >> None,kr)
+    Observable('dimer',A(site=('u',ANY)))
+    # accommodates site with explicit state and arbitrary bond
+    ok_(run_kasim(model,time=0,cleanup=True))
+    
+def test_exported_kappa_file():
+    m = """from pysb import *
+Model()
+Monomer('A',['site'],{'site': ['u']})
+Parameter('two',2)
+Parameter('kr',0.1)
+Parameter('num_A',1000)
+Expression('kf',1e-5/two)
+Initial(A(site=('u')),num_A)
+Rule('dimerize',A(site='u')+A(site='u') <> A(site=('u',1))%A(site=('u',1)),kf,kr)
+Rule('degrade_dimer',A(site=('u',ANY)) >> None,kr)
+Observable('dimer',A(site=('u',ANY)))
+Observable('total_A_patterns',A(site=('u',WILD)))"""
+    wf = open('test.py','w')
+    wf.write(m)
+    wf.close()
+    commands = 'python -m pysb.export test.py kappa > test.ka; KaSim -i test.ka -e 0'
+    # tests kappa WILD pattern and kappa syntax generation
+    ok_(subprocess.check_call(commands,shell=True) == 0)
+    subprocess.call('rm test.ka; rm test.py*',shell=True)
+    
+    


### PR DESCRIPTION
This (long overdue) pull request is based off of @ryants branch (pull request #117) which added additional Kappa functionality, including ANY and WILD bonds and Expressions, and some new tests.

In addition to these changes, I updated kappa.py to use KaSa for all static analysis rather than complx, which is now deprecated. I also fixed what was previously the "sympy_to_muparser" function in the generator/kappa.py file to make it match our current approach in generator/bng.py.

One thing to note is that Kappa 4.0, which is currently under development, will use a different syntax for observables. I updated the necessary code in 828492259e14f but then commented it out in 6204902 because this new syntax causes problems for some versions of KaSim3. When KaSim 4.0 is stable, we can uncomment these lines to make the switch to the new syntax.

I set up a Travis build procedure for testing pysb Kappa functionality, which required installing ocaml and the opam package manager for ocaml (which is then used to install a KaSim dependency, ocaml-findlib). After some fiddling around, I finally got the correct recipe for the ocaml installation/KaSim build from the .travis.yml file of the KaSim repo itself. Note that it appears that some of the source downloads from the KaSim git repo (e.g., KaSim3.5), when built, only produce a KaSim binary and not a KaSa binary, causing the tests of the KaSa functionality to fail. As a result I git cloned the KaSim source in the travis script and then did a checkout of the KaSim commit tagged "last-KaSim3" under the assumption that this will be their last KaSim 3 release before they make the (possibly breaking) changes involved in KaSim 4.

The most notable wart that remains is that the PySB Kappa tools require KaSim and KaSa to be on the user's PATH. There is currently no implementation of using an environment variable, e.g., KAPPA_HOME, to find the location of KaSim/KaSa, nor a standard set of installation locations that are searched.