### PR TITLE
BNGL fixes: begin/end model declarations; only send "done" when using console

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -387,7 +387,7 @@ class BngFileInterface(BngBaseInterface):
             multiple actions in a row, where results need to be read
             into PySB before a new series of actions is executed.
         """
-        self.command_queue.write('end actions\ndone\n')
+        self.command_queue.write('end actions\n')
         bng_commands = self.command_queue.getvalue()
         try:
             # Generate BNGL file

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -18,7 +18,7 @@ class BngGenerator(object):
         return self.__content
 
     def generate_content(self):
-        self.__content = ''
+        self.__content = "begin model\n"
         self.generate_parameters()
         self.generate_compartments()
         self.generate_molecule_types()
@@ -26,6 +26,7 @@ class BngGenerator(object):
         self.generate_functions()
         self.generate_species()
         self.generate_reaction_rules()
+        self.__content += "end model\n"
 
     def generate_parameters(self):
         exprs = self.model.expressions_constant()


### PR DESCRIPTION
Two minor fixes to the BioNetGen language outputted by PySB:
* Wrap model declarations with `begin model` and `end model`
* Only send `done` command when using the BNG console (not needed for file-based BNG interface)