### PR TITLE
Use fixed git SHA for Kappa tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
+- git checkout f87eada
 - make all
 - export PATH=$PATH:`pwd`
 - cd ../

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -387,7 +387,7 @@ class BngFileInterface(BngBaseInterface):
             multiple actions in a row, where results need to be read
             into PySB before a new series of actions is executed.
         """
-        self.command_queue.write('end actions\ndone\n')
+        self.command_queue.write('end actions\n')
         bng_commands = self.command_queue.getvalue()
         try:
             # Generate BNGL file

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -18,7 +18,7 @@ class BngGenerator(object):
         return self.__content
 
     def generate_content(self):
-        self.__content = ''
+        self.__content = "begin model\n"
         self.generate_parameters()
         self.generate_compartments()
         self.generate_molecule_types()
@@ -26,6 +26,7 @@ class BngGenerator(object):
         self.generate_functions()
         self.generate_species()
         self.generate_reaction_rules()
+        self.__content += "end model\n"
 
     def generate_parameters(self):
         exprs = self.model.expressions_constant()


### PR DESCRIPTION
The Kappa team are making lots of updates recently, leaving us with a moving target for Travis unit tests. For now, we'll stick to the commit from March 9, 2016: https://github.com/Kappa-Dev/KaSim/commit/f87eada74a188dc14eabfbe43f8e264cd5352a6a until a more permanent solution is found.