### PR TITLE
Simulator fixes

### DIFF
--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -279,14 +279,24 @@ class Solver(object):
 
         # Integrator
         if integrator == 'lsoda':
+            # lsoda is accessed via scipy.integrate.odeint which, as a function,
+            # requires that we pass its args at the point of call. Thus we need
+            # to stash stuff like the rhs and jacobian functions in self so we
+            # can pass them in later.
             self.integrator = integrator
-            # lsoda's arguments are in a different order to other integrators
+            # lsoda's rhs and jacobian function arguments are in a different
+            # order to other integrators, so we define these shims that swizzle
+            # the argument order appropriately.
             self.func = lambda t, y, p: rhs(y, t, p)
             if jac_fn is None:
                 self.jac_fn = None
             else:
                 self.jac_fn = lambda t, y, p: jac_fn(y, t, p)
         else:
+            # The scipy.integrate.ode integrators on the other hand are object
+            # oriented and hold the functions and such internally. Once we set
+            # up the integrator object we only need to retain a reference to it
+            # and can forget about the other bits.
             self.integrator = scipy.integrate.ode(rhs, jac=jac_fn)
             with warnings.catch_warnings():
                 warnings.filterwarnings('error', 'No integrator name match')

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -282,7 +282,10 @@ class Solver(object):
             self.integrator = integrator
             # lsoda's arguments are in a different order to other integrators
             self.func = lambda t, y, p: rhs(y, t, p)
-            self.jac_fn = lambda t, y, p: jacobian(y, t, p)
+            if jac_fn is None:
+                self.jac_fn = None
+            else:
+                self.jac_fn = lambda t, y, p: jac_fn(y, t, p)
         else:
             self.integrator = scipy.integrate.ode(rhs, jac=jac_fn)
             with warnings.catch_warnings():

--- a/pysb/simulate.py
+++ b/pysb/simulate.py
@@ -112,7 +112,7 @@ class Simulator:
         for n in range(len(self.y)):
             len_tout_n = len(self.tout[n])
             # observables
-            if len(len_obs):
+            if len_obs:
                 self.yobs[n] = tmp_obs.copy()
             else:
                 self.yobs[n] = np.ndarray((len_tout_n, 0))

--- a/pysb/simulate.py
+++ b/pysb/simulate.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 import numpy as np
 import itertools
+import sympy
 
 class Simulator:
     """An abstract base class for numerical simulation of models.
@@ -101,18 +102,25 @@ class Simulator:
         self.yobs_view = len(self.y) * [None]
         self.yexpr = len(self.y) * [None]
         self.yexpr_view = len(self.y) * [None]
+        len_tout = len(self.tout[0])
+        tmp_obs = np.ndarray(len_tout, zip(self.model.observables.keys(), itertools.repeat(float)))
+        exprs = self.model.expressions_dynamic()
+        obs_names = self.model.observables.keys()
+        len_obs = len(self.model.observables)
+        model_obs = self.model.observables
         # loop over simulations
         for n in range(len(self.y)):
+            len_tout_n = len(self.tout[n])
             # observables
-            if len(self.model.observables):
-                self.yobs[n] = np.ndarray(len(self.tout[n]), zip(self.model.observables.keys(), itertools.repeat(float)))
+            if len(len_obs):
+                self.yobs[n] = tmp_obs.copy()
             else:
-                self.yobs[n] = np.ndarray((len(self.tout[n]), 0))
+                self.yobs[n] = np.ndarray((len_tout_n, 0))
             self.yobs_view[n] = self.yobs[n].view(float).reshape(len(self.yobs[n]), -1)
-            for i,obs in enumerate(self.model.observables):
+            for i,obs in enumerate(model_obs):
                 self.yobs_view[n][:,i] = (self.y[n][:,obs.species] * obs.coefficients).sum(axis=1)
             # expressions
-            exprs = self.model.expressions_dynamic()
+
             if len(exprs):
                 self.yexpr[n] = np.ndarray(len(self.tout[n]), zip(exprs.keys(), itertools.repeat(float)))
             else:
@@ -121,9 +129,9 @@ class Simulator:
             if param_values is None:
                 param_values = [p.value for p in self.model.parameters]
             p_subs = { p.name : param_values[i] for i,p in enumerate(self.model.parameters) }
-            obs_names = self.model.observables.keys()
+
             obs_dict = { name : self.yobs_view[n][:,i] for i,name in enumerate(obs_names) }
-            for i,expr in enumerate(self.model.expressions_dynamic()):
+            for i,expr in enumerate(exprs):
                 expr_subs = expr.expand_expr(self.model).subs(p_subs)
                 func = sympy.lambdify(obs_names, expr_subs, "numpy")
                 self.yexpr_view[n][:,i] = func(**obs_dict)

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -1,24 +1,16 @@
 from pysb.testing import *
-from pysb.core import *
-from pysb.macros import *
 from pysb.integrate import odesolve, Solver
-from pylab import linspace, plot, xlabel, ylabel, show
-from sympy import sympify
 import numpy as np
-from pysb import *
+from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.bng import run_ssa
-from pysb.macros import synthesize
-import matplotlib.pyplot as plt
-from unittest import TestCase
 
 from pysb.examples import robertson, earm_1_0
 
 
-class SolverTests(TestCase):
+class TestSolver(object):
+
     @with_model
     def setUp(self):
-        """ Setup for Solver() tests """
-
         Monomer('A', ['a'])
         Monomer('B', ['b'])
 
@@ -36,75 +28,87 @@ class SolverTests(TestCase):
         Observable("B_free", B(b=None))
         Observable("AB_complex", A(a=1) % B(b=1))
 
-        synthesize(A(a=None), ksynthA)
-        synthesize(B(b=None), ksynthB)
+        Rule('A_synth', None >> A(a=None), ksynthA)
+        Rule('B_synth', None >> B(b=None), ksynthB)
         Rule('AB_bind', A(a=None) + B(b=None) >> A(a=1) % B(b=1), kbindAB)
 
-        time = np.linspace(0, 0.005, 101)
-        self.solver = Solver(model, time)
-        self.solver_lsoda = Solver(model, time, integrator='lsoda')
-        self.solver_lsoda_jac = Solver(model, time, integrator='lsoda',
-                                       use_analytic_jacobian=True)
+        self.model = model
 
-    def test_solver_run(self):
-        """ Test solver.run() with no arguments """
+        # This timespan is chosen to be enough to trigger a Jacobian evaluation
+        # on the various solvers.
+        self.time = np.linspace(0, 1)
+        self.solver = Solver(self.model, self.time, integrator='vode')
+
+    def tearDown(self):
+        self.model = None
+        self.time = None
+        self.solver = None
+
+    def test_vode_solver_run(self):
+        """Test vode."""
         self.solver.run()
-        
+
+    def test_vode_jac_solver_run(self):
+        """Test vode and analytic jacobian."""
+        solver_vode_jac = Solver(self.model, self.time, integrator='vode',
+                                  use_analytic_jacobian=True)
+        solver_vode_jac.run()
+
     def test_lsoda_solver_run(self):
-        """ Test solver.run() with no arguments """
-        self.solver_lsoda.run()
-    
+        """Test lsoda."""
+        solver_lsoda = Solver(self.model, self.time, integrator='lsoda')
+        solver_lsoda.run()
+
     def test_lsoda_jac_solver_run(self):
-        """ Test solver.run() with no arguments """
-        self.solver_lsoda_jac.run()
-        
+        """Test lsoda and analytic jacobian."""
+        solver_lsoda_jac = Solver(self.model, self.time, integrator='lsoda',
+                                  use_analytic_jacobian=True)
+        solver_lsoda_jac.run()
+
     @raises(NotImplementedError)
     def test_y0_as_dictionary_monomer_species(self):
-        """ Test solver.run() with y0 as a dictionary containing monomers
-            defined within model """
+        """Test y0 with model-defined species."""
         self.solver.run(y0={"A(a=None)": 10, "B(b=1) % A(a=1)": 0,
                         "B(b=None)": 0})
-        assert np.abs(self.solver.y[0,0] - 10) < 1e-8
+        assert np.allclose(self.solver.y[0, 0], 10)
 
     @raises(NotImplementedError)
     def test_y0_as_dictionary_with_bound_species(self):
-        """ Test solver.run() with y0 as a dictionary containing a complex
-        that is generated with BioNetGen """
+        """Test y0 with dynamically generated species."""
         self.solver.run(y0={"A(a=None)": 0, "B(b=1) % A(a=1)": 100,
                         "B(b=None)": 0})
-        assert np.abs(self.solver.y[0, 3] - 100) < 1e-8
+        assert np.allclose(self.solver.y[0, 3], 100)
 
     @raises(NotImplementedError)
     def test_y0_invalid_dictionary_key(self):
-        """ Test solver.run() using y0 dictionary with invalid monomer name """
+        """Test y0 with invalid monomer name."""
         self.solver.run(y0={"C(c=None)": 1})
 
     @raises(NotImplementedError)
     def test_y0_non_numeric_value(self):
-        """ Test solver.run() using y0 dictionary with a non-numeric value """
+        """Test y0 with non-numeric value."""
         self.solver.run(y0={"A(a=None)": 'eggs'})
 
     def test_param_values_as_dictionary(self):
-        """ Test solver.run() with param_values as a dictionary """
+        """Test param_values as a dictionary."""
         self.solver.run(param_values={'kbindAB': 0})
-        # kbindAB=0 should ensure no AB_complex is produced
-        assert all(self.solver.yobs["AB_complex"] < 1e-8)
+        # kbindAB=0 should ensure no AB_complex is produced.
+        assert np.allclose(self.solver.yobs["AB_complex"], 0)
 
     @raises(IndexError)
     def test_param_values_invalid_dictionary_key(self):
-        """ Test solver.run() using param_values dictionary with invalid
-               parameter name """
+        """Test param_values with invalid parameter name."""
         self.solver.run(param_values={'spam': 150})
 
     @raises(ValueError, TypeError)
     def test_param_values_non_numeric_value(self):
-        """ Test solver.run() using param_values dict with a non-numeric
-               value """
+        """Test param_values with non-numeric value."""
         self.solver.run(param_values={'ksynthA': 'eggs'})
 
 
 @with_model
 def test_integrate_with_expression():
+    """Ensure a model with Expressions simulates."""
 
     Monomer('s1')
     Monomer('s9')
@@ -128,46 +132,46 @@ def test_integrate_with_expression():
     Rule('R2', None >> s20(), ks0)
     Rule('R3', s16() + s20() >> s16() + s1(), keff)
 
-    time = linspace(0, 40, 100)
+    time = np.linspace(0, 40)
     x = odesolve(model, time)
 
 
 def test_robertson_integration():
+    """Ensure robertson model simulates."""
     t = np.linspace(0, 100)
     # Run with or without inline
-    sol = Solver(robertson.model, t, use_analytic_jacobian=True)
+    sol = Solver(robertson.model, t)
     sol.run()
     assert sol.y.shape[0] == t.shape[0]
-
     if Solver._use_inline:
         # Also run without inline
         Solver._use_inline = False
-        sol = Solver(robertson.model, t, use_analytic_jacobian=True)
+        sol = Solver(robertson.model, t)
         sol.run()
         assert sol.y.shape[0] == t.shape[0]
         Solver._use_inline = True
 
 
 def test_earm_integration():
-    t = np.linspace(0, 1e3, 1000)
+    """Ensure earm_1_0 model simulates."""
+    t = np.linspace(0, 1e3)
     # Run with or without inline
-    sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
+    sol = Solver(earm_1_0.model, t)
     sol.run()
     if Solver._use_inline:
         # Also run without inline
         Solver._use_inline = False
-        sol = Solver(earm_1_0.model, t, use_analytic_jacobian=True)
+        sol = Solver(earm_1_0.model, t)
         sol.run()
         Solver._use_inline = True
 
 
 def test_run_ssa():
-    """
-    Rudimentary test, mainly to ensure API compatibility
-    """
+    """Test run_ssa."""
     run_ssa(robertson.model, t_end=20000, n_steps=100, verbose=False)
 
 
 @raises(UserWarning)
 def test_nonexistent_integrator():
+    """Ensure nonexistent integrator raises."""
     Solver(robertson.model, np.linspace(0, 1, 2), integrator='does_not_exist')


### PR DESCRIPTION
Rebased version of #192 from @JamesPino. Original comment:

> Corrected an lsoda error that occured if _use_analytic_jacobian was False. Before it would try to assign self.jac_fn = lambda t, y, p: jacobian(y, t, p). But jacobian is only defined if _use_analytic_jacobian =True.
> 
> The rest are enhancments to the simulator class. A lot of calls could be done once outside of the main loop, which sped up the _calc_yobs_yexp quite a bit.

This still ought to have a test that would fail before the jac_fn fix. Will implement that now.