### PR TITLE
Update PySB's Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM ipython/scipyserver
+FROM jupyter/scipy-notebook
 MAINTAINER Alex Lubbock <code@alexlubbock.com>
 
-RUN apt-get install -y wget unzip
+USER root
 
-RUN wget http://bionetgen.googlecode.com/files/BioNetGen-2.2.5-stable.zip -O /BioNetGen-2.2.5-stable.zip
-RUN unzip /BioNetGen-2.2.5-stable.zip -d /
-RUN ln -s /BioNetGen-2.2.5-stable /usr/local/share/BioNetGen
+RUN ln -snf /bin/bash /bin/sh
 
-RUN git clone https://github.com/pysb/pysb.git /pysb
-RUN cd /pysb && python setup.py install
+RUN apt-get install -y wget
 
-RUN git clone https://github.com/lolab-vu/pysb-tutorials.git /notebooks/examples
+RUN wget "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=142" -O /BioNetGen-2.2.6-stable.tar.gz
+RUN mkdir /BioNetGen && tar xzf /BioNetGen-2.2.6-stable.tar.gz -C /BioNetGen
+RUN ln -s /BioNetGen/BioNetGen-2.2.6-stable /usr/local/share/BioNetGen
 
-RUN sed -i.bak 's/ipython notebook/ipython2 notebook/g' /notebook.sh
+USER jovyan
+
+RUN source activate python2 && pip install git+git://github.com/pysb/pysb.git
+RUN git clone https://github.com/lolab-vu/pysb-tutorials.git /home/jovyan/work/examples


### PR DESCRIPTION
* Use `jupyter/scipy-notebook` base image (`ipython/scipyserver` is deprecated)
* Update BioNetGen to 2.2.6-stable
* Use non-privileged user within container