### PR TITLE
BioNetGen installation script, with setuptools --install-bng option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,8 @@ before_install:
     nose h5py pexpect pandas
 - pip install -i https://pypi.binstar.org/pypi/simple pygraphviz==1.3rc1
 - pip install python-coveralls
-- wget "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=142"
-    -O BioNetGen-2.2.6-stable.tar.gz
-- tar xzf BioNetGen-2.2.6-stable.tar.gz
-- export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
+- python scripts/install_bng.py /tmp/BioNetGen
+- export BNGPATH=/tmp/BioNetGen
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
 - opam install ocamlfind --yes

--- a/scripts/install_bng.py
+++ b/scripts/install_bng.py
@@ -1,0 +1,100 @@
+#!python
+
+# Script to download and install BioNetGen
+import tempfile
+from six.moves.urllib.request import urlretrieve
+import tarfile
+import zipfile
+import sys
+import os
+import shutil
+import platform
+import contextlib
+
+bng_urls = {'Linux': "http://www.csb.pitt.edu/Faculty/Faeder"
+            "/?smd_process_download=1&download_id=142",
+            'Darwin': "http://www.csb.pitt.edu/Faculty/Faeder"
+            "/?smd_process_download=1&download_id=148",
+            'Windows': "http://www.csb.pitt.edu/Faculty/Faeder"
+            "/?smd_process_download=1&download_id=151"}
+
+
+def _print_download_progress(count, blocksize, totalsize):
+    """ Print download progress to stdout """
+    progress = count * blocksize * 100 / totalsize
+    sys.stdout.write("\rDownloading BioNetGen, %3d%% complete..." % progress)
+    sys.stdout.flush()
+
+
+def _tar_extract_internal_dir(srctar, destdir, selector):
+    """ Extracts files from a tar and moves them """
+    if type(selector) is str:
+        prefix = selector
+        selector = lambda m: m.name.startswith(prefix)
+    members = [m for m in srctar.getmembers() if selector(m)]
+    for m in members:
+        m.name = m.name[m.name]
+    srctar.extractall(path=destdir, members=members)
+
+
+def _get_default_bng_directory():
+    """ Returns the BNG installation directory for this platform """
+    return "c:/Program Files/BioNetGen" if platform.system() == "Windows" \
+        else "/usr/local/share/BioNetGen"
+
+
+@contextlib.contextmanager
+def _make_temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+def install_bng(target_directory=None, verbose=True):
+    """ Downloads and installs BioNetGen to the specified directory,
+    or platform default location if not specified """
+    if target_directory is None:
+        target_directory = _get_default_bng_directory()
+
+    # Check the target directory is writeable now, rather than failing after
+    # download. It's easier just to actually create the directory here, rather
+    # than check if it could be created or already exists.
+    os.mkdir(target_directory)
+
+    try:
+        # Download BNG
+        with tempfile.NamedTemporaryFile() as tf:
+            reporthook = _print_download_progress if verbose else None
+
+            # Check binary availability for this platform
+            this_os = platform.system()
+            if this_os not in bng_urls.keys():
+                raise Exception("Could not find a BioNetGen binary for your "
+                                "operating system %s. Please install it "
+                                "manually." % this_os)
+
+            urlretrieve(bng_urls[this_os], tf.name, reporthook=reporthook)
+
+            # Extract BNG
+            if verbose:
+                print("\nExtracting BioNetGen to %s..." % target_directory)
+            with _make_temp_directory() as tempdir:
+                if platform.system() == "Windows":
+                    with zipfile.ZipFile.open(mode="r", fileobj=tf) as zf:
+                        zf.extractall(path=tempdir)
+                else:
+                    with tarfile.open(mode="r:gz", fileobj=tf) as tar:
+                        tar.extractall(path=tempdir)
+                os.rmdir(target_directory)
+                shutil.move(os.path.join(tempdir, os.listdir(tempdir)[0]),
+                            target_directory)
+    except:
+        shutil.rmtree(target_directory, ignore_errors=True)
+        raise
+
+    if verbose:
+        print("BioNetGen installation complete.")
+
+
+if __name__ == '__main__':
+    install_bng(target_directory=(None if len(sys.argv) == 1 else sys.argv[1]))

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,44 @@
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup
+from setuptools.command.install import install
 import setuptools.command.build_py
-
 import versioneer
-
 import sys, os, subprocess, re
+from scripts.install_bng import install_bng
+
 
 class build_py(setuptools.command.build_py.build_py):
     # Simplest way to use a specific list of fixers. Note use_2to3_fixers will
     # be ignored.
     fixer_names = ['lib2to3.fixes.fix_ne']
 
+
+class PysbInstaller(install):
+    user_options = install.user_options
+    user_options.append(('install-bng', None, 'Download and install '
+                                              'BioNetGen (requires write '
+                                              'access to /usr/local/share on '
+                                              'Mac or Linux, or c:\\Program '
+                                              'Files on Windows). An '
+                                              'error will occur if a '
+                                              'directory called BioNetGen '
+                                              'exists in the above locations '
+                                              'already.'))
+
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.install_bng = None
+
+    def run(self):
+        install.run(self)
+        if self.install_bng:
+            install_bng()
+
+
 def main():
 
-    cmdclass = {'build_py': build_py}
+    cmdclass = {'build_py': build_py, 'install': PysbInstaller}
     cmdclass.update(versioneer.get_cmdclass())
 
     setup(name='pysb',


### PR DESCRIPTION
This PR adds a script for downloading and installing BioNetGen into the
platform-specific location expected by PySB (or any other specified location).
This option reduces hassle for new users, facilitates cross-platform unit
testing (by installing the correct BNG binary for the current platform) and 
moves us closer to a one step install:
`pip install --install-option="--install-bng" pysb`.

Untested on Windows as yet.
