### PR TITLE
`pip install pysb` fails if `ez_setup` package is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ def main():
           install_requires=['numpy', 'scipy', 'sympy'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect'],
+          py_modules=['ez_setup'],
           cmdclass=cmdclass,
           use_2to3=True,
           keywords=['systems', 'biology', 'model', 'rules'],


### PR DESCRIPTION
PySB should use the internal ez_setup.py if the ez_setup package isn't present, but it doesn't currently work when installing from pypi using pip. Here's my output trying to install PySB with Python 3.4.3 on OSX in a clean virtualenv:

```
$ pip install pysb
You are using pip version 7.0.1, however version 8.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting pysb
  Downloading pysb-1.1.0.tar.gz (222kB)
    100% |████████████████████████████████| 225kB 2.2MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/wl/h_hnb70s2136qm6qkwyv5jlh0000gn/T/pip-build-64n_1ygl/pysb/setup.py", line 1, in <module>
        from ez_setup import use_setuptools
    ImportError: No module named 'ez_setup'

    ----------------------------------------
```
However, installing from github with `pip install git+git://github.com/pysb/pysb.git` does work.

I think the failure is due to the ez_setup.py package not being specified in `py_modules` in setup.py, so it isn't copied into the temp directory during the install process. This PR should fix this, although I'm unable to verify since installing from github works regardless - perhaps @jmuhlich could verify?