### PR TITLE
Documentation updates & new installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,8 @@ PySB depends on the following:
   * Perl - http://www.perl.org/get.html
   * BioNetGen - http://bionetgen.org/
 
-For full instructions, see the Installation chapter of the manual.
+For full instructions, see the Installation chapter of the manual at
+http://docs.pysb.org/en/latest/installation.html
 
 Documentation
 -------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,7 +51,7 @@ copyright = u'2012, C. F. Lopez, J. L. Muhlich, J. A. Bachman'
 # -- Mock out some problematic modules-------------------------------------
 
 # Note that for sub-modules, all parent modules must be listed explicitly.
-MOCK_MODULES = [ 'pygraphviz', 'sympy', 'sympy.printing',
+MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy', 'sympy.printing',
                  'sympy.printing.mathml', 'numpy', 'scipy', 'scipy.integrate' ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.MagicMock()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,8 +51,10 @@ copyright = u'2012, C. F. Lopez, J. L. Muhlich, J. A. Bachman'
 # -- Mock out some problematic modules-------------------------------------
 
 # Note that for sub-modules, all parent modules must be listed explicitly.
-MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy', 'sympy.printing',
-                 'sympy.printing.mathml', 'numpy', 'scipy', 'scipy.integrate' ]
+MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy',  'sympy.parsing',
+                 'sympy.parsing.sympy_parser',
+                 'sympy.printing', 'sympy.printing.mathml', 'numpy',
+                 'scipy', 'scipy.integrate' ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.MagicMock()
 sys.modules['sympy'].Symbol = type('Symbol', (object,), {})

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,95 +3,112 @@ Installation
 
 There are two different ways to install and use PySB:
 
-1. **Download and run the virtual machine containing the complete PySB
-   installation.** Users wishing to try out PySB, who are unfamiliar with the
-   procedure for installing Python packages or who just want a simpler
-   installation procedure, should choose this option.
+1. **Install PySB natively on your computer (recommended).**
 
    *OR*
 
-2. **Install the necessary software dependencies natively on your computer.**
-   Users who are comfortable with installing Python packages and compiling
-   source code should choose this option.
+2. **Download a Docker container with PySB and Jupyter Notebook.** If you
+   are familiar with `Docker`_, PySB can be installed from the Docker
+   Hub by typing :command:`docker pull pysb/pysb`. Further details are
+   below.
 
-Option 1: The PySB virtual machine
-----------------------------------
+.. note::
+    **Need Help?**
+    If you run into any problems with installation, please visit our chat room:
+    https://gitter.im/pysb/pysb
 
-For easy installation, we provide a pre-configured virtual machine (VM) running
-the `Ubuntu Linux`_ operating system that comes with all necessary software
-installed.  It also includes other useful software (e.g., `Git`_, `IPython`_,
-`GraphViz`_, `Kappa`_, `OCaml`_), and has been designed to make getting
-up-to-date versions of PySB and other required packages easy. The VM will
-require 2GB of free hard drive space to install, plus an extra 500MB during the
-download and import process.
+Option 1: Install PySB natively on your computer
+------------------------------------------------
 
-In addition to the PySB virtual machine file itself, you'll need virtualization
-software to run it, such as Oracle's free and open-source `VirtualBox`_.  The
-instructions given below are for VirtualBox, but other virtualization software
-such as `VMWare Player`_ (free) or `Parallels`_ can also be used. Here's the
-installation procedure:
+1. **Install Anaconda**
 
-1. `Download VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ and
-   install it.
+   Our recommended approach is to use `Anaconda`_, which is a distribution of
+   Python containing most of the numeric and scientific software needed to
+   get started. If you are a Mac or Linux user, have used Python before and
+   are comfortable using ``pip`` to install software, you may want to skip
+   this step and use your existing Python installation.
 
-2. `Download the PySB OVA <http://www.pysb.org/#download>`_ (Open Virtualization
-   Appliance) file. The file is approximately 500MB. Double-click the downloaded
-   .ova file to open it in VirtualBox, if your web browser doesn't offer to do
-   so.
+   Anaconda has a simple graphical installer which can be downloaded from
+   https://www.continuum.io/downloads - select your operating system
+   and download the **Python 2.7 version**. The default installer options
+   are usually appropriate.
 
-3. VirtualBox will now display the Appliance Import Wizard. Click the "Import"
-   button to continue. Note that the newly created VM will occupy about 2GB of
-   hard drive space. Once the import is complete, you may delete the .ova file.
+   .. note::
+       **Windows users:** If you are unsure whether to use the 32-bit or
+       64-bit installer, press the Windows Start button, search for “About
+       your PC”, and under “System type” it will specify 32-bit operating
+       system or 64-bit operating system
 
-4. In the VirtualBox Manager window, double-click the "PySB demo" entry to
-   launch the VM.
+2. (Windows only) **Install perl**
 
-Now you may use the virtual machine to create and work with PySB models. All
-files created in the VM will be saved on a virtual disk image, and you may shut
-down the VM and re-launch it later from the VirtualBox Manager without losing
-your work. If you would like to share files between the VM and your desktop
-system, see the VirtualBox documentation for instructions.
+   Press the Windows Start button, search for “command prompt”, and select
+   it/press enter. Then enter the following at the prompt:
 
+       :command:`conda install --yes perl`
 
-Option 2: Installing the dependencies yourself
-----------------------------------------------
+   Use the command prompt when you need to type commands in a terminal.
 
-Required software
-^^^^^^^^^^^^^^^^^
+3. **Install BioNetGen**
 
-These are the minimum requirements needed to simulate a model. The given version
-numbers have been explicitly tested, and where a number is followed by a ``+`` we
-believe all newer versions will work as well. Older versions may also work but
-we haven't formally tested anything older than what's listed below.
+   Download BioNetGen from here:
+   http://bionetgen.org/index.php/BioNetGen_Distributions
 
-* `Python`_ 2.7.x or 3.4+
-* `NumPy`_ 1.6+
-* `SciPy`_ 0.9+
-* `SymPy`_ 0.7+
-* `BioNetGen`_ 2.2.5+ (requires Perl -- see Perl requirement below)
+   Extract the download, rename the unzipped ``BioNetGen-x.y.z`` folder
+   to just ``BioNetGen`` and move it into ``/usr/local/share`` (Mac or
+   Linux) or ``C:\Program Files`` (Windows). If you would like to put it
+   somewhere else, set the ``BNGPATH`` environment variable to the full
+   path to the ``BioNetGen-x.y.z`` folder.
 
-  Rename the unzipped ``BioNetGen-x.y.z`` folder to just ``BioNetGen`` and move
-  it into ``/usr/local/share`` (Mac or Linux) or ``C:\\Program Files``
-  (Windows). If you would like to put it somewhere else, set the ``BNGPATH``
-  environment variable to the full path to the ``BioNetGen-x.y.z`` folder.
+4. **Install PySB**
 
-* `Perl`_ 5.8+
+   The installation is very straightforward with ``pip`` - type the
+   following in a terminal:
 
-  Mac and Linux users can use the version of Perl included with their operating
-  system. Windows users should get Strawberry Perl from
-  http://strawberryperl.com/.
+       :command:`pip install pysb`
 
-Recommended software
-^^^^^^^^^^^^^^^^^^^^
+   .. note::
+       **Mac users:** To open a terminal on a Mac, open Spotlight search
+       (press command key and space), type ``terminal`` and press enter.
+
+5. **Start Python and PySB**
+
+   If you installed Python using `Anaconda`_ on Windows, search for and select
+   ``IPython`` from your Start Menu (Windows). Otherwise, open a terminal
+   and type ``python`` to get started (or ``ipython``, if installed).
+
+   You will then be at the Python prompt. Type ``import pysb`` to try
+   loading PySB. If no error messages appear and the next Python prompt
+   appears, you have succeeded in installing PySB! You can now proceed to
+   the :doc:`tutorial`.
+
+   Those from a programming background may choose to use Python from within
+   an Integrated Development Environment (IDE) such as `PyCharm`_,
+   `Eclipse`_ or `Emacs`_.
+
+Recommended additional software
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following software is not required for the basic operation of PySB, but
+provides extra capabilities and features when installed.
 
 * `matplotlib`_
 
   This Python package allows you to plot the results of your simulations. It
   is not a hard requirement of PySB but many of the example scripts use it.
+  Installed with :command:`pip install matplotlib`.
+
+* `pandas`_
+
+  This Python package provides extra capabilities for examining large
+  numerical datasets, with statistical summaries and database-like
+  manipulation capabilities. It is not a hard requirement of PySB, but it is a
+  useful addition, particularly with large sets of simulation results.
+  Installed with :command:`pip install pandas`.
 
 * `IPython`_
 
   An alternate interactive Python shell, much improved over the standard one.
+  Installed with :command:`pip install ipython`.
 
 * `Kappa`_ 4.0
 
@@ -110,15 +127,80 @@ Recommended software
   version and operating system information so that you have just ``KaSim.exe``
   (Windows) or ``KaSim`` (Mac or Linux).
 
-.. _Ubuntu Linux: http://www.ubuntu.com/
+Option 2: Docker container with PySB and Jupyter Notebook
+----------------------------------------------------------
+
+Background
+^^^^^^^^^^
+
+`Docker`_ is a virtualization platform which encapsulates software within a
+container. It can be thought of like a virtual machine, only it contains
+just the application software (and supporting dependencies) and not a full
+operating system stack.
+
+Install Docker and the PySB software stack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. **Install Docker**
+
+   To use PySB with Docker, first you'll need to install Docker, which can be
+   obtained from http://www.docker.com.
+
+2. **Download the PySB software stack from the Docker Hub**
+
+   On the command line, this requires a single command:
+
+       :command:`docker pull pysb/pysb`
+
+   This only needs to be done once, or when software updates are required.
+
+3. **Start the container**
+
+   Start the Docker container with the following command (on Linux, the command
+   may need to be prefixed with ``sudo``):
+
+       :command:`docker run -d -p 8888:8888 pysb/pysb`
+
+   This starts the PySB Docker container with Jupyter notebook and connects it
+   to port 8888.
+
+4. **Open Jupyter Notebook in a web browser**
+
+   Open a web browser of your choice and enter the address
+   http://localhost:8888 in the address bar. You should see a web page with the
+   Jupyter notebook logo. Several example and tutorial notebooks are included
+   to get you started.
+
+Important notes
+^^^^^^^^^^^^^^^
+
+To see graphics from matplotlib within the Jupyter Notebook, you'll need to
+set the following option in your notebooks before calling any plot commands:
+
+.. code-block:: ipython
+
+    %matplotlib inline
+
+Any Jupyter notebooks created will be saved in the container itself, rather
+than on the host computer. Notebooks can be downloaded using the Jupyter
+interface, or a directory on the host computer can be shared with the
+container.
+
+The PySB container builds on the Jupyter SciPy notebook, which contains
+further information on the options available for the container (such
+as sharing a directory with the host computer to preserve notebooks,
+setting a password and more). Documentation from the Jupyter project is
+available at
+https://github.com/jupyter/docker-stacks/tree/master/scipy-notebook
+
+.. _Anaconda: https://www.continuum.io/downloads
+.. _Docker: http://www.docker.org/
 .. _Kappa: http://www.kappalanguage.org/
 .. _Git: http://git-scm.com/
 .. _IPython: http://ipython.org/
 .. _OCaml: http://caml.inria.fr/ocaml/
 .. _GraphViz: http://www.graphviz.org/
-.. _VirtualBox: https://www.virtualbox.org/
-.. _VMWare Player: http://www.vmware.com/products/player/
-.. _Parallels: http://www.parallels.com/
+.. _pandas: http://pandas.pydata.org/
 .. _Python: http://www.python.org/
 .. _SciPy: http://www.scipy.org/
 .. _NumPy: http://www.numpy.org/
@@ -126,3 +208,6 @@ Recommended software
 .. _matplotlib: http://matplotlib.org/
 .. _BioNetGen: http://www.bionetgen.org/
 .. _Perl: http://www.perl.org/
+.. _PyCharm: https://www.jetbrains.com/pycharm/
+.. _Eclipse: http://www.eclipse.org
+.. _Emacs: https://www.gnu.org/s/emacs

--- a/doc/modules/export/pysb_flat.rst
+++ b/doc/modules/export/pysb_flat.rst
@@ -1,0 +1,5 @@
+Export a "flat" PySB model (:py:mod:`pysb.export.pysb_flat`)
+============================================================
+
+.. automodule:: pysb.export.pysb_flat
+    :members:

--- a/doc/modules/importers/index.rst
+++ b/doc/modules/importers/index.rst
@@ -1,0 +1,8 @@
+Importing from other formats (:py:mod:`pysb.importers`)
+=======================================================
+
+.. automodule:: pysb.importers.bngl
+   :members: model_from_bngl
+
+.. automodule:: pysb.importers.sbml
+   :members: model_from_sbml, sbml_translator

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -6,6 +6,7 @@ PySB Modules Reference
 
    core.rst
    integrate.rst
+   simulator.rst
    bng.rst
    kappa.rst
    macros.rst

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -11,4 +11,5 @@ PySB Modules Reference
    kappa.rst
    macros.rst
    tools/render.rst
+   importers/index.rst
    export/index.rst

--- a/doc/modules/simulator.rst
+++ b/doc/modules/simulator.rst
@@ -1,0 +1,5 @@
+Simulation tools (:py:mod:`pysb.simulator`)
+===========================================
+
+.. automodule:: pysb.simulator
+  :members:

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -314,13 +314,12 @@ def model_from_bngl(filename, force=False):
     """
     Convert a BioNetGen .bngl model file into a PySB Model.
 
-    Limitations
-    -----------
+    **Limitations**
 
     The following features are not supported in PySB and will cause an error
     if present in a .bngl file:
 
-    * Fixed species (with a $ prefix, like $Null)
+    * Fixed species (with a ``$`` prefix, like ``$Null``)
     * BNG excluded or included reaction patterns (deprecated in BNG)
     * BNG local functions
     * Molecules with identically named sites, such as ``M(l,l)``

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -21,9 +21,18 @@ def sbml_translator(input_file,
                     pathway_commons=False,
                     verbose=False):
     """
-    Runs the BioNetGen sbmlTranslator binary.
+    Run the BioNetGen sbmlTranslator binary to convert SBML to BNGL
 
-    For more descriptions of the arguments, see the `sbmlTranslator
+    This function runs the external program sbmlTranslator, included with
+    BioNetGen, which converts SBML files to BioNetGen language (BNGL).
+
+    Generally, PySB users don't need to run this function directly; an SBML
+    model can be imported to PySB in a single step with
+    :func:`model_from_sbml`. However, users may wish to note the parameters
+    for this function, which alter the way the SBML file is processed. These
+    parameters can be supplied as ``**kwargs`` to :func:`model_from_sbml`.
+
+    For more detailed descriptions of the arguments, see the `sbmlTranslator
     documentation <http://bionetgen.org/index.php/SBML2BNGL>`_.
 
     Parameters
@@ -113,8 +122,7 @@ def model_from_sbml(filename, force=False, cleanup=True, **kwargs):
     :class:`BnglBuilder` class converts the BioNetGen language model into a
     PySB Model.
 
-    Limitations
-    -----------
+    **Limitations**
 
     Read the `sbmlTranslator documentation
     <http://bionetgen.org/index.php/SBML2BNGL>`_ for further information on
@@ -134,7 +142,7 @@ def model_from_sbml(filename, force=False, cleanup=True, **kwargs):
         Delete temporary directory on completion if True. Set to False for
         debugging purposes.
     **kwargs: kwargs
-        Keyword arguments to pass on to :func:`SbmlBuilder.sbml_translator`
+        Keyword arguments to pass on to :func:`sbml_translator`
     """
     tmpdir = tempfile.mkdtemp()
     verbose = kwargs.get('verbose', False)

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -380,8 +380,11 @@ def bind_name_func(rule_expression):
 
 def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
     """
-    Generate the reversible binding reaction S1 + S2 <> S1:S2, with optional complexes attached to either
-    S1 (C1:S1 + S2 <> C1:S1:S2), S2 (S1 + C2:S2 <> C2:S2:S1), or both (C1:S1 + C2:S2 <> C1:S1:S2:C2).
+    Generate the reversible binding reaction ``S1 + S2 <> S1:S2``,
+    with optional complexes attached to either
+    ``S1`` (``C1:S1 + S2 <> C1:S1:S2``), ``S2`` (``S1 + C2:S2 <> C2:S2:S1``),
+    or both (``C1:S1 + C2:S2 <> C1:S1:S2:C2``).
+
     Parameters
     ----------
     s1, s2 : Monomer, MonomerPattern, or ComplexPattern
@@ -397,23 +400,42 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
     m1, m2 : Monomer or MonomerPattern
         If s1 or s2 binding site is present in multiple monomers
         within a complex, the specific monomer desired for binding must be specified.
+
     Returns
     -------
     components : ComponentSet
         The generated components. Contains the bidirectional binding Rule
         and optionally two Parameters if klist was given as numbers.
+
     Examples
     --------
-    Binding between A:B and C:D::
-        Model()
-        Monomer('A', ['a', 'b'])
-        Monomer('B', ['c', 'd'])
-        Monomer('C', ['e', 'f'])
-        Monomer('D', ['g', 'h'])
-        bind_complex(A(a=1) % B(c=1), 'b', C(e=2) % D(g=2), 'h', [1e-4, 1e-1])
-    Execution::
+
+    Binding between ``A:B`` and ``C:D``:
+
         >>> Model() # doctest:+ELLIPSIS
-        <Model '_interactive_' (monomers: 0, rules: 0, parameters: 0, expressions: 0, compartments: 0) at ...>
+        <Model '_interactive_' ...>
+        >>> Monomer('A', ['a', 'b'])
+        Monomer('A', ['a', 'b'])
+        >>> Monomer('B', ['c', 'd'])
+        Monomer('B', ['c', 'd'])
+        >>> Monomer('C', ['e', 'f'])
+        Monomer('C', ['e', 'f'])
+        >>> Monomer('D', ['g', 'h'])
+        Monomer('D', ['g', 'h'])
+        >>> bind_complex(A(a=1) % B(c=1), 'b', C(e=2) % D(g=2), 'h', [1e-4, \
+            1e-1]) #doctest:+NORMALIZE_WHITESPACE
+        ComponentSet([
+        Rule('bind_AB_DC', A(a=1, b=None) % B(c=1) + D(g=3, h=None) % C(e=3)
+          <> A(a=1, b=50) % B(c=1) % D(g=3, h=50) % C(e=3), bind_AB_DC_kf,
+          bind_AB_DC_kr),
+        Parameter('bind_AB_DC_kf', 0.0001),
+        Parameter('bind_AB_DC_kr', 0.1),
+        ])
+
+    Execution:
+
+        >>> Model() # doctest:+ELLIPSIS
+        <Model '_interactive_' ...>
         >>> Monomer('A', ['a', 'b'])
         Monomer('A', ['a', 'b'])
         >>> Monomer('B', ['c', 'd'])
@@ -425,24 +447,26 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
         >>> bind(A, 'a', B, 'c', [1e4, 1e-1]) #doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
         Rule('bind_A_B',
-        A(a=None) + B(c=None) <> A(a=1) % B(c=1),
-        bind_A_B_kf, bind_A_B_kr),
+          A(a=None) + B(c=None) <> A(a=1) % B(c=1),
+          bind_A_B_kf, bind_A_B_kr),
         Parameter('bind_A_B_kf', 10000.0),
         Parameter('bind_A_B_kr', 0.1),
         ])
         >>> bind(C, 'e', D, 'g', [1e4, 1e-1]) #doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
         Rule('bind_C_D',
-        C(e=None) + D(g=None) <> C(e=1) % D(g=1),
-        bind_C_D_kf, bind_C_D_kr),
+          C(e=None) + D(g=None) <> C(e=1) % D(g=1),
+          bind_C_D_kf, bind_C_D_kr),
         Parameter('bind_C_D_kf', 10000.0),
         Parameter('bind_C_D_kr', 0.1),
         ])
-        >>> bind_complex(A(a=1) % B(c=1), 'b', C(e=2) % D(g=2), 'h', [1e-4, 1e-1]) #doctest:+NORMALIZE_WHITESPACE
+        >>> bind_complex(A(a=1) % B(c=1), 'b', C(e=2) % D(g=2), 'h', [1e-4, \
+            1e-1]) #doctest:+NORMALIZE_WHITESPACE
         ComponentSet([
         Rule('bind_AB_DC',
-        A(a=1, b=None) % B(c=1) + D(g=3, h=None) % C(e=3) <> A(a=1, b=50) % B(c=1) % D(g=3, h=50) % C(e=3),
-        bind_AB_DC_kf, bind_AB_DC_kr),
+          A(a=1, b=None) % B(c=1) + D(g=3, h=None) % C(e=3) <> A(a=1,
+          b=50) % B(c=1) % D(g=3, h=50) % C(e=3),
+          bind_AB_DC_kf, bind_AB_DC_kr),
         Parameter('bind_AB_DC_kf', 0.0001),
         Parameter('bind_AB_DC_kr', 0.1),
         ])

--- a/pysb/simulator/__init__.py
+++ b/pysb/simulator/__init__.py
@@ -1,2 +1,4 @@
-from .base import SimulatorException
+from .base import SimulatorException, SimulationResult
 from .scipyode import ScipyOdeSimulator
+
+__all__ = ['ScipyOdeSimulator', 'SimulationResult']

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -17,8 +17,9 @@ class SimulatorException(Exception):
 class Simulator(object):
     """An abstract base class for numerical simulation of models.
 
-    Please note that the interface for this class is considered
-    experimental and may change without warning as PySB is updated.
+    .. warning::
+        The interface for this class is considered experimental and may
+        change without warning as PySB is updated.
 
     Parameters
     ----------
@@ -213,8 +214,17 @@ class SimulationResult(object):
     """
     Results of a simulation with properties and methods to access them.
 
-    Please note that the interface for this class is considered
-    experimental and may change without warning as PySB is updated.
+    .. warning::
+        Please note that the interface for this class is considered
+        experimental and may change without warning as PySB is updated.
+
+    .. note::
+
+        In the attribute descriptions, a "trajectory set" is a 2D numpy
+        array, species on first axis and time on second axis, with each element
+        containing the concentration or count of the species at the specified time.
+
+        A list of trajectory sets contains a trajectory set for each simulation.
 
     Parameters
     ----------
@@ -224,27 +234,72 @@ class SimulationResult(object):
         A set of species trajectories from a simulation. Should either be a
         list of 2D numpy arrays or a single 3D numpy array.
 
-    Attributes
-    ----------
-    In the descriptions below, a "trajectory set" is a 2D numpy array,
-    species on first axis and time on second axis, with each element
-    containing the concentration or count of the species at the specified time.
+    Examples
+    --------
+    The following examples use a simple model with three observables and one
+    expression, with a single simulation.
 
-    A list of trajectory sets contains a trajectory set for each simulation.
+    >>> from pysb.examples.expression_observables import model
+    >>> from pysb.simulator import ScipyOdeSimulator
+    >>> import numpy as np
+    >>> np.set_printoptions(precision=4)
+    >>> sim = ScipyOdeSimulator(model, tspan=np.linspace(0, 40, 10))
+    >>> simulation_result = sim.run()
 
-    all : list
-        List of trajectory sets. The first dimension contains species,
-        observables and expressions (in that order)
-    species : list
-        List of trajectory sets. The first dimension contains species.
-    observables : list
-        List of trajectory sets. The first dimension contains observables.
-    expressions : list
-        List of trajectory sets. The first dimension contains expressions.
-    dataframe : :py:class:`pandas.DataFrame`
-        A conversion of the trajectory sets (species, observables and
-        expressions for all simulations) into a single
-        :py:class:`pandas.DataFrame`.
+    ``simulation_result`` is a :class:`SimulationResult` object. An
+    observable can be accessed like so:
+
+    >>> print(simulation_result.observables['Bax_c0']) \
+        #doctest: +NORMALIZE_WHITESPACE
+    [  1.0000e+00   1.1744e-02   1.3791e-04   1.6196e-06   1.9021e-08
+       2.2344e-10   2.6394e-12   4.8067e-14  -6.2097e-14  -7.5308e-15]
+
+    It is also possible to retrieve the value of all observables at a
+    particular time point, e.g. the final concentrations:
+
+    >>> print(simulation_result.observables[-1]) #doctest: +ELLIPSIS
+    (-7.5308...e-15, -1.6809...e-13, 1.0000...)
+
+    Expressions are read in the same way as observables:
+
+    >>> print(simulation_result.expressions['NBD_signal']) \
+        #doctest: +NORMALIZE_WHITESPACE
+    [ 0.   4.7847  4.9956  4.9999  5.   5.   5.   5.   5.   5. ]
+
+    The species trajectories can be accessed as a numpy ndarray:
+
+    >>> print(simulation_result.species)
+    [[  1.0000e+00   0.0000e+00   0.0000e+00]
+     [  1.1744e-02   5.2194e-02   9.3606e-01]
+     [  1.3791e-04   1.2259e-03   9.9864e-01]
+     [  1.6196e-06   2.1595e-05   9.9998e-01]
+     [  1.9021e-08   3.3814e-07   1.0000e+00]
+     [  2.2344e-10   4.9648e-09   1.0000e+00]
+     [  2.6394e-12   7.0287e-11   1.0000e+00]
+     [  4.8067e-14   1.3515e-12   1.0000e+00]
+     [ -6.2097e-14  -1.3652e-12   1.0000e+00]
+     [ -7.5308e-15  -1.6809e-13   1.0000e+00]]
+
+    Species, observables and expressions can be combined into a single numpy
+    ndarray and accessed similarly. Here, the initial concentrations of all
+    these entities are examined:
+
+    >>> print(simulation_result.all[0])
+    (1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
+
+    The ``all`` array can be accessed as a pandas DataFrame object,
+    which allows for more convenient indexing and access to pandas advanced
+    functionality, such as indexing and slicing. Here, the concentrations of
+    the observable ``Bax_c0`` and the expression ``NBD_signal`` are read at
+    time points between 5 and 15 seconds:
+
+    >>> df = simulation_result.dataframe
+    >>> print(df.loc[5:15, ['Bax_c0', 'NBD_signal']]) \
+        #doctest: +NORMALIZE_WHITESPACE
+                 Bax_c0  NBD_signal
+    time
+    8.888889   0.000138    4.995633
+    13.333333  0.000002    4.999927
     """
     def __init__(self, simulator, trajectories):
         self.squeeze = True
@@ -333,8 +388,10 @@ class SimulationResult(object):
 
     @property
     def all(self):
-        """Aggregate species, observables, and expressions trajectories into
-        a numpy.ndarray with record-style data-type for return to the user."""
+        """
+        Aggregate species, observables, and expressions trajectories into
+        a numpy.ndarray with record-style data-type for return to the user.
+        """
         if self._yfull is None:
             sp_names = ['__s%d' % i for i in range(len(self._model.species))]
             yfull_dtype = zip(sp_names, itertools.repeat(float))
@@ -362,6 +419,11 @@ class SimulationResult(object):
 
     @property
     def dataframe(self):
+        """
+        A conversion of the trajectory sets (species, observables and
+        expressions for all simulations) into a single
+        :py:class:`pandas.DataFrame`.
+        """
         if pd is None:
             raise Exception('Please "pip install pandas" for this feature')
         sim_ids = (np.repeat(range(self.nsims), [len(t) for t in self.tout]))
@@ -378,12 +440,21 @@ class SimulationResult(object):
 
     @property
     def species(self):
+        """
+        List of trajectory sets. The first dimension contains species.
+        """
         return self._squeeze_output(self._y)
 
     @property
     def observables(self):
+        """
+        List of trajectory sets. The first dimension contains observables.
+        """
         return self._squeeze_output(self._yobs)
 
     @property
     def expressions(self):
+        """
+        List of trajectory sets. The first dimension contains expressions.
+        """
         return self._squeeze_output(self._yexpr)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -21,6 +21,75 @@ def _exec(code, locals):
 
 
 class ScipyOdeSimulator(Simulator):
+    """
+    Simulate a model using SciPy ODE integration
+
+    Uses :func:`scipy.integrate.odeint` for the ``lsoda`` integrator,
+    :func:`scipy.integrate.ode` for all other integrators.
+
+    .. warning::
+        The interface for this class is considered experimental and may
+        change without warning as PySB is updated.
+
+    Parameters
+    ----------
+    model : pysb.Model
+        Model to simulate.
+    tspan : vector-like, optional
+        Time values over which to simulate. The first and last values define
+        the time range. Returned trajectories are sampled at every value unless
+        the simulation is interrupted for some reason, e.g., due to
+        satisfaction of a logical stopping criterion (see 'tout' below).
+    initials : vector-like or dict, optional
+        Values to use for the initial condition of all species. Ordering is
+        determined by the order of model.species. If not specified, initial
+        conditions will be taken from model.initial_conditions (with
+        initial condition parameter values taken from `param_values` if
+        specified).
+    param_values : vector-like or dict, optional
+        Values to use for every parameter in the model. Ordering is
+        determined by the order of model.parameters.
+        If passed as a dictionary, keys must be parameter names.
+        If not specified, parameter values will be taken directly from
+        model.parameters.
+    verbose : bool, optional (default: False)
+        Verbose output.
+    **kwargs : dict
+        Extra keyword arguments, including:
+
+        * ``integrator``: Choice of integrator, including ``vode`` (default),
+          ``zvode``, ``lsoda``, ``dopri5`` and ``dop853``. See
+          :func:`scipy.integrate.ode` for further information.
+        * ``integrator_options``: A dictionary of keyword arguments to
+          supply to the integrator. See :func:`scipy.integrate.ode`.
+        * ``cleanup``: Boolean, `cleanup` argument used for
+          :func:`pysb.bng.generate_equations` call
+
+    Notes
+    -----
+    If ``tspan`` is not defined, it may be defined in the call to the
+    ``run`` method.
+
+    Examples
+    --------
+    Simulate a model and display the results for an observable:
+
+    >>> from pysb.examples.robertson import model
+    >>> import numpy as np
+    >>> np.set_printoptions(precision=4)
+    >>> sim = ScipyOdeSimulator(model, tspan=np.linspace(0, 40, 10))
+    >>> simulation_result = sim.run()
+    >>> print(simulation_result.observables['A_total']) \
+        #doctest: +NORMALIZE_WHITESPACE
+    [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
+    0.7158]
+
+    For further information on retrieving trajectories (species,
+    observables, expressions over time) from the ``simulation_result``
+    object returned by :func:`run`, see the examples under the
+    :class:`SimulationResult` class.
+    """
+
     # some sane default options for a few well-known integrators
     default_integrator_options = {
         'vode': {
@@ -59,7 +128,7 @@ class ScipyOdeSimulator(Simulator):
         # Generate the equations for the model
         pysb.bng.generate_equations(self._model, self.cleanup, self.verbose)
 
-        def eqn_substitutions(eqns):
+        def _eqn_substitutions(eqns):
             """String substitutions on the sympy C code for the ODE RHS and
             Jacobian functions to use appropriate terms for variables and
             parameters."""
@@ -97,7 +166,7 @@ class ScipyOdeSimulator(Simulator):
         code_eqs = '\n'.join(['ydot[%d] = %s;' %
                               (i, sympy.ccode(self._model.odes[i]))
                               for i in range(len(self._model.odes))])
-        code_eqs = eqn_substitutions(code_eqs)
+        code_eqs = _eqn_substitutions(code_eqs)
 
         self._test_inline()
 
@@ -157,7 +226,7 @@ class ScipyOdeSimulator(Simulator):
                     jac_eq_str = 'jac[%d, %d] = %s;' % (
                     i, j, sympy.ccode(entry))
                     jac_eqs_list.append(jac_eq_str)
-            jac_eqs = eqn_substitutions('\n'.join(jac_eqs_list))
+            jac_eqs = _eqn_substitutions('\n'.join(jac_eqs_list))
 
             # Try to inline the Jacobian if possible (as above for RHS)
             if not self._use_inline:
@@ -242,6 +311,24 @@ class ScipyOdeSimulator(Simulator):
                 pass
 
     def run(self, tspan=None, param_values=None, initials=None):
+        """
+        Run a simulation and returns the result (trajectories)
+
+        .. note::
+            ``tspan``, ``param_values`` and ``initials`` values supplied to
+            this method will persist to future :func:`run` calls.
+
+        Parameters
+        ----------
+        tspan
+        param_values
+        initials
+            See parameter definitions in :class:`ScipyOdeSimulator`.
+
+        Returns
+        -------
+        A :class:`SimulationResult` object
+        """
         if tspan is not None:
             self.tspan = tspan
         if self.tspan is None:


### PR DESCRIPTION
This PR contains new PySB installation instructions for Anaconda and Docker-based installs, which work on Windows, Mac and Linux. Hopefully the new step-by-step approach is clear, but feedback is welcome. I removed the virtual appliance instructions since it's quite out of date now (based on PySB 0.1.9).

I've improved documentation for the Simulation class and SBML/BNGL importers, which are now included in Sphinx output. I also fixed a couple of Sphinx warnings when parsing the `bind_complex` macro docstring and missing pysb_flat exporter docs.