### PR TITLE
Fix isinstance(foo, str) in bng and kappa generation

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -23,6 +23,13 @@ try:
 except ImportError:
     pass
 
+# Python 2
+try:
+    basestring
+# Python 3
+except NameError:
+    basestring = str
+
 # Cached value of BNG path
 _bng_path = None
 
@@ -154,7 +161,7 @@ class BngBaseInterface(object):
         param :
             An argument to a BNG action call
         """
-        if isinstance(param, str):
+        if isinstance(param, basestring):
             return '"%s"' % param
         elif isinstance(param, bool):
             return 1 if param else 0

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -23,10 +23,9 @@ try:
 except ImportError:
     pass
 
-# Python 2
+# Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
-# Python 3
 except NameError:
     basestring = str
 

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -3,6 +3,12 @@ import warnings
 import pysb
 import sympy
 
+# Python 2
+try:
+    basestring
+# Python 3
+except NameError:
+    basestring = str
 
 class BngGenerator(object):
 
@@ -174,16 +180,16 @@ def format_site_condition(site, state):
     if state == None:
         state_code = ''
     # single bond
-    elif type(state) == int:
+    elif isinstance(state, int):
         state_code = '!' + str(state)
     # multiple bonds
-    elif type(state) == list and all(isinstance(s, int) for s in state):
+    elif isinstance(state, list) and all(isinstance(s, int) for s in state):
         state_code = ''.join('!%d' % s for s in state)
     # state
-    elif type(state) == str:
+    elif isinstance(state, basestring):
         state_code = '~' + state
     # state AND single bond
-    elif type(state) == tuple:
+    elif isinstance(state, tuple):
         # bond is wildcard (zero or more unspecified bonds)
         if state[1] == pysb.WILD:
             state = (state[0], '?')

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -3,10 +3,9 @@ import warnings
 import pysb
 import sympy
 
-# Python 2
+# Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
-# Python 3
 except NameError:
     basestring = str
 

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -3,6 +3,13 @@ import sympy
 from re import sub
 import warnings
 
+# Python 2
+try:
+    basestring
+# Python 3
+except NameError:
+    basestring = str
+
 class KappaGenerator(object):
 
     # Dialect can be either 'complx' or 'kasim' (default)
@@ -176,17 +183,17 @@ def format_site_condition(site, state):
     if state == None:
         state_code = ''
     # If there is a bond number
-    elif type(state) == int:
+    elif isinstance(state, int):
         state_code = '!' + str(state)
     # If there is a lists of bonds to the site (not supported by Kappa)
-    elif type(state) == list:
+    elif isinstance(state, list):
         raise KappaException("Kappa generator does not support multiple bonds "
                               "to a single site.")
     # Site with state
-    elif type(state) == str:
+    elif isinstance(state, basestring):
         state_code = '~' + state
     # Site with state and a bond
-    elif type(state) == tuple:
+    elif isinstance(state, tuple):
         # If the bond is ANY
         if state[1] == pysb.ANY:
             state_code = '~%s!_' % state[0]

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -3,10 +3,9 @@ import sympy
 from re import sub
 import warnings
 
-# Python 2
+# Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
-# Python 3
 except NameError:
     basestring = str
 

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -106,6 +106,3 @@ def test_unicode_strs():
     Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
     generate_equations(model)
-
-if __name__ == '__main__':
-    test_unicode_strs()

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -98,3 +98,14 @@ def test_zero_order_synth_no_initials():
     Rule('Rule1', None >> A(), Parameter('ksynth', 100))
     Rule('Rule2', A() <> B(), Parameter('kf', 10), Parameter('kr', 1))
     generate_equations(model)
+
+@with_model
+def test_unicode_strs():
+    Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
+    Monomer(u'B')
+    Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
+    Initial(A(b=u'y'), Parameter(u'A_0', 100))
+    generate_equations(model)
+
+if __name__ == '__main__':
+    test_unicode_strs()

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -173,3 +173,16 @@ def test_influence_map_kasa():
     res = influence_map(model, cleanup=True)
     ok_(isinstance(res, pgv.AGraph))
 
+@with_model
+def test_unicode_strs():
+    Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
+    Monomer(u'B')
+    Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
+    Initial(A(b=u'y'), Parameter(u'A_0', 100))
+    Observable(u'B_', B())
+    npts = 200
+    kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
+
+if __name__ == '__main__':
+    test_unicode_strs()
+

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -182,7 +182,3 @@ def test_unicode_strs():
     Observable(u'B_', B())
     npts = 200
     kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
-
-if __name__ == '__main__':
-    test_unicode_strs()
-

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -30,10 +30,9 @@ import re
 import pygraphviz
 import pysb.bng
 
-# Python 2
+# Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
-# Python 3
 except NameError:
     basestring = str
 

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -30,6 +30,13 @@ import re
 import pygraphviz
 import pysb.bng
 
+# Python 2
+try:
+    basestring
+# Python 3
+except NameError:
+    basestring = str
+
 def run(model):
     """
     Render the species from a model into the "dot" graph format.
@@ -72,7 +79,7 @@ def render_species_as_dot(species_list, graph_name=""):
             for site in mp.monomer.sites:
                 site_state = None
                 cond = mp.site_conditions[site]
-                if isinstance(cond, str):
+                if isinstance(cond, basestring):
                     site_state = cond
                 elif isinstance(cond, tuple):
                     site_state = cond[0]


### PR DESCRIPTION
This is a follow-up to the previous PR (#230) which made the corresponding fix in core.py, and fixes issue #233. We had found that while #230 allowed models to be created with unicode names/sites in Python 2, BNG and Kappa generation would fail due to unicode strings not being matched in the series of tests on site conditions. I've added corresponding tests in test_bng.py and test_kappa.py.

In the interest of completeness, I grepped all PySB source for other code containing `type(foo) == str` or `isinstance(foo, str)` and found cases only in bng.py and (_bng_param method) and render_reactions.py, which I also updated in this pull request.

