### PR TITLE
Logging framework & Simulator class multiple initials/params support

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -579,7 +579,7 @@ def generate_equations(model, cleanup=True, verbose=False):
     #   or, use a separate "math model" object to contain ODEs
     if model.odes:
         return
-    lines = iter(generate_network(model,cleanup,verbose=verbose).split('\n'))
+    lines = iter(generate_network(model,cleanup=cleanup,verbose=verbose).split('\n'))
     _parse_netfile(model, lines)
 
 

--- a/pysb/examples/michment.py
+++ b/pysb/examples/michment.py
@@ -1,0 +1,26 @@
+from pysb import *
+from pysb.macros import catalyze_state
+
+Model()
+
+VOL = 1. # volume (arbitrary units)
+
+Parameter('kf',   1./VOL)
+Parameter('kr',   1000)
+Parameter('kcat', 100)
+
+Monomer('E', ['s'])
+Monomer('S', ['e', 'state'], {'state': ['0','1']})
+
+catalyze_state(E(), 's', S(), 'e', 'state', '0', '1', [kf,kr,kcat])
+
+Observable("E_free",     E(s=None))
+Observable("S_free",     S(e=None, state='0'))
+Observable("ES_complex", E(s=1) % S(e=1))
+Observable("Product",    S(e=None, state='1'))
+
+Parameter("Etot", 1.*VOL)
+Initial(E(s=None), Etot)
+
+Parameter('S0', 10.*VOL)
+Initial(S(e=None, state='0'), S0)

--- a/pysb/examples/michment.py
+++ b/pysb/examples/michment.py
@@ -3,9 +3,9 @@ from pysb.macros import catalyze_state
 
 Model()
 
-VOL = 1. # volume (arbitrary units)
+Parameter('vol', 1.) # volume (arbitrary units)
 
-Parameter('kf',   1./VOL)
+Parameter('kf',   1./vol.value)
 Parameter('kr',   1000)
 Parameter('kcat', 100)
 
@@ -19,8 +19,8 @@ Observable("S_free",     S(e=None, state='0'))
 Observable("ES_complex", E(s=1) % S(e=1))
 Observable("Product",    S(e=None, state='1'))
 
-Parameter("Etot", 1.*VOL)
+Parameter("Etot", 1.*vol.value)
 Initial(E(s=None), Etot)
 
-Parameter('S0', 10.*VOL)
+Parameter('S0', 10.*vol.value)
 Initial(S(e=None, state='0'), S0)

--- a/pysb/examples/run_michment.py
+++ b/pysb/examples/run_michment.py
@@ -1,0 +1,29 @@
+from pysb.examples.michment import model
+from pysb.simulator import ScipyOdeSimulator
+import numpy as np
+import matplotlib.pyplot as plt
+
+tspan = np.linspace(0, 50, 501)
+
+sim = ScipyOdeSimulator(model, tspan, verbose=False)
+
+etot_ref = model.parameters['Etot'].value
+s0_ref = model.parameters['S0'].value
+
+trajectories = []
+for Etot in np.linspace(0.8, 1.2, 21):
+    for S0 in np.linspace(0.8, 1.2, 21):
+        model.parameters['Etot'].value = Etot*etot_ref
+        model.parameters['S0'].value = S0*s0_ref
+        trajectories.append( sim.run().all )
+
+x = np.array([tr['Product'] for tr in trajectories]).T
+
+plt.plot(tspan, x.mean(axis=1), 'b', lw=3, label="Product")
+plt.plot(tspan, x.max(axis=1), 'b--', lw=2, label="min/max")
+plt.plot(tspan, x.min(axis=1), 'b--', lw=2)
+plt.xlabel('time')
+plt.ylabel('concentration')
+plt.legend(loc='upper left')
+
+plt.show()

--- a/pysb/examples/run_michment.py
+++ b/pysb/examples/run_michment.py
@@ -15,12 +15,7 @@ for i,ic in enumerate(model.initial_conditions):
 
 tspan = np.linspace(0, 50, 501)
 sim = ScipyOdeSimulator(model, tspan, verbose=False)
-
-n_sims = len(initials.values()[0])
-trajectories = []
-for n in range(n_sims):
-    trajectories.append( sim.run( initials=
-        {key : val[n] for key,val in initials.items()} ).all )
+trajectories = sim.run(initials=initials).all
 
 x = np.array([tr['Product'] for tr in trajectories]).T
 

--- a/pysb/examples/run_tyson_oscillator.py
+++ b/pysb/examples/run_tyson_oscillator.py
@@ -1,6 +1,6 @@
 from pysb.examples.tyson_oscillator import model
-import numpy as np
 from pysb.simulator import ScipyOdeSimulator
+import numpy as np
 import matplotlib.pyplot as plt
 
 t = np.linspace(0, 100, 10001)

--- a/pysb/examples/tyson_oscillator.py
+++ b/pysb/examples/tyson_oscillator.py
@@ -4,8 +4,9 @@ from scipy.constants import N_A
 
 Model()
 
-VOL = 1e-20
-NA_V = N_A*VOL
+Parameter('vol', 1e-20)
+
+NA_V = N_A*vol.value
 
 Parameter('k1', 0.015*NA_V)
 # Parameter('k1', 0.015)

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -41,9 +41,15 @@ class Solver(object):
     yobs : numpy.ndarray with record-style data-type
         Observable trajectories. Length is ``len(tspan)`` and record names
         follow ``model.observables`` names.
+    yobs_view : numpy.ndarray
+        An array view (sharing the same data buffer) on ``yobs``.
+        Dimensionality is ``(len(tspan), len(model.observables))``.
     yexpr : numpy.ndarray with record-style data-type
         Expression trajectories. Length is ``len(tspan)`` and record names
         follow ``model.expressions_dynamic()`` names.
+    yexpr_view : numpy.ndarray
+        An array view (sharing the same data buffer) on ``yexpr``.
+        Dimensionality is ``(len(tspan), len(model.expressions_dynamic()))``.
     integrator : scipy.integrate.ode
         Integrator object.
 
@@ -64,6 +70,8 @@ class Solver(object):
                                      integrator=integrator, cleanup=cleanup,
                                      **integrator_options)
         self.result = None
+        self._yexpr_view = None
+        self._yobs_view = None
 
     @property
     def _use_inline(self):
@@ -82,8 +90,21 @@ class Solver(object):
         return self.result.observables if self.result is not None else None
 
     @property
+    def yobs_view(self):
+        if self._yobs_view is None:
+            self._yobs_view = self.yobs.view(float).reshape(len(self.yobs), -1)
+        return self._yobs_view
+
+    @property
     def yexpr(self):
         return self.result.expressions if self.result is not None else None
+
+    @property
+    def yexpr_view(self):
+        if self._yexpr_view is None:
+            self._yexpr_view = self.yexpr.view(float).reshape(len(self.yexpr),
+                                                              -1)
+        return self._yexpr_view
 
     def run(self, param_values=None, y0=None):
         """Perform an integration.
@@ -106,6 +127,8 @@ class Solver(object):
             initial condition parameter values taken from `param_values` if
             specified).
         """
+        self._yobs_view = None
+        self._yexpr_view = None
         self.result = self._sim.run(param_values=param_values, initials=y0)
 
 

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -41,15 +41,9 @@ class Solver(object):
     yobs : numpy.ndarray with record-style data-type
         Observable trajectories. Length is ``len(tspan)`` and record names
         follow ``model.observables`` names.
-    yobs_view : numpy.ndarray
-        An array view (sharing the same data buffer) on ``yobs``.
-        Dimensionality is ``(len(tspan), len(model.observables))``.
     yexpr : numpy.ndarray with record-style data-type
         Expression trajectories. Length is ``len(tspan)`` and record names
         follow ``model.expressions_dynamic()`` names.
-    yexpr_view : numpy.ndarray
-        An array view (sharing the same data buffer) on ``yexpr``.
-        Dimensionality is ``(len(tspan), len(model.expressions_dynamic()))``.
     integrator : scipy.integrate.ode
         Integrator object.
 
@@ -80,12 +74,16 @@ class Solver(object):
         ScipyOdeSimulator._use_inline = use_inline
 
     @property
+    def y(self):
+        return self.result.species if self.result is not None else None
+
+    @property
     def yobs(self):
         return self.result.observables if self.result is not None else None
 
     @property
-    def y(self):
-        return self.result.species if self.result is not None else None
+    def yexpr(self):
+        return self.result.expressions if self.result is not None else None
 
     def run(self, param_values=None, y0=None):
         """Perform an integration.

--- a/pysb/logging.py
+++ b/pysb/logging.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 import logging
-import versioneer
 import platform
 import socket
 import time
 import os
 import warnings
+import pysb
 
 SECONDS_IN_HOUR = 3600
 DEBUG_ENV_VAR = 'PYSB_DEBUG'
@@ -90,7 +90,7 @@ def setup_logger(level=logging.INFO, console_output=True, file_output=False,
         file_handler.setFormatter(log_fmt)
         log.addHandler(file_handler)
 
-    log.info('Logging started on PySB version %s', versioneer.get_version())
+    log.info('Logging started on PySB version %s', pysb.__version__)
     if time_utc:
         log.info('Log entry times are in UTC')
     else:

--- a/pysb/logging.py
+++ b/pysb/logging.py
@@ -1,0 +1,146 @@
+from __future__ import absolute_import
+import logging
+import versioneer
+import platform
+import socket
+import time
+import os
+import warnings
+
+SECONDS_IN_HOUR = 3600
+DEBUG_ENV_VAR = 'PYSB_DEBUG'
+BASE_LOGGER_NAME = 'pysb'
+
+
+def formatter(time_utc=False):
+    """
+    Build a logging formatter using local or UTC time
+
+    Parameters
+    ----------
+    time_utc : bool, optional (default: False)
+        Use local time stamps in log messages if False, or Universal
+        Coordinated Time (UTC), also known as Greenwich Mean Time (GMT) if True
+
+    Returns
+    -------
+    A logging.Formatter object for PySB logging
+    """
+    log_fmt = logging.Formatter('%(asctime)s.%(msecs).3d - %(name)s - '
+                                '%(levelname)s - %(message)s',
+                                datefmt='%Y-%m-%d %H:%M:%S')
+    if time_utc:
+        log_fmt.converter = time.gmtime
+
+    return log_fmt
+
+
+def setup_logger(level=logging.INFO, console_output=True, file_output=False,
+                 time_utc=False, capture_warnings=True):
+    """
+    Set up a new logging.Logger for PySB logging
+
+    Calling this method will override any existing handlers, formatters etc.
+    attached to the PySB logger. Typically, :func:`get_logger` should be
+    used instead, which returns the existing PySB logger if it has already
+    been set up, and can handle PySB submodule namespaces.
+
+    Parameters
+    ----------
+    level : int
+        Logging level, typically using a constant like logging.INFO or
+        logging.DEBUG
+    console_output : bool
+        Set up a default console log handler if True (default)
+    file_output : string
+        Supply a filename to copy all log output to that file, or set to
+        False to disable (default)
+    time_utc : bool
+        Specifies whether log entry time stamps should be in local time
+        (when False) or UTC (True). See :func:`formatter` for more
+        formatting options.
+    capture_warnings : bool
+        Capture warnings from Python's warnings module if True (default)
+
+    Returns
+    -------
+    A logging.Logger object for PySB logging. Note that other PySB modules
+    should use a logger specific to their namespace instead by calling
+    :func:`get_logger`.
+    """
+    log = logging.getLogger(BASE_LOGGER_NAME)
+
+    # Logging level can be overridden with environment variable
+    if DEBUG_ENV_VAR in os.environ:
+        level = logging.DEBUG
+    log.setLevel(level)
+
+    # Remove default logging handler
+    log.handlers = []
+
+    log_fmt = formatter(time_utc=time_utc)
+
+    if console_output:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(log_fmt)
+        log.addHandler(stream_handler)
+
+    if file_output:
+        file_handler = logging.FileHandler(file_output)
+        file_handler.setFormatter(log_fmt)
+        log.addHandler(file_handler)
+
+    log.info('Logging started on PySB version %s', versioneer.get_version())
+    if time_utc:
+        log.info('Log entry times are in UTC')
+    else:
+        utc_offset = time.timezone if (time.localtime().tm_isdst == 0) else \
+            time.altzone
+        utc_offset = -(utc_offset / SECONDS_IN_HOUR)
+        log.info('Log entry time offset from UTC: %.2f hours', utc_offset)
+
+    log.debug('OS Platform: %s', platform.platform())
+    log.debug('Python version: %s', platform.python_version())
+    log.debug('Hostname: %s', socket.getfqdn())
+
+    logging.captureWarnings(capture_warnings)
+
+    return log
+
+
+def get_logger(logger_name=BASE_LOGGER_NAME, **kwargs):
+    """
+    Returns (if extant) or creates a PySB logger
+
+    If the PySB base logger has already been set up, this method will return it
+    or any of its descendant loggers without overriding the settings - i.e.
+    any values supplied as kwargs will be ignored.
+
+    Parameters
+    ----------
+    logger_name : string
+        Get a logger for a specific namespace, typically __name__ for code
+        outside of classes or self.__module__ inside a class
+    **kwargs : kwargs
+        Keyword arguments to supply to :func:`setup_logger`. Only used when
+        the PySB logger hasn't been set up yet (i.e. there have been no
+        calls to this function or :func:`get_logger` directly).
+
+    Returns
+    -------
+    A logging.Logger object with the requested name
+
+    Examples
+    --------
+
+    >>> from pysb.logging import get_logger
+    >>> logger = get_logger(__name__)
+    >>> logger.debug('Test message')
+    """
+    if BASE_LOGGER_NAME not in logging.Logger.manager.loggerDict.keys():
+        setup_logger(**kwargs)
+    elif kwargs:
+        warnings.warn('PySB logger already exists, ignoring keyword '
+                      'arguments to setup_logger')
+
+    return logging.getLogger(logger_name)

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -3,6 +3,7 @@ import numpy as np
 import itertools
 import sympy
 import collections
+import numbers
 from pysb.core import MonomerPattern, ComplexPattern, as_complex_pattern, \
                       Component
 try:
@@ -181,7 +182,7 @@ class Simulator(object):
                     
                     def _get_value(sim):
                         if isinstance(value_obj, collections.Iterable) and \
-                           isinstance(value_obj[sim], (int, float)):
+                           isinstance(value_obj[sim], numbers.Number):
                             value = value_obj[sim]
                         elif isinstance(value_obj, Component):
                             if value_obj in self._model.parameters:

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -123,10 +123,10 @@ class Simulator(object):
                     # if val is a number, convert it to a single-element array
                     if not isinstance(val, collections.Sequence):
                         new_initials[cplx_pat] = np.array([val])
-                    # otherwise, check whether simulator supports multiple 
+                    # otherwise, check whether simulator supports multiple
                     # initial values
                     elif len(val) > 1 and not self._supports['multi_initials']:
-                        raise SimulatorException(self.__class__.__name__ + 
+                        raise SimulatorException(self.__class__.__name__ +
                                         " does not support multiple initial"
                                         " values at this time.")
                 self._initials = new_initials
@@ -138,7 +138,7 @@ class Simulator(object):
                     new_initials = np.resize(new_initials, (1,len(new_initials)))
                 # check whether simulator supports multiple initial values
                 elif not self._supports['multi_initials']:
-                    raise SimulatorException(self.__class__.__name__ + 
+                    raise SimulatorException(self.__class__.__name__ +
                                     " does not support multiple initial"
                                     " values at this time.")
                 # make sure number of initials values equals len(model.species)
@@ -160,9 +160,9 @@ class Simulator(object):
         # specified in the self._initials dictionary
         n_sims = 1
         if isinstance(self._initials, dict):
-            # record the length of the arrays and make 
+            # record the length of the arrays and make
             # sure they're all the same.
-            for key,val in self._initials.items():                    
+            for key,val in self._initials.items():
                 if n_sims == 1:
                     n_sims = len(val)
                 elif len(val) != n_sims:
@@ -189,7 +189,7 @@ class Simulator(object):
                     # (i.e., an override)
                     if y0[sim][si] != 0:
                         continue
-                    
+
                     def _get_value(sim):
                         if isinstance(value_obj, collections.Sequence) and \
                            isinstance(value_obj[sim], numbers.Number):
@@ -203,7 +203,7 @@ class Simulator(object):
                         else:
                             raise TypeError("Unexpected initial condition value type")
                         return value
-                        
+
                     # initials from the model
                     if isinstance(initials_source, np.ndarray):
                         if len(initials_source.shape) == 1:
@@ -220,7 +220,7 @@ class Simulator(object):
                     else:
                          value = _get_value(sim)
                     y0[sim][si] = value
-                            
+
         # Process any overrides
         if isinstance(self._initials, dict):
             _set_initials(self._initials.items())
@@ -238,9 +238,9 @@ class Simulator(object):
             n_sims = 1
             if isinstance(self._params, dict):
                 param_values_dict = self._params
-                # record the length of the arrays and make 
+                # record the length of the arrays and make
                 # sure they're all the same.
-                for key,val in param_values_dict.items():                    
+                for key,val in param_values_dict.items():
                     if n_sims == 1:
                         n_sims = len(val)
                     elif len(val) != n_sims:
@@ -277,10 +277,10 @@ class Simulator(object):
                 # if val is a number, convert it to a single-element array
                 if not isinstance(val, collections.Sequence):
                     new_params[key] = np.array([val])
-                # otherwise, check whether simulator supports multiple 
+                # otherwise, check whether simulator supports multiple
                 # param_values
                 elif len(val) > 1 and not self._supports['multi_param_values']:
-                    raise SimulatorException(self.__class__.__name__ + 
+                    raise SimulatorException(self.__class__.__name__ +
                                     " does not support multiple parameter"
                                     " values at this time.")
                     # NOTE: Strings are iterables, so they fall here
@@ -294,7 +294,7 @@ class Simulator(object):
                 new_params = np.resize(new_params, (1,len(new_params)))
             # check whether simulator supports multiple parameter values
             elif not self._supports['multi_param_values']:
-                raise SimulatorException(self.__class__.__name__ + 
+                raise SimulatorException(self.__class__.__name__ +
                                 " does not support multiple parameter"
                                 " values at this time.")
             # make sure number of param values equals len(model.parameters)
@@ -319,14 +319,14 @@ class Simulator(object):
             self.param_values = param_values
         if initials is not None:
             self.initials = initials
-        # If only one set of param_values, run all simulations 
+        # If only one set of param_values, run all simulations
         # with the same parameters
         if len(self.param_values) == 1:
             self.param_values = np.repeat(self.param_values,
                                           len(self.initials),
-                                          axis=0)        
-        # If only one set of initials, run all simulations 
-        # with the same initial conditions   
+                                          axis=0)
+        # If only one set of initials, run all simulations
+        # with the same initial conditions
         if len(self.initials) == 1:
             self.initials = np.repeat(self.initials,
                                       len(self.param_values),
@@ -336,7 +336,7 @@ class Simulator(object):
             raise SimulatorException(
                     "'param_values' and 'initials' must be equal lengths.\n"
                     "len(param_values): %d\n"
-                    "len(initials): %d" % 
+                    "len(initials): %d" %
                     (len(self.param_values), len(self.initials)))
         elif len(self.param_values.shape) != 2 or \
                 self.param_values.shape[1] != len(self._model.parameters):
@@ -352,7 +352,7 @@ class Simulator(object):
                     "len(model.species).\n"
                     "initials.shape: " + str(self.initials.shape) +
                     "\nlen(model.species): %d" % len(self._model.species))
-            # NOTE: Not sure if the check on 'initials' should be here or not. 
+            # NOTE: Not sure if the check on 'initials' should be here or not.
             # Network-free simulators don't have species, but we will want to
             # allow users to supply initials. Right now, that will raise an
             # exception. Need to think about this. --LAH
@@ -386,7 +386,7 @@ class SimulationResult(object):
         A set of species trajectories from a simulation. Should either be a
         list of 2D numpy arrays or a single 3D numpy array.
     squeeze : bool, optional (default: True)
-        Return trajectories as a 2D array, rather than a 3d array, if only 
+        Return trajectories as a 2D array, rather than a 3d array, if only
         a single simulation was performed.
 
     Examples
@@ -477,7 +477,7 @@ class SimulationResult(object):
                 raise ValueError("trajectories should be a 3D array or a list "
                                  "of 2D arrays")
             self._y = trajectories
-        
+
         self._nsims = len(self._y)
         if len(self.tout) != self._nsims:
             raise ValueError("Simulator tout should be the same length as "

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -299,6 +299,52 @@ class Simulator(object):
 
         Implementations should return a :class:`.SimulationResult` object.
         """
+        if tspan is not None:
+            self.tspan = tspan
+        if self.tspan is None:
+            raise SimulatorException("tspan must be defined before "
+                                     "simulation can run")
+        if param_values is not None:
+            self.param_values = param_values
+        if initials is not None:
+            self.initials = initials
+        # If only one set of param_values, run all simulations 
+        # with the same parameters
+        if len(self.param_values) == 1:
+            self.param_values = np.repeat(self.param_values,
+                                          len(self.initials),
+                                          axis=0)        
+        # If only one set of initials, run all simulations 
+        # with the same initial conditions   
+        if len(self.initials) == 1:
+            self.initials = np.repeat(self.initials,
+                                      len(self.param_values),
+                                      axis=0)
+        # Error checks on 'param_values' and 'initials'
+        if len(self.param_values) != len(self.initials):
+            raise SimulatorException(
+                    "'param_values' and 'initials' must be equal lengths.\n"
+                    "len(param_values): %d\n"
+                    "len(initials): %d" % 
+                    (len(self.param_values), len(self.initials)))
+        elif len(self.param_values.shape) != 2 or \
+                self.param_values.shape[1] != len(self._model.parameters):
+            raise SimulatorException(
+                    "'param_values' must be a 2D array of dimension N_SIMS x "
+                    "len(model.parameters).\n"
+                    "param_values.shape: " + str(self.param_values.shape) +
+                    "\nlen(model.parameters): %d" % len(self._model.parameters))
+        elif len(self.initials.shape) != 2 or \
+                self.initials.shape[1] != len(self._model.species):
+            raise SimulatorException(
+                    "'initials' must be a 2D array of dimension N_SIMS x "
+                    "len(model.species).\n"
+                    "initials.shape: " + str(self.initials.shape) +
+                    "\nlen(model.species): %d" % len(self._model.species))
+            # NOTE: Not sure if the check on 'initials' should be here or not. 
+            # Network-free simulators don't have species, but we will want to
+            # allow users to supply initials. Right now, that will raise an
+            # exception. Need to think about this. --LAH
         return None
 
 

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -97,6 +97,10 @@ class Simulator(object):
         self.param_values = param_values
 
     @property
+    def model(self):
+        return self._model
+
+    @property
     def initials(self):
         return self._initials if isinstance(self._initials, np.ndarray) \
                else self._get_initials()

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -121,7 +121,7 @@ class Simulator(object):
                                                  'ComplexPattern' %
                                                  repr(cplx_pat))
                     # if val is a number, convert it to a single-element array
-                    if not isinstance(val, collections.Iterable):
+                    if not isinstance(val, collections.Sequence):
                         new_initials[cplx_pat] = np.array([val])
                     # otherwise, check whether simulator supports multiple 
                     # initial values
@@ -191,7 +191,7 @@ class Simulator(object):
                         continue
                     
                     def _get_value(sim):
-                        if isinstance(value_obj, collections.Iterable) and \
+                        if isinstance(value_obj, collections.Sequence) and \
                            isinstance(value_obj[sim], numbers.Number):
                             value = value_obj[sim]
                         elif isinstance(value_obj, Component):
@@ -275,7 +275,7 @@ class Simulator(object):
                     raise IndexError("new_params dictionary has unknown "
                                      "parameter name (%s)" % key)
                 # if val is a number, convert it to a single-element array
-                if not isinstance(val, collections.Iterable):
+                if not isinstance(val, collections.Sequence):
                     new_params[key] = np.array([val])
                 # otherwise, check whether simulator supports multiple 
                 # param_values

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -81,11 +81,11 @@ class Simulator(object):
     @abstractmethod
     def __init__(self, model, tspan=None, initials=None,
                  param_values=None, verbose=False, **kwargs):
-        # Get or create base PySB logger exists
-        self._logger = get_logger(self.__module__)
+        # Get or create base a PySB logger for this module and model
+        self._logger = get_logger(self.__module__, model=model)
         if verbose:
             self._logger.setLevel(logging.DEBUG)
-        self._logger.debug('[%s] Simulator created', model.name)
+        self._logger.debug('Simulator created')
         self._model = model
         self.verbose = verbose
         self.tout = None
@@ -309,7 +309,7 @@ class Simulator(object):
 
         Implementations should return a :class:`.SimulationResult` object.
         """
-        self._logger.info('[%s] Simulation(s) started', self._model.name)
+        self._logger.info('Simulation(s) started')
         if tspan is not None:
             self.tspan = tspan
         if self.tspan is None:
@@ -457,8 +457,7 @@ class SimulationResult(object):
     13.333333  0.000002    4.999927
     """
     def __init__(self, simulator, tout, trajectories, squeeze=True):
-        simulator._logger.debug('[%s] SimulationResult constructor started',
-                                simulator._model.name)
+        simulator._logger.debug('SimulationResult constructor started')
         self.squeeze = squeeze
         self.tout = tout
         self._yfull = None
@@ -531,8 +530,7 @@ class SimulationResult(object):
                 func = sympy.lambdify(obs_names, expr_subs, "numpy")
                 self._yexpr_view[n][:, i] = func(**obs_dict)
 
-        simulator._logger.debug('[%s] SimulationResult constructor finished',
-                                simulator._model.name)
+        simulator._logger.debug('SimulationResult constructor finished')
 
     def _squeeze_output(self, trajectories):
         """

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -40,9 +40,13 @@ class ScipyOdeSimulator(Simulator):
             'mxstep': 2**31-1,
         }
     }
-
+    
     def __init__(self, model, tspan=None, initials=None, param_values=None,
                  verbose=False, **kwargs):
+        
+        self._supports['multi_initials'] = False
+        self._supports['multi_param_values'] = False
+        
         super(ScipyOdeSimulator, self).__init__(model,
                                                 tspan=tspan,
                                                 initials=initials,

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -28,10 +28,8 @@ class ScipyOdeSimulator(Simulator):
             'with_jacobian': True,
             # Set nsteps as high as possible to give our users flexibility in
             # choosing their time step. (Let's be safe and assume vode was
-            # compiled
-            # with 32-bit ints. What would actually happen if it was and we
-            # passed
-            # 2**64-1 though?)
+            # compiled with 32-bit ints. What would actually happen if it was 
+            # and we passed 2**64-1 though?)
             'nsteps': 2 ** 31 - 1,
         },
         'cvode': {
@@ -241,7 +239,7 @@ class ScipyOdeSimulator(Simulator):
                     distutils.errors.CompileError, ImportError):
                 pass
 
-    def run(self, tspan=None, param_values=None, initials=None):
+    def run(self, tspan=None, initials=None, param_values=None):
         if tspan is not None:
             self.tspan = tspan
         if self.tspan is None:
@@ -253,8 +251,8 @@ class ScipyOdeSimulator(Simulator):
             self.param_values = param_values
         if initials is not None:
             self.initials = initials
-        y0 = self.initials_list
-        param_values = self.param_values
+        y0 = self.initials[0]
+        param_values = self.param_values[0]
         if self.integrator == 'lsoda':
             trajectories[0] = scipy.integrate.odeint(self.func,
                                                 y0,
@@ -285,5 +283,6 @@ class ScipyOdeSimulator(Simulator):
             if self.verbose: print("...Done.")
             if self.integrator.t < self.tspan[-1]:
                 trajectories[0, i:, :] = 'nan'
+                
         self.tout = [self.tspan, ]
         return SimulationResult(self, trajectories)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -21,6 +21,10 @@ def _exec(code, locals):
 
 
 class ScipyOdeSimulator(Simulator):
+    
+    _supports = { 'multi_initials' : False,
+                  'multi_param_values' : False }
+    
     # some sane default options for a few well-known integrators
     default_integrator_options = {
         'vode': {
@@ -43,9 +47,6 @@ class ScipyOdeSimulator(Simulator):
     
     def __init__(self, model, tspan=None, initials=None, param_values=None,
                  verbose=False, **kwargs):
-        
-        self._supports['multi_initials'] = False
-        self._supports['multi_param_values'] = False
         
         super(ScipyOdeSimulator, self).__init__(model,
                                                 tspan=tspan,

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -349,8 +349,7 @@ class ScipyOdeSimulator(Simulator):
         trajectories = np.ndarray((n_sims, len(self.tspan),
                               len(self._model.species)))
         for n in range(n_sims):
-            self._logger.info('[%s] Running simulation %d of %d',
-                              self._model.name, n + 1, n_sims)
+            self._logger.info('Running simulation %d of %d', n + 1, n_sims)
             if self.integrator == 'lsoda':
                 trajectories[n] = scipy.integrate.odeint(self.func,
                                                     self.initials[n],
@@ -369,15 +368,13 @@ class ScipyOdeSimulator(Simulator):
                 i = 1
                 while self.integrator.successful() and self.integrator.t < \
                         self.tspan[-1]:
-                    self._logger.debug('[%s] Simulation %d/%d '
-                                       'Integrating t=%g',
-                                       self._model.name, n + 1, n_sims,
-                                       self.integrator.t)
+                    self._logger.debug('Simulation %d/%d Integrating t=%g',
+                                       n + 1, n_sims, self.integrator.t)
                     trajectories[n][i] = self.integrator.integrate(self.tspan[i])
                     i += 1
                 if self.integrator.t < self.tspan[-1]:
                     trajectories[n, i:, :] = 'nan'
 
         tout = np.array([self.tspan]*n_sims)
-        self._logger.info('[%s] All simulation(s) complete', self._model.name)
+        self._logger.info('All simulation(s) complete')
         return SimulationResult(self, tout, trajectories)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -349,6 +349,8 @@ class ScipyOdeSimulator(Simulator):
         trajectories = np.ndarray((n_sims, len(self.tspan),
                               len(self._model.species)))
         for n in range(n_sims):
+            self._logger.info('[%s] Running simulation %d of %d',
+                              self._model.name, n + 1, n_sims)
             if self.integrator == 'lsoda':
                 trajectories[n] = scipy.integrate.odeint(self.func,
                                                     self.initials[n],
@@ -357,7 +359,7 @@ class ScipyOdeSimulator(Simulator):
                                                     args=(self.param_values[n],),
                                                     **self.opts)
             else:
-                self.integrator.set_initial_value(self.initials[n], 
+                self.integrator.set_initial_value(self.initials[n],
                                                   self.tspan[0])
                 # Set parameter vectors for RHS func and Jacobian
                 self.integrator.set_f_params(self.param_values[n])
@@ -365,19 +367,17 @@ class ScipyOdeSimulator(Simulator):
                     self.integrator.set_jac_params(self.param_values[n])
                 trajectories[n][0] = self.initials[n]
                 i = 1
-                if self.verbose:
-                    print("Integrating...")
-                    print("\tTime")
-                    print("\t----")
-                    print("\t%g" % self.integrator.t)
                 while self.integrator.successful() and self.integrator.t < \
                         self.tspan[-1]:
+                    self._logger.debug('[%s] Simulation %d/%d '
+                                       'Integrating t=%g',
+                                       self._model.name, n + 1, n_sims,
+                                       self.integrator.t)
                     trajectories[n][i] = self.integrator.integrate(self.tspan[i])
                     i += 1
-                    if self.verbose: print("\t%g" % self.integrator.t)
-                if self.verbose: print("...Done.")
                 if self.integrator.t < self.tspan[-1]:
                     trajectories[n, i:, :] = 'nan'
-                
+
         tout = np.array([self.tspan]*n_sims)
+        self._logger.info('[%s] All simulation(s) complete', self._model.name)
         return SimulationResult(self, tout, trajectories)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -282,5 +282,5 @@ class ScipyOdeSimulator(Simulator):
                 if self.integrator.t < self.tspan[-1]:
                     trajectories[n, i:, :] = 'nan'
                 
-        self.tout = np.array([self.tspan]*n_sims)
-        return SimulationResult(self, trajectories)
+        tout = np.array([self.tspan]*n_sims)
+        return SimulationResult(self, tout, trajectories)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -101,7 +101,7 @@ class ScipyOdeSimulator(Simulator):
             'with_jacobian': True,
             # Set nsteps as high as possible to give our users flexibility in
             # choosing their time step. (Let's be safe and assume vode was
-            # compiled with 32-bit ints. What would actually happen if it was 
+            # compiled with 32-bit ints. What would actually happen if it was
             # and we passed 2**64-1 though?)
             'nsteps': 2 ** 31 - 1,
         },
@@ -113,10 +113,10 @@ class ScipyOdeSimulator(Simulator):
             'mxstep': 2**31-1,
         }
     }
-    
+
     def __init__(self, model, tspan=None, initials=None, param_values=None,
                  verbose=False, **kwargs):
-        
+
         super(ScipyOdeSimulator, self).__init__(model,
                                                 tspan=tspan,
                                                 initials=initials,

--- a/pysb/tests/__init__.py
+++ b/pysb/tests/__init__.py
@@ -1,0 +1,6 @@
+from pysb.logging import get_logger
+import logging
+
+# Nosetests adds its own logging handler - console_output=False avoids
+# duplication
+get_logger(level=logging.DEBUG, console_output=False)

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -110,7 +110,13 @@ def test_integrate_with_expression():
     Rule('R3', s16() + s20() >> s16() + s1(), keff)
 
     time = np.linspace(0, 40)
-    x = odesolve(model, time)
+
+    solver = Solver(model, time)
+    solver.run()
+
+    assert solver.yexpr_view.shape == (len(time),
+                                       len(model.expressions_dynamic()))
+    assert solver.yobs_view.shape == (len(time), len(model.observables))
 
 
 def test_robertson_integration():

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -3,6 +3,7 @@ from pysb.integrate import odesolve, Solver
 import numpy as np
 from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.bng import run_ssa
+from pysb.simulator.base import SimulatorException
 
 from pysb.examples import robertson, earm_1_0
 
@@ -76,7 +77,7 @@ class TestSolver(object):
         """Test param_values with invalid parameter name."""
         self.solver.run(param_values={'spam': 150})
 
-    @raises(ValueError, TypeError)
+    @raises(ValueError, TypeError, SimulatorException)
     def test_param_values_non_numeric_value(self):
         """Test param_values with non-numeric value."""
         self.solver.run(param_values={'ksynthA': 'eggs'})

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -25,7 +25,7 @@ def test_simres_dataframe():
     sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
     simres = SimulationResult(sim, [tspan1, tspan2], [trajectories1, trajectories2])
     df = simres.dataframe
- 
+
     assert df.shape == (len(tspan1) + len(tspan2),
                         len(model.species) + len(model.observables))
 
@@ -34,6 +34,6 @@ def test_simres_dataframe():
     simres2 = SimulationResult(sim, [tspan1, tspan3],
                                np.stack([trajectories1, trajectories3]))
     df2 = simres2.dataframe
- 
+
     assert df2.shape == (len(tspan1) + len(tspan3),
                          len(model.species) + len(model.observables))

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -19,24 +19,24 @@ def test_simres_dataframe():
     df_single = simres1.dataframe
 
     # Generate multiple trajectories
-    trajectories1 = simres1.species
-    trajectories2 = sim.run(tspan=tspan2).species
-    trajectories3 = sim.run(tspan=tspan3).species
+#     trajectories1 = simres1.species
+#     trajectories2 = sim.run(tspan=tspan2).species
+#     trajectories3 = sim.run(tspan=tspan3).species
 
     # Try a simulation result with two different tspan lengths
-    sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
-    sim.tout = [tspan1, tspan2]
-    simres = SimulationResult(sim, [trajectories1, trajectories2])
-    df = simres.dataframe
-
-    assert df.shape == (len(tspan1) + len(tspan2),
-                        len(model.species) + len(model.observables))
+#     sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
+#     sim.tout = [tspan1, tspan2]
+#     simres = SimulationResult(sim, [trajectories1, trajectories2])
+#     df = simres.dataframe
+# 
+#     assert df.shape == (len(tspan1) + len(tspan2),
+#                         len(model.species) + len(model.observables))
 
     # Next try a simulation result with two identical tspan lengths, stacked
     # into a single 3D array of trajectories
-    sim.tout = [tspan1, tspan3]
-    simres2 = SimulationResult(sim, np.stack([trajectories1, trajectories3]))
-    df2 = simres2.dataframe
-
-    assert df2.shape == (len(tspan1) + len(tspan3),
-                         len(model.species) + len(model.observables))
+#     sim.tout = [tspan1, tspan3]
+#     simres2 = SimulationResult(sim, np.stack([trajectories1, trajectories3]))
+#     df2 = simres2.dataframe
+# 
+#     assert df2.shape == (len(tspan1) + len(tspan3),
+#                          len(model.species) + len(model.observables))

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -24,6 +24,7 @@ def test_simres_dataframe():
     trajectories3 = sim.run(tspan=tspan3).species
 
     # Try a simulation result with two different tspan lengths
+    sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
     sim.tout = [tspan1, tspan2]
     simres = SimulationResult(sim, [trajectories1, trajectories2])
     df = simres.dataframe

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -23,8 +23,7 @@ def test_simres_dataframe():
 
     # Try a simulation result with two different tspan lengths
     sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
-    sim.tout = [tspan1, tspan2]
-    simres = SimulationResult(sim, [trajectories1, trajectories2])
+    simres = SimulationResult(sim, [tspan1, tspan2], [trajectories1, trajectories2])
     df = simres.dataframe
  
     assert df.shape == (len(tspan1) + len(tspan2),
@@ -32,8 +31,8 @@ def test_simres_dataframe():
 
     # Next try a simulation result with two identical tspan lengths, stacked
     # into a single 3D array of trajectories
-    sim.tout = [tspan1, tspan3]
-    simres2 = SimulationResult(sim, np.stack([trajectories1, trajectories3]))
+    simres2 = SimulationResult(sim, [tspan1, tspan3],
+                               np.stack([trajectories1, trajectories3]))
     df2 = simres2.dataframe
  
     assert df2.shape == (len(tspan1) + len(tspan3),

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -7,8 +7,6 @@ import numpy as np
 def test_simres_dataframe():
     """ Test SimulationResult.dataframe() """
 
-    # We don't currently have a Simulator which does multiple simulations at
-    # a time, so we fake it to test SimulationResult.dataframe()
     tspan1 = np.linspace(0, 100, 100)
     tspan2 = np.linspace(50, 100, 50)
     tspan3 = np.linspace(100, 150, 100)
@@ -19,24 +17,24 @@ def test_simres_dataframe():
     df_single = simres1.dataframe
 
     # Generate multiple trajectories
-#     trajectories1 = simres1.species
-#     trajectories2 = sim.run(tspan=tspan2).species
-#     trajectories3 = sim.run(tspan=tspan3).species
+    trajectories1 = simres1.species
+    trajectories2 = sim.run(tspan=tspan2).species
+    trajectories3 = sim.run(tspan=tspan3).species
 
     # Try a simulation result with two different tspan lengths
-#     sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
-#     sim.tout = [tspan1, tspan2]
-#     simres = SimulationResult(sim, [trajectories1, trajectories2])
-#     df = simres.dataframe
-# 
-#     assert df.shape == (len(tspan1) + len(tspan2),
-#                         len(model.species) + len(model.observables))
+    sim = ScipyOdeSimulator(model, param_values={'k6' : [1.,1.]}, integrator='lsoda')
+    sim.tout = [tspan1, tspan2]
+    simres = SimulationResult(sim, [trajectories1, trajectories2])
+    df = simres.dataframe
+ 
+    assert df.shape == (len(tspan1) + len(tspan2),
+                        len(model.species) + len(model.observables))
 
     # Next try a simulation result with two identical tspan lengths, stacked
     # into a single 3D array of trajectories
-#     sim.tout = [tspan1, tspan3]
-#     simres2 = SimulationResult(sim, np.stack([trajectories1, trajectories3]))
-#     df2 = simres2.dataframe
-# 
-#     assert df2.shape == (len(tspan1) + len(tspan3),
-#                          len(model.species) + len(model.observables))
+    sim.tout = [tspan1, tspan3]
+    simres2 = SimulationResult(sim, np.stack([trajectories1, trajectories3]))
+    df2 = simres2.dataframe
+ 
+    assert df2.shape == (len(tspan1) + len(tspan3),
+                         len(model.species) + len(model.observables))

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -48,7 +48,7 @@ class TestScipySimulator(object):
     def test_vode_solver_run(self):
         """Test vode."""
         simres = self.sim.run()
-        assert simres.nsims == 1
+        assert simres._nsims == 1
 
     def test_vode_jac_solver_run(self):
         """Test vode and analytic jacobian."""

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -73,13 +73,13 @@ class TestScipySimulator(object):
     def test_y0_as_list(self):
         """Test y0 with list of initial conditions"""
         # Test the initials getter method before anything is changed
-        assert np.allclose(self.sim.initials[0:3],
+        assert np.allclose(self.sim.initials[0][0:3],
                            [ic[1].value for ic in
                             self.model.initial_conditions])
 
         initials = [10, 20, 0, 0]
         simres = self.sim.run(initials=initials)
-        assert np.allclose(self.sim.initials, initials)
+        assert np.allclose(self.sim.initials[0], initials)
         assert np.allclose(simres.observables['A_free'][0], 10)
 
     def test_y0_as_ndarray(self):
@@ -92,7 +92,7 @@ class TestScipySimulator(object):
         simres = self.sim.run(initials={self.mon('A')(a=None): 10,
                                self.mon('B')(b=1) % self.mon('A')(a=1): 0,
                                self.mon('B')(b=None): 0})
-        assert np.allclose(self.sim.initials_list, [10, 0, 1, 0])
+        assert np.allclose(self.sim.initials, [10, 0, 1, 0])
         assert np.allclose(simres.observables['A_free'][0], 10)
 
     def test_y0_as_dictionary_with_bound_species(self):

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -102,7 +102,7 @@ class TestScipySimulator(object):
                                self.mon('B')(b=None): 0})
         assert np.allclose(simres.observables['AB_complex'][0], 100)
 
-    @raises(TypeError)
+    @raises(TypeError, SimulatorException)
     def test_y0_non_numeric_value(self):
         """Test y0 with non-numeric value."""
         self.sim.run(initials={self.mon('A')(a=None): 'eggs'})
@@ -128,7 +128,7 @@ class TestScipySimulator(object):
         """Test param_values with invalid parameter name."""
         self.sim.run(param_values={'spam': 150})
 
-    @raises(ValueError, TypeError)
+    @raises(ValueError, TypeError, SimulatorException)
     def test_param_values_non_numeric_value(self):
         """Test param_values with non-numeric value."""
         self.sim.run(param_values={'ksynthA': 'eggs'})


### PR DESCRIPTION
This PR contains two main features:

* A new logging framework for PySB, built on the Python logging module, just integrated into the Simulation class for now, but which will facilitate new capabilities:
  * Finer-grained verbosity selection than verbose=True or False using logging levels.
  * Support for multiple logging handlers, allowing logging to console, file, various centralized network servers. This will be useful for distributed/parallel/cluster-based PySB setups.
  * We've discussed a benchmark suite before. A custom benchmarking log handler could be written to time various pieces of code based on start/stop events.
* The ability to run simulations using multiple different initial condition/parameter value sets. This code was written by @lh64. This capability is also important for the upcoming cupSODA simulator, which can run multiple such simulations in parallel.

I also removed the extraneous output from `weave_inline` when running simulations by capturing STDERR and redirecting it to /dev/null (in commit 9471277).