### PR TITLE
Centralised methods for getting and settings paths to external executables

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -13,6 +13,7 @@ import abc
 from warnings import warn
 import shutil
 import collections
+import pysb.pathfinder as pf
 
 try:
     from cStringIO import StringIO
@@ -29,73 +30,10 @@ try:
 except NameError:
     basestring = str
 
-# Cached value of BNG path
-_bng_path = None
 
 def set_bng_path(dir):
-    global _bng_path
-    _bng_path = os.path.join(dir,'BNG2.pl')
-    # Make sure file exists and that it is not a directory
-    if not os.access(_bng_path, os.F_OK) or not os.path.isfile(_bng_path):
-        raise Exception('Could not find BNG2.pl in ' + os.path.abspath(dir) + '.')
-    # Make sure file has executable permissions
-    elif not os.access(_bng_path, os.X_OK):
-        raise Exception("BNG2.pl in " + os.path.abspath(dir) + " does not have executable permissions.")
-
-def _get_bng_path():
-    """
-    Return the path to BioNetGen's BNG2.pl.
-
-    Looks for a BNG distribution at the path stored in the BNGPATH environment
-    variable if that's set, or else in a few hard-coded standard locations.
-
-    """
-
-    global _bng_path
-
-    # Just return cached value if it's available
-    if _bng_path:
-        return _bng_path
-
-    path_var = 'BNGPATH'
-    dist_dirs = [
-        '/usr/local/share/BioNetGen',
-        'c:/Program Files/BioNetGen',
-        ]
-    # BNG 2.1.8 moved BNG2.pl up out of the Perl2 subdirectory, so to be more
-    # compatible we check both the old and new locations.
-    script_subdirs = ['', 'Perl2']
-
-    def check_dist_dir(dist_dir):
-        # Return the full path to BNG2.pl inside a BioNetGen distribution
-        # directory, or False if directory does not contain a BNG2.pl in one of
-        # the expected places.
-        for subdir in script_subdirs:
-            script_path = os.path.join(dist_dir, subdir, 'BNG2.pl')
-            if os.access(script_path, os.F_OK):
-                return script_path
-        else:
-            return False
-
-    # First check the environment variable, which has the highest precedence
-    if path_var in os.environ:
-        script_path = check_dist_dir(os.environ[path_var])
-        if not script_path:
-            raise Exception('Environment variable %s is set but BNG2.pl could'
-                            ' not be found there' % path_var)
-    # If the environment variable isn't set, check the standard locations
-    else:
-        for dist_dir in dist_dirs:
-            script_path = check_dist_dir(dist_dir)
-            if script_path:
-                break
-        else:
-            raise Exception('Could not find BioNetGen installed in one of the '
-                            'following locations:' +
-                            ''.join('\n    ' + d for d in dist_dirs))
-    # Cache path for future use
-    _bng_path = script_path
-    return script_path
+    """ Deprecated. Use pysb.pathfinder.set_path() instead. """
+    pf.set_path('bng', dir)
 
 
 class BngInterfaceError(RuntimeError):
@@ -288,7 +226,8 @@ class BngConsole(BngBaseInterface):
                     bng_file.write(self.generator.get_content())
 
             # Start BNG Console and load BNGL
-            self.console = pexpect.spawn('perl %s --console' % _get_bng_path(),
+            self.console = pexpect.spawn('perl %s --console' %
+                                         pf.get_path('bng'),
                                          cwd=self.base_directory,
                                          timeout=timeout)
             self._console_wait()
@@ -429,7 +368,8 @@ class BngFileInterface(BngBaseInterface):
             self.command_queue.close()
             self._init_command_queue()
 
-            p = subprocess.Popen(['perl', _get_bng_path(), self.bng_filename],
+            p = subprocess.Popen(['perl', pf.get_path('bng'),
+                                  self.bng_filename],
                                  cwd=self.base_directory,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -33,6 +33,9 @@ except NameError:
 
 def set_bng_path(dir):
     """ Deprecated. Use pysb.pathfinder.set_path() instead. """
+    warn("Function %s() is deprecated; use pysb.pathfinder.set_path() "
+         "instead" % set_bng_path.__name__, category=DeprecationWarning,
+         stacklevel=2)
     pf.set_path('bng', dir)
 
 

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -1,6 +1,6 @@
 from __future__ import print_function as _
 from pysb.importers.bngl import model_from_bngl
-from pysb.bng import _get_bng_path
+import pysb.pathfinder as pf
 import subprocess
 import os
 import tempfile
@@ -66,7 +66,7 @@ def sbml_translator(input_file,
     string
         BNGL output filename
     """
-    sbmltrans_bin = os.path.join(os.path.dirname(_get_bng_path()),
+    sbmltrans_bin = os.path.join(os.path.dirname(pf.get_path('bng')),
                                  'bin/sbmlTranslator')
     sbmltrans_args = [sbmltrans_bin, '-i', input_file]
     if output_file is None:

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -12,6 +12,7 @@ specified in one of three ways:
 
 from __future__ import print_function as _
 import pysb
+import pysb.pathfinder as pf
 from pysb.generator.kappa import KappaGenerator
 import os
 import subprocess
@@ -29,95 +30,19 @@ try:
 except ImportError:
     pass
 
-# Cached value of Kappa program paths
-_kasim_path = None
-_kasa_path = None
-
-def _check_dist_dir(kappa_prog, dist_dir):
-    kappa_prog_path = os.path.join(dist_dir, kappa_prog)
-    if os.access(kappa_prog_path, os.F_OK):
-        return kappa_prog_path
-    else:
-        return None
 
 def set_kappa_path(path):
     """Set the path to the KaSim and KaSa executables.
 
+    Deprecated. Use pysb.pathfinder.set_path() instead.
+
     Parameters
     ----------
     path: string
-        Directory containing KaSim and Kasa executables.
+        Directory containing KaSim and KaSa executables.
     """
-
-    global _kasim_path
-    global _kasa_path
-    # Check locations of both KaSim and KaSa
-    kasim_path = _check_dist_dir('KaSim', path)
-    kasa_path = _check_dist_dir('KaSa', path)
-    # KaSim is required, so raise if we didn't find it.
-    if kasim_path is None:
-        raise Exception('Could not find KaSim in %s.' % os.path.abspath(path))
-    # KaSa is optional, so only warn if we didn't find it.
-    if kasa_path is None:
-        warnings.warn('Could not find KaSa in %s; install KaSa for static '
-                      'analysis features.' % os.path.abspath(path))
-    _kasim_path = kasim_path
-    _kasa_path = kasa_path
-
-def _get_kappa_path(kappa_prog):
-    """
-    Return the path to the KaSim or KaSa executable.
-
-    Looks for a KaSim/KaSa distribution at the path stored in the KAPPAPATH
-    environment variable if that's set, or else in a few hard-coded standard
-    locations.
-    """
-
-    if kappa_prog not in ['KaSim', 'KaSa']:
-        raise ValueError("kappa_prog must be one of 'KaSim', 'KaSa'.")
-
-    global _kasim_path
-    global _kasa_path
-
-    # Just return cached value if it's available
-    if kappa_prog == 'KaSim' and _kasim_path is not None:
-        return _kasim_path
-    elif kappa_prog == 'KaSa' and _kasa_path is not None:
-        return _kasa_path
-
-    path_var = 'KAPPAPATH'
-    dist_dirs = [
-        '/usr/local/share/KaSim',
-        'c:/Program Files/KaSim',
-        ]
-
-    # First check the environment variable, which has the highest precedence
-    if path_var in os.environ:
-        kappapath = os.environ[path_var]
-        kappa_prog_path = _check_dist_dir(kappa_prog, kappapath)
-        if not kappa_prog_path:
-            raise Exception('Environment variable %s is set to "%s" but %s '
-                            'could not be found there.' %
-                            (path_var, kappapath, kappa_prog))
-    # If the environment variable isn't set, check the standard locations
-    else:
-        for dist_dir in dist_dirs:
-            kappa_prog_path = _check_dist_dir(kappa_prog, dist_dir)
-            if kappa_prog_path:
-                break
-        else:
-            raise Exception('Could not find %s installed in one of the '
-                            'following locations:' % kappa_prog +
-                            ''.join('\n    ' + d for d in dist_dirs) +
-                            '\nSet the environment variable %s to the '
-                            'directory containing KaSim and KaSa.' % path_var)
-    # Cache path for future use
-    if kappa_prog == 'KaSim':
-        _kasim_path = kappa_prog_path
-    elif kappa_prog == 'KaSa':
-        _kasa_path = kappa_prog_path
-
-    return kappa_prog_path
+    pf.set_path('kasim', path)
+    pf.set_path('kasa', path)
 
 
 class KasimInterfaceError(RuntimeError):
@@ -231,7 +156,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
             kappa_file.write('\n%s\n' % perturbation)
 
     # Run KaSim
-    kasim_path = _get_kappa_path('KaSim')
+    kasim_path = pf.get_path('kasim')
     p = subprocess.Popen([kasim_path] + args,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if verbose:
@@ -358,7 +283,7 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
         kappa_file.write(gen.get_content())
 
     # Run KaSa using the given args
-    kasa_path = _get_kappa_path('KaSa')
+    kasa_path = pf.get_path('kasa')
     p = subprocess.Popen([kasa_path] + args,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if verbose:

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -4,10 +4,11 @@ Wrapper functions for running the Kappa programs *KaSim* and *KaSa*.
 The path to the directory containing the KaSim and KaSa executables can be
 specified in one of three ways:
 
-- setting the KAPPAPATH environment variable to the KaSim directory
-- setting the path using the :py:func:`set_kappa_path` function at runtime
-- adding the path to the KaSim directory to the system PATH environment variable
-
+- set the KAPPAPATH environment variable to the KaSim directory
+- move Kappa to /usr/local/share/KaSim (macOS, Linux) or
+  c:\Program Files\KaSim (Windows)
+- set the path using the :py:func:`pysb.pathfinder.set_path` function at
+  runtime
 """
 
 from __future__ import print_function as _
@@ -16,9 +17,7 @@ import pysb.pathfinder as pf
 from pysb.generator.kappa import KappaGenerator
 import os
 import subprocess
-import random
 import re
-import sympy
 import numpy as np
 import tempfile
 import shutil
@@ -41,6 +40,10 @@ def set_kappa_path(path):
     path: string
         Directory containing KaSim and KaSa executables.
     """
+    warnings.warn("Function %s() is deprecated; use "
+                  "pysb.pathfinder.set_path() instead" %
+                  set_kappa_path.__name__, category=DeprecationWarning,
+                  stacklevel=2)
     pf.set_path('kasim', path)
     pf.set_path('kasa', path)
 

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -1,0 +1,148 @@
+import os
+
+_path_config = {
+    'bng': {
+        'name': 'BioNetGen',
+        'executable': 'BNG2.pl',
+        'env_var': 'BNGPATH',
+        'search_paths': {
+            'posix': ('/usr/local/share/BioNetGen', ),
+            'nt': ('c:/Program Files/BioNetGen', )
+        }
+    },
+    'kasa': {
+        'name': 'KaSa (Kappa)',
+        'executable': 'KaSa',
+        'env_var': 'KAPPAPATH',
+        'search_paths': {
+            'posix': ('/usr/local/share/KaSim', ),
+            'nt': ('c:/Program Files/KaSim', )
+        }
+    },
+    'kasim': {
+        'name': 'KaSim (Kappa)',
+        'executable': 'KaSim',
+        'env_var': 'KAPPAPATH',
+        'search_paths': {
+            'posix': ('/usr/local/share/KaSim',),
+            'nt': ('c:/Program Files/KaSim',)
+        }
+    }
+}
+_path_cache = {}
+
+
+def get_path(prog_name):
+    """
+    Gets the currently active path to an external executable
+
+    The path will be determined automatically if not set (see return value).
+    To override, call :func:`set_path`.
+
+    Parameters
+    ----------
+    prog_name: str
+        The PySB internal program name for an executable. One of 'bng'
+        (BioNetGen), 'kasa' (Kappa's KaSa) or 'kasim' (Kappa's KaSim).
+
+    Returns
+    -------
+    The currently active path to an external executable. If the path hasn't
+    previously been set, the relevant environment variable for that
+    program's path will be searched. Failing that, a list of default paths
+    for the operating system will be checked. An Exception is raised if none
+    of these approaches works.
+    """
+    try:
+        return _path_cache[prog_name]
+    except KeyError:
+        pass
+
+    if prog_name not in _path_config.keys():
+        raise ValueError('%s is not a known external executable' % prog_name)
+
+    path_conf = _path_config[prog_name]
+
+    # Try environment variable, if set
+    if path_conf['env_var'] in os.environ:
+        env_var_val = os.environ[path_conf['env_var']]
+        try:
+            _path_cache[prog_name] = _validate_path(prog_name, env_var_val)
+            return _path_cache[prog_name]
+        except ValueError:
+            raise ValueError('Environment variable %s is set to %s, but the '
+                             'program %s or its executable %s could not be '
+                             'found there. Check file existence and '
+                             'permissions.' % (
+                                path_conf['env_var'],
+                                env_var_val,
+                                path_conf['name'],
+                                path_conf['executable']))
+
+    # Check default paths for this operating system
+    if os.name not in path_conf['search_paths'].keys():
+        raise Exception('No default path is known for %s on your '
+                        'operating system "%s". Set the path using the '
+                        'environment variable %s or by calling the function '
+                        '%s.%s()' % (path_conf['name'],
+                                    os.name,
+                                    path_conf['env_var'],
+                                    set_path.__module__,
+                                    set_path.__name__))
+
+    search_paths = path_conf['search_paths'][os.name]
+    for search_path in search_paths:
+        try:
+            _path_cache[prog_name] = _validate_path(prog_name, search_path)
+            return _path_cache[prog_name]
+        except ValueError:
+            pass
+
+    raise Exception('The program %s was not found in the default search '
+                    'path(s) for your operating system:\n\n%s\n\nEither '
+                    'install it to one of those paths, or set a custom path '
+                    'using the environment variable %s or by calling the '
+                    'function %s.%s()' % (path_conf['name'],
+                                          "\n".join(search_paths),
+                                          path_conf['env_var'],
+                                          set_path.__module__,
+                                          set_path.__name__))
+
+
+def set_path(prog_name, full_path):
+    """
+    Sets the full path to an external executable
+
+    Parameters
+    ----------
+    prog_name: str
+        The internal program name for an executable. See :func:`get_path` for
+        valid values.
+    full_path: str
+        The full path to the external executable or its enclosing directory.
+        If the path is a directory, it will be searched for the executable.
+        A ValueError will be raised if there's an issue with the path (not
+        found, permissions etc.).
+    """
+    if prog_name not in _path_config.keys():
+        raise ValueError('%s is not a known external executable' % prog_name)
+
+    _path_cache[prog_name] = _validate_path(prog_name, full_path)
+
+
+def _validate_path(prog_name, full_path):
+    if not os.access(full_path, os.F_OK):
+        raise ValueError('Unable to access path %s. Check the file exists '
+                         'and the current user has permission to access it.' %
+                         full_path)
+
+    if not os.path.isfile(full_path):
+        # It's a directory, try appending the executable name
+        return _validate_path(prog_name, os.path.join(full_path, _path_config[
+            prog_name]['executable']))
+
+    if not os.access(full_path, os.X_OK):
+        raise ValueError('The file %s does not have executable permissions.' %
+                         full_path)
+
+    return full_path

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -1,5 +1,6 @@
 import pysb
 import os
+import pysb.pathfinder as pf
 from pysb.bng import BngConsole
 from pysb.importers.bngl import model_from_bngl, BnglImportError
 from pysb.importers.sbml import model_from_sbml
@@ -45,7 +46,7 @@ def _bngl_location(filename):
     Gets the location of one of BioNetGen's validation model files in BNG's
     Validate directory.
     """
-    bng_dir = os.path.dirname(pysb.bng._get_bng_path())
+    bng_dir = os.path.dirname(pf.get_path('bng'))
     bngl_file = os.path.join(bng_dir, 'Validate', filename + '.bngl')
     return bngl_file
 
@@ -55,7 +56,7 @@ def _sbml_location(filename):
     Gets the location of one of BioNetGen's validation SBML files in BNG's
     Validate/INPUT_FILES directory.
     """
-    bng_dir = os.path.dirname(pysb.bng._get_bng_path())
+    bng_dir = os.path.dirname(pf.get_path('bng'))
     sbml_file = os.path.join(bng_dir, 'Validate/INPUT_FILES', filename +
                              '.xml')
     return sbml_file


### PR DESCRIPTION
Since we're adding more links to external executables from PySB (e.g. cupSODA), it makes sense to centralise the code used for getting and setting paths to those executables from default paths and/or environment variables.

This PR adds a small PySB submodule called pathfinder to handle this task.