### PR TITLE
Two small fixes for data types not matching docstrings

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -474,7 +474,7 @@ class ComplexPattern(object):
     ----------
     monomer_patterns : list of MonomerPatterns
         MonomerPatterns that make up the complex.
-    compartment : Compartment
+    compartment : Compartment or None
         Location restriction. None means don't care.
     match_once : bool, optional
         If True, the pattern will only count once against a species in which the

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -154,7 +154,7 @@ class BnglBuilder(Builder):
             cplx_pats = []
             for mp in o.iterfind(_ns('{0}ListOfPatterns/{0}Pattern')):
                 match_once = mp.get('matchOnce')
-                match_once = 1 if match_once == "1" else 0
+                match_once = True if match_once == "1" else False
                 cplx_pats.append(ComplexPattern(self._parse_species(mp),
                                                 compartment=None,
                                                 match_once=match_once))


### PR DESCRIPTION
Two small fixes:
* Updated ComplexPattern docstring to show Compartment can be `None` (otherwise a warning is generated in some IDEs)
* `match_once` should be a boolean in the BNGL importer, not int.