### PR TITLE
Fix BNGL, SBML importers and unit tests on Windows

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -363,7 +363,7 @@ class BngFileInterface(BngBaseInterface):
                     bng_commands = bng_commands.replace('begin actions\n',
                                          'begin actions\n\treadFile({'
                                          'file=>"%s"});\n' % self.net_filename)
-                else:
+                elif self.model:
                     bng_file.write(self.generator.get_content())
                 bng_file.write(bng_commands)
 

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -28,7 +28,6 @@ class BnglBuilder(Builder):
     def __init__(self, filename, force=False):
         super(BnglBuilder, self).__init__()
         with BngFileInterface(model=None) as con:
-            #con.load_bngl(filename)
             con.action('readFile', file=filename, skip_actions=1)
             con.action('writeXML', evaluate_expressions=0)
             con.execute()

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -1,7 +1,7 @@
 from pysb.core import MonomerPattern, ComplexPattern, RuleExpression, \
     ReactionPattern, ANY, WILD
 from pysb.builder import Builder
-from pysb.bng import BngConsole
+from pysb.bng import BngFileInterface
 import xml.etree.ElementTree
 import re
 from sympy.parsing.sympy_parser import parse_expr
@@ -27,9 +27,11 @@ class BnglBuilder(Builder):
     """
     def __init__(self, filename, force=False):
         super(BnglBuilder, self).__init__()
-        with BngConsole(model=None) as con:
-            con.load_bngl(filename)
+        with BngFileInterface(model=None) as con:
+            #con.load_bngl(filename)
+            con.action('readFile', file=filename, skip_actions=1)
             con.action('writeXML', evaluate_expressions=0)
+            con.execute()
             self._force = force
             self._x = xml.etree.ElementTree.parse('%s.xml' %
                                                   con.base_filename)\

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -1,6 +1,9 @@
 from pysb.testing import *
 from pysb import *
 from pysb.bng import *
+from nose.plugins.skip import SkipTest
+import os
+
 
 @with_model
 def test_generate_network():
@@ -14,8 +17,11 @@ def test_generate_network():
     Rule('degrade', A() >> None, k)
     ok_(generate_network(model))
 
+
 @with_model
 def test_simulate_network_console():
+    if os.name == 'nt':
+        raise SkipTest('BNG Console does not work on Windows')
     Monomer('A')
     Parameter('A_0', 1)
     Initial(A(), A_0)
@@ -25,6 +31,7 @@ def test_simulate_network_console():
     with BngConsole(model, suppress_warnings=True) as bng:
         bng.generate_network(overwrite=True)
         bng.action('simulate', method='ssa', t_end=20000, n_steps=100)
+
 
 @with_model
 def test_sequential_simulations():
@@ -47,6 +54,7 @@ def test_sequential_simulations():
         yfull2 = bng.read_simulation_results()
         ok_(yfull2.size == 51)
 
+
 @with_model
 def test_compartment_species_equivalence():
     Parameter('p', 1)
@@ -60,6 +68,7 @@ def test_compartment_species_equivalence():
     for i, (cp, param) in enumerate(model.initial_conditions):
         ok_(cp.is_equivalent_to(model.species[i]))
     ok_(model.species[2].is_equivalent_to(Q(x=1) ** C % R(y=1) ** C))
+
 
 @with_model
 def test_bidirectional_rules_collapse():
@@ -76,6 +85,7 @@ def test_bidirectional_rules_collapse():
     ok_(len(model.reactions_bidirectional[0]['rule']) == 3)
     ok_(model.reactions_bidirectional[0]['reversible'])
 
+
 @with_model
 def test_bidirectional_rules():
     Monomer('A')
@@ -91,6 +101,7 @@ def test_bidirectional_rules():
     ok_(model.reactions_bidirectional[0]['reversible'])
     #TODO Check that 'rate' has 4 terms
 
+
 @with_model
 def test_zero_order_synth_no_initials():
     Monomer('A')
@@ -98,6 +109,7 @@ def test_zero_order_synth_no_initials():
     Rule('Rule1', None >> A(), Parameter('ksynth', 100))
     Rule('Rule2', A() <> B(), Parameter('kf', 10), Parameter('kr', 1))
     generate_equations(model)
+
 
 @with_model
 def test_unicode_strs():

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -1,7 +1,7 @@
 import pysb
 import os
 import pysb.pathfinder as pf
-from pysb.bng import BngConsole
+from pysb.bng import BngFileInterface
 from pysb.importers.bngl import model_from_bngl, BnglImportError
 from pysb.importers.sbml import model_from_sbml
 import numpy
@@ -18,16 +18,18 @@ def bngl_import_compare_simulations(bng_file, force=False,
     m = model_from_bngl(bng_file, force=force)
 
     # Simulate using the BNGL file directly
-    with BngConsole(model=None, suppress_warnings=True) as bng:
-        bng.load_bngl(bng_file)
-        bng.generate_network()
+    with BngFileInterface(model=None) as bng:
+        bng.action('readFile', file=bng_file, skip_actions=1)
+        bng.action('generate_network')
         bng.action('simulate', method='ode', sample_times=sim_times)
+        bng.execute()
         yfull1 = bng.read_simulation_results()
 
     # Convert to a PySB model, then simulate using BNG
-    with BngConsole(m, suppress_warnings=True) as bng:
-        bng.generate_network()
+    with BngFileInterface(model=m) as bng:
+        bng.action('generate_network')
         bng.action('simulate', method='ode', sample_times=sim_times)
+        bng.execute()
         yfull2 = bng.read_simulation_results()
 
     # Check all species trajectories are equal (within numerical tolerance)


### PR DESCRIPTION
This PR adds Windows support for the BNGL and SBML importers, and fixes the unit test suite on that platform. This was done by switching the `BngConsole` calls, which don't work on Windows due to a lack of `pexpect.spawn()` support, to `BngFileInterface`.