### PR TITLE
Handling unicode Observable and Expression names in python 2

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -514,18 +514,15 @@ class SimulationResult(object):
         obs_names = list(model_obs.keys())
 
         if not _allow_unicode_recarray():
-            for i, expr_name in enumerate(expr_names):
-                try:
-                    expr_names[i] = expr_name.encode('ascii')
-                except UnicodeEncodeError:
-                    raise ValueError('Non-ASCII compatible expression '
-                                     'names not allowed')
-            for i, obs_name in enumerate(obs_names):
-                try:
-                    obs_names[i] = obs_name.encode('ascii')
-                except UnicodeEncodeError:
-                    raise ValueError('Non-ASCII compatible observable '
-                                     'names not allowed')
+            for name_list, name_type in zip((expr_names, obs_names),
+                                            ('Expression', 'Observable')):
+                for i, name in enumerate(name_list):
+                    try:
+                        name_list[i] = name.encode('ascii')
+                    except UnicodeEncodeError:
+                        error_msg = 'Non-ASCII compatible' + \
+                                    '%s names not allowed' % name_type
+                        raise ValueError(error_msg)
 
         yobs_dtype = zip(obs_names, itertools.repeat(float)) if obs_names \
             else float
@@ -654,7 +651,7 @@ class SimulationResult(object):
 def _allow_unicode_recarray():
     """Return True if numpy recarray can take unicode data type.
 
-    In python 2, numpy doesn't allow unicode strings are names in arrays even
+    In python 2, numpy doesn't allow unicode strings as names in arrays even
     if they are ascii encodeable. This function tests this directly.
     """
     try:

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -2,7 +2,8 @@ from pysb.testing import *
 import sys
 import copy
 import numpy as np
-from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
+from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression, \
+                 SelfExporter
 from pysb.simulator import ScipyOdeSimulator, SimulatorException
 from pysb.examples import robertson, earm_1_0
 
@@ -265,6 +266,7 @@ def test_unicode_obsname_ascii():
     sim = ScipyOdeSimulator(rob_copy)
     simres = sim.run(tspan=t)
 
+
 if sys.version_info[0] < 3:
     @raises(ValueError)
     def test_unicode_obsname_nonascii():
@@ -272,6 +274,34 @@ if sys.version_info[0] < 3:
         t = np.linspace(0, 100)
         rob_copy = copy.deepcopy(robertson.model)
         rob_copy.observables[0].name = u'A_total\u1234'
+        sim = ScipyOdeSimulator(rob_copy)
+        simres = sim.run(tspan=t)
+
+
+def test_unicode_exprname_ascii():
+    """Ensure ascii-convetible unicode expression names are handled."""
+    t = np.linspace(0, 100)
+    rob_copy = copy.deepcopy(robertson.model)
+    SelfExporter.do_export = False
+    ab = rob_copy.observables['A_total'] + rob_copy.observables['B_total']
+    expr = Expression(u'A_plus_B', ab)
+    rob_copy.add_component(expr)
+    SelfExporter.do_export = True
+    sim = ScipyOdeSimulator(rob_copy)
+    simres = sim.run(tspan=t)
+
+
+if sys.version_info[0] < 3:
+    @raises(ValueError)
+    def test_unicode_exprname_nonascii():
+        """Ensure non-ascii unicode expression names error in python 2."""
+        t = np.linspace(0, 100)
+        rob_copy = copy.deepcopy(robertson.model)
+        SelfExporter.do_export = False
+        ab = rob_copy.observables['A_total'] + rob_copy.observables['B_total']
+        expr = Expression(u'A_plus_B\u1234', ab)
+        rob_copy.add_component(expr)
+        SelfExporter.do_export = True
         sim = ScipyOdeSimulator(rob_copy)
         simres = sim.run(tspan=t)
 

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -2,8 +2,7 @@ from pysb.testing import *
 import sys
 import copy
 import numpy as np
-from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression, \
-                 SelfExporter
+from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.simulator import ScipyOdeSimulator, SimulatorException
 from pysb.examples import robertson, earm_1_0
 
@@ -282,11 +281,9 @@ def test_unicode_exprname_ascii():
     """Ensure ascii-convetible unicode expression names are handled."""
     t = np.linspace(0, 100)
     rob_copy = copy.deepcopy(robertson.model)
-    SelfExporter.do_export = False
     ab = rob_copy.observables['A_total'] + rob_copy.observables['B_total']
-    expr = Expression(u'A_plus_B', ab)
+    expr = Expression(u'A_plus_B', ab, _export=False)
     rob_copy.add_component(expr)
-    SelfExporter.do_export = True
     sim = ScipyOdeSimulator(rob_copy)
     simres = sim.run(tspan=t)
 
@@ -297,11 +294,9 @@ if sys.version_info[0] < 3:
         """Ensure non-ascii unicode expression names error in python 2."""
         t = np.linspace(0, 100)
         rob_copy = copy.deepcopy(robertson.model)
-        SelfExporter.do_export = False
         ab = rob_copy.observables['A_total'] + rob_copy.observables['B_total']
-        expr = Expression(u'A_plus_B\u1234', ab)
+        expr = Expression(u'A_plus_B\u1234', ab, _export=False)
         rob_copy.add_component(expr)
-        SelfExporter.do_export = True
         sim = ScipyOdeSimulator(rob_copy)
         simres = sim.run(tspan=t)
 

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -1,4 +1,6 @@
 from pysb.testing import *
+import sys
+import copy
 import numpy as np
 from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.simulator import ScipyOdeSimulator, SimulatorException
@@ -253,3 +255,23 @@ def test_nonexistent_integrator():
     """Ensure nonexistent integrator raises."""
     ScipyOdeSimulator(robertson.model, tspan=np.linspace(0, 1, 2),
                       integrator='does_not_exist')
+
+
+def test_unicode_obsname_ascii():
+    """Ensure ascii-convetible unicode observable names are handled."""
+    t = np.linspace(0, 100)
+    rob_copy = copy.deepcopy(robertson.model)
+    rob_copy.observables[0].name = u'A_total'
+    sim = ScipyOdeSimulator(rob_copy)
+    simres = sim.run(tspan=t)
+
+if sys.version_info[0] < 3:
+    @raises(ValueError)
+    def test_unicode_obsname_nonascii():
+        """Ensure non-ascii unicode observable names error in python 2."""
+        t = np.linspace(0, 100)
+        rob_copy = copy.deepcopy(robertson.model)
+        rob_copy.observables[0].name = u'A_total\u1234'
+        sim = ScipyOdeSimulator(rob_copy)
+        simres = sim.run(tspan=t)
+


### PR DESCRIPTION
Due to a numpy issue, unicode Observable and Expression names (even if they are ASCII encodeable) in python 2 error when creating the output arrays of simulation in `pysb.simulator.base`. This pull request adds a function to test for numpy.ndarray with unicode explicitly (rather than testing for python version) and if it is not allowed in the current environment, the Observable and Expression names are ascii-encoded. In case a UnicodeEncodingError is encountered in this process, it is raised.