### PR TITLE
Much faster expression evaluation by pulling lambdify out of loop

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,7 +54,7 @@ copyright = u'2012, C. F. Lopez, J. L. Muhlich, J. A. Bachman'
 MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy',  'sympy.parsing',
                  'sympy.parsing.sympy_parser',
                  'sympy.printing', 'sympy.printing.mathml', 'numpy',
-                 'scipy', 'scipy.integrate' ]
+                 'scipy', 'scipy.integrate', 'scipy.constants' ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.MagicMock()
 sys.modules['sympy'].Symbol = type('Symbol', (object,), {})

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -6,7 +6,7 @@ import collections
 import numbers
 from pysb.core import MonomerPattern, ComplexPattern, as_complex_pattern, \
                       Component
-from pysb.logging import get_logger
+from pysb.logging import get_logger, EXTENDED_DEBUG
 import logging
 
 try:
@@ -542,20 +542,24 @@ class SimulationResult(object):
         param_values = simulator.param_values
 
         # loop over simulations
+        sym_names = obs_names + [p.name for p in self._model.parameters]
+        expanded_exprs = [sympy.lambdify(sym_names, expr.expand_expr(),
+                                         "numpy") for expr in exprs]
         for n in range(self.nsims):
+            simulator._logger.log(EXTENDED_DEBUG, 'Evaluating exprs/obs %d/%d'
+                                  % (n + 1, self.nsims))
+
             # observables
             for i, obs in enumerate(model_obs):
                 self._yobs_view[n][:, i] = (
                     self._y[n][:, obs.species] * obs.coefficients).sum(axis=1)
 
             # expressions
-            obs_dict = dict((k, self._yobs[n][k]) for k in obs_names)
-            subs = dict((p, param_values[n][i]) for i, p in
-                        enumerate(self._model.parameters))
+            sym_dict = dict((k, self._yobs[n][k]) for k in obs_names)
+            sym_dict.update(dict((p.name, param_values[n][i]) for i, p in
+                            enumerate(self._model.parameters)))
             for i, expr in enumerate(exprs):
-                expr_subs = expr.expand_expr().subs(subs)
-                func = sympy.lambdify(obs_names, expr_subs, "numpy")
-                self._yexpr_view[n][:, i] = func(**obs_dict)
+                self._yexpr_view[n][:, i] = expanded_exprs[i](**sym_dict)
 
         simulator._logger.debug('SimulationResult constructor finished')
 


### PR DESCRIPTION
sympy.lambdify is relatively slow, and was unnecessarily being evaluated for
every simulation during `SimulationResult` construction. I've refactored the
`SimulationResult` constructor so that each expression is only lamdbified
once, which greatly increases speed. On my laptop, running 25 simulations
with a 202 expression model, the total time went from >12 minutes to
<12 seconds.

Also included is a one line fix for the broken [`pysb.simulator` readthedocs module](http://pysb.readthedocs.io/en/latest/modules/simulator.html) (empty at the time of writing).