### PR TITLE
Read Expression values from BNG .gdat files

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -182,26 +182,26 @@ class BngBaseInterface(object):
         """
         # Read concentrations data
         cdat_arr = numpy.loadtxt(self.base_filename + '.cdat', skiprows=1)
+        names = ['time'] + ['__s%d' % i for i in range(cdat_arr.shape[1]-1)] # -1 for time column
+
         # Read groups data
-        if self.model and len(self.model.observables):
+        if os.path.isfile(self.base_filename + '.gdat'):
+            f = open(self.base_filename + '.gdat', 'r')
+            names += f.readline().split()[2:] # exclude \# and time column
+            f.close()
             # Exclude first column (time)
             gdat_arr = numpy.loadtxt(self.base_filename + '.gdat',
                                      skiprows=1)[:,1:]
         else:
             gdat_arr = numpy.ndarray((len(cdat_arr), 0))
-
-        # -1 for time column
-        names = ['time'] + ['__s%d' % i for i in range(cdat_arr.shape[1]-1)]
+        
         yfull_dtype = list(zip(names, itertools.repeat(float)))
-        if self.model and len(self.model.observables):
-            yfull_dtype += list(zip(self.model.observables.keys(),
-                                    itertools.repeat(float)))
         yfull = numpy.ndarray(len(cdat_arr), yfull_dtype)
 
         yfull_view = yfull.view(float).reshape(len(yfull), -1)
-        yfull_view[:, :len(names)] = cdat_arr
-        yfull_view[:, len(names):] = gdat_arr
-
+        yfull_view[:, :cdat_arr.shape[1]] = cdat_arr
+        yfull_view[:, cdat_arr.shape[1]:] = gdat_arr
+        
         return yfull
 
 

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -14,8 +14,6 @@ from warnings import warn
 import shutil
 import collections
 import pysb.pathfinder as pf
-from pysb.simulator import SimulationResult
-
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -205,7 +203,6 @@ class BngBaseInterface(object):
                 names += f.readline().split()[2:]
                 # Exclude first column (time)
                 gdat_arr = numpy.loadtxt(f)
-                print(gdat_arr)
                 if cdat_arr is None:
                     cdat_arr = numpy.ndarray((len(gdat_arr), 0))
                 else:

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -112,6 +112,37 @@ def test_zero_order_synth_no_initials():
 
 
 @with_model
+def test_nfsim():
+    Monomer('A', ['a'])
+    Monomer('B', ['b'])
+
+    Parameter('ksynthA', 100)
+    Parameter('ksynthB', 100)
+    Parameter('kbindAB', 100)
+
+    Parameter('A_init', 20)
+    Parameter('B_init', 30)
+
+    Initial(A(a=None), A_init)
+    Initial(B(b=None), B_init)
+
+    Observable("A_free", A(a=None))
+    Observable("B_free", B(b=None))
+    Observable("AB_complex", A(a=1) % B(b=1))
+
+    Rule('A_synth', None >> A(a=None), ksynthA)
+    Rule('B_synth', None >> B(b=None), ksynthB)
+    Rule('AB_bind', A(a=None) + B(b=None) >> A(a=1) % B(b=1), kbindAB)
+
+    with BngFileInterface(model) as bng:
+        bng.action('simulate', method='nf', t_end=1000, n_steps=100)
+        bng.execute()
+        res = bng.read_simulation_results()
+        assert res.dtype.names == ('time', 'A_free', 'B_free', 'AB_complex')
+        assert len(res) == 101
+
+
+@with_model
 def test_unicode_strs():
     Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
     Monomer(u'B')


### PR DESCRIPTION
Modified pysb.bng.BngBaseInterface.read_simulation_results() to read in header names from the .gdat file rather than set the names equal to the names of model.observables. This is necessary because BNG can be instructed to print function (Expression) values to the .gdat file with the 'print_functions=1' argument. This also required changing the 'if' statement from a check on whether model.observables exists to whether the .gdat file exists (since, in principle, the .gdat file could contain only functions).