### PR TITLE
Fix PysbFlatExporter with compartmental models

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -857,8 +857,13 @@ class Compartment(Component):
         self.size = size
 
     def __repr__(self):
-        return  '%s(name=%s, parent=%s, dimension=%s, size=%s)' % \
-            (self.__class__.__name__, repr(self.name), repr(self.parent), repr(self.dimension), repr(self.size))
+        return '%s(name=%s, parent=%s, dimension=%s, size=%s)' % (
+            self.__class__.__name__,
+            repr(self.name),
+            'None' if self.parent is None else self.parent.name,
+            repr(self.dimension),
+            'None' if self.size is None else self.size.name
+        )
 
 
 class Rule(Component):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1468,10 +1468,10 @@ class Model(object):
         source_cp = as_complex_pattern(self.monomers['__source']())
         if self.compartments:
             for c in self.compartments:
-                source_cp.compartment = c
-                if not any(source_cp.is_equivalent_to(other_cp) for
+                source_cp_cpt = source_cp ** c
+                if not any(source_cp_cpt.is_equivalent_to(other_cp) for
                            other_cp, value in self.initial_conditions):
-                    self.initial(source_cp, self.parameters['__source_0'])
+                    self.initial(source_cp_cpt, self.parameters['__source_0'])
         else:
             if not any(source_cp.is_equivalent_to(other_cp) for other_cp, value in self.initial_conditions):
                 self.initial(source_cp, self.parameters['__source_0'])

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -443,6 +443,8 @@ class MonomerPattern(object):
 
     def __pow__(self, other):
         if isinstance(other, Compartment):
+            if self.compartment is not None:
+                raise CompartmentAlreadySpecifiedError()
             mp_new = self()
             mp_new.compartment = other
             return mp_new
@@ -626,6 +628,8 @@ class ComplexPattern(object):
 
     def __pow__(self, other):
         if isinstance(other, Compartment):
+            if self.compartment is not None:
+                raise CompartmentAlreadySpecifiedError()
             cp_new = self.copy()
             cp_new.compartment = other
             return cp_new
@@ -1456,7 +1460,7 @@ class Model(object):
         source_cp = as_complex_pattern(self.monomers['__source']())
         if self.compartments:
             for c in self.compartments:
-                source_cp = source_cp ** c
+                source_cp.compartment = c
                 if not any(source_cp.is_equivalent_to(other_cp) for
                            other_cp, value in self.initial_conditions):
                     self.initial(source_cp, self.parameters['__source_0'])
@@ -1528,6 +1532,9 @@ class DuplicateSiteError(ValueError):
     pass
 
 class UnknownSiteError(ValueError):
+    pass
+
+class CompartmentAlreadySpecifiedError(ValueError):
     pass
 
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -516,15 +516,22 @@ class ComplexPattern(object):
         """Checks for equality with another ComplexPattern"""
         # Didn't implement __eq__ to avoid confusion with __ne__ operator used for Rule building
 
+        # Check both patterns are concrete
+        assert self.is_concrete(), "%s is not a concrete pattern (species)" \
+                                   % repr(self)
+        assert other.is_concrete(), "%s is not a concrete pattern (species)" \
+                                    % repr(other)
+
         # FIXME the literal site_conditions comparison requires bond numbering to be identical,
         #   so some sort of canonicalization of that numbering is necessary.
         if not isinstance(other, ComplexPattern):
             raise Exception("Can only compare ComplexPattern to another ComplexPattern")
         mp_order = lambda mp: (mp[0], mp[1].keys(), mp[2])
-        return (self.compartment == other.compartment and
-                sorted([(repr(mp.monomer), mp.site_conditions, mp.compartment)
+        return (sorted([(repr(mp.monomer), mp.site_conditions,
+                         mp.compartment or self.compartment)
                        for mp in self.monomer_patterns], key=mp_order) ==
-                sorted([(repr(mp.monomer), mp.site_conditions, mp.compartment)
+                sorted([(repr(mp.monomer), mp.site_conditions,
+                         mp.compartment or other.compartment)
                        for mp in other.monomer_patterns], key=mp_order))
 
     def copy(self):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -515,19 +515,27 @@ class ComplexPattern(object):
         return mp_concrete_ok or compartment_ok
 
     def is_equivalent_to(self, other):
-        """Checks for equality with another ComplexPattern"""
-        # Didn't implement __eq__ to avoid confusion with __ne__ operator used for Rule building
+        """
+        Test a concrete ComplexPattern for equality with another.
+
+        Use of this method on non-concrete ComplexPatterns was previously
+        allowed, but is now deprecated.
+        """
+
+        # Didn't implement __eq__ to avoid confusion with __ne__ operator used
+        # for Rule building
 
         # Check both patterns are concrete
-        assert self.is_concrete(), "%s is not a concrete pattern (species)" \
-                                   % repr(self)
-        assert other.is_concrete(), "%s is not a concrete pattern (species)" \
-                                    % repr(other)
+        if not self.is_concrete() or not other.is_concrete():
+            warnings.warn("is_equivalent_to() will only work with concrete "
+                          "patterns in a future version", DeprecationWarning)
 
-        # FIXME the literal site_conditions comparison requires bond numbering to be identical,
-        #   so some sort of canonicalization of that numbering is necessary.
+        # FIXME the literal site_conditions comparison requires bond numbering
+        # to be identical, so some sort of canonicalization of that
+        # numbering is necessary.
         if not isinstance(other, ComplexPattern):
-            raise Exception("Can only compare ComplexPattern to another ComplexPattern")
+            raise Exception("Can only compare ComplexPattern to another "
+                            "ComplexPattern")
         mp_order = lambda mp: (mp[0], mp[1].keys(), mp[2])
         return (sorted([(repr(mp.monomer), mp.site_conditions,
                          mp.compartment or self.compartment)

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -1,6 +1,8 @@
 from pysb.testing import *
 from pysb.core import *
 from functools import partial
+import itertools
+
 
 def test_component_names_valid():
     for name in 'a', 'B', 'AbC', 'dEf', '_', '_7', '__a01b__999x_x___':
@@ -132,5 +134,35 @@ def test_complex_pattern_call():
 def test_monomer_unicode():
     Monomer(u'A', [u's'], {u's': [u's1', u's2']})
 
-if __name__ == '__main__':
-    test_monomer_unicode()
+
+def _check_pattern_equivalence(complex_pattern_list, equivalent=True):
+    """ Check all complex pattern permutations are equivalent (or not) """
+    for cp0, cp1 in itertools.permutations(complex_pattern_list, 2):
+        assert cp0.is_equivalent_to(cp1) == equivalent
+
+
+@with_model
+def test_complex_pattern_equivalence_compartments():
+    Monomer('A')
+    Monomer('B')
+
+    Compartment('C1')
+    Compartment('C2')
+
+    cp0 = ComplexPattern([A()], compartment=C1)  # Only species compartment
+    cp1 = as_complex_pattern(A() ** C1)          # Only monomer compartment
+    cp2 = ComplexPattern([A() ** C1], compartment=C1)  # Both compartments
+
+    _check_pattern_equivalence((cp0, cp1, cp2))
+
+    cp3 = (A() % B()) ** C1
+    cp4 = A() ** C1 % B() ** C1
+    cp5 = (A() ** C1 % B()) ** C1
+    # Species compartment is ignored if all monomer patterns have a compartment
+    cp6 = (A() ** C1 % B() ** C1) ** C2
+
+    _check_pattern_equivalence((cp3, cp4, cp5, cp6))
+
+    # Species compartment should not override a specified monomer compartment
+    cp7 = (A() ** C1 % B() ** C2) ** C1
+    _check_pattern_equivalence((cp5, cp7), equivalent=False)

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -166,3 +166,12 @@ def test_complex_pattern_equivalence_compartments():
     # Species compartment should not override a specified monomer compartment
     cp7 = (A() ** C1 % B() ** C2) ** C1
     _check_pattern_equivalence((cp5, cp7), equivalent=False)
+
+    # Test enable_synth_deg creates two initial conditions, one for each
+    # compartment
+    model.enable_synth_deg()
+    assert len(model.initial_conditions) == 2
+
+    # Check that enable_synth_deg is idempotent
+    model.enable_synth_deg()
+    assert len(model.initial_conditions) == 2


### PR DESCRIPTION
The PysbFlatExporter fails with compartmental models due to `Compartment`'s
`repr()` implementation, which means parameters and parent compartments
get printed in full rather than just their name, which leads to a
`ComponentDuplicateNameError` with compartmental models when using the
PysbFlatExporter. This PR fixes the issue.

Resolves: pysb/pysb#210