### PR TITLE
KaSa interface fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_install:
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-- opam install ocamlfind --yes
+#- opam install ocamlfind --yes
+- opam install -y conf-which base-bytes
+- opam install -y ocamlbuild yojson
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_install:
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
-- git checkout f87eada
+# KaSim version as of 5/1/2017
+- git checkout 0733210
 - make all
 - export KAPPAPATH=`pwd`
 - cd ../

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -267,18 +267,19 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
     # Contact map args:
     if contact_map:
         cm_args = ['--compute-contact-map', '--output-contact-map',
-                   os.path.basename(cm_filename)]
+                   os.path.basename(cm_filename),
+                   '--output-contact-map-directory', base_directory]
     else:
         cm_args = ['--no-compute-contact-map']
     # Influence map args:
     if influence_map:
         im_args = ['--compute-influence-map', '--output-influence-map',
-                   os.path.basename(im_filename)]
+                   os.path.basename(im_filename),
+                   '--output-influence-map-directory', base_directory]
     else:
         im_args = ['--no-compute-influence-map']
     # Full arg list
-    args = [kappa_filename, '--output-directory', base_directory] \
-            + cm_args + im_args
+    args = [kappa_filename] + cm_args + im_args
 
     # Generate the Kappa model code from the PySB model and write it to
     # the Kappa file:

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -15,8 +15,8 @@ _path_config = {
         'executable': 'KaSa',
         'env_var': 'KAPPAPATH',
         'search_paths': {
-            'posix': ('/usr/local/share/KaSim', ),
-            'nt': ('c:/Program Files/KaSim', )
+            'posix': ('/usr/local/share/KaSa', ),
+            'nt': ('c:/Program Files/KaSa', )
         }
     },
     'kasim': {


### PR DESCRIPTION
This PR introduces some small changes to the Kappa interface in PySB to make static analysis (generating contact maps and influence maps) compatible with the 4th generation Kappa tools. First, the executable for static analysis changes from KaSim to KaSa, and second, the output folders for contact map and influence map have to be specified separately.