### PR TITLE
Allow rxn rate params/exprs with sympy fn names

### DIFF
--- a/doc/modules/importers/index.rst
+++ b/doc/modules/importers/index.rst
@@ -5,4 +5,4 @@ Importing from other formats (:py:mod:`pysb.importers`)
    :members: model_from_bngl
 
 .. automodule:: pysb.importers.sbml
-   :members: model_from_sbml, sbml_translator
+   :members: model_from_sbml, model_from_biomodels, sbml_translator

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -632,7 +632,9 @@ def _parse_reaction(model, line):
     rule_name, is_reverse = zip(*[re.subn('^_reverse_|\(reverse\)$', '', r) for r in rule_list])
     is_reverse = tuple(bool(i) for i in is_reverse)
     r_names = ['__s%d' % r for r in reactants]
-    combined_rate = sympy.Mul(*[sympy.S(t) for t in r_names + rate])
+    rate_param = [model.parameters.get(r) or model.expressions.get(r) or
+                  float(r) for r in rate]
+    combined_rate = sympy.Mul(*[sympy.S(t) for t in r_names + rate_param])
     reaction = {
         'reactants': reactants,
         'products': products,

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -118,3 +118,12 @@ def test_unicode_strs():
     Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
     generate_equations(model)
+
+
+@with_model
+def test_sympy_parameter_keyword():
+    Monomer('A')
+    Initial(A(), Parameter('A_0', 100))
+    Parameter('deg', 10)  # deg is a sympy function
+    Rule('Rule1', A() >> None, deg)
+    generate_equations(model)


### PR DESCRIPTION
Defining a parameter or expression using a sympy function name (e.g.
`deg`) will cause the following error:

    SympifyError: SympifyError: <function deg at 0x10f0d0140>

The error is down to `_parse_reaction` in bng.py, which runs `sympy.S(x)`
where `x` is a string such as `'deg'`. Converting the string to the relevant
parameter or expression object resolves this.

Resolves: pysb/pysb#259