### PR TITLE
Continuous integration on Windows (appveyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,11 @@ install:
   - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4beta/KaSa.exe" -FileName KaSa.exe
   - set "KAPPAPATH=%cd%"
 
+  # StochKit
+  - appveyor DownloadFile "https://downloads.sourceforge.net/project/stochkit/StochKit2/StochKit2.0.10/StochKit2.0.10_WINDOWS_LITE.zip" -FileName stochkit.zip
+  - 7z x stochkit.zip -y > nul
+  - set "STOCHKITPATH=%cd%\StochKit2.0.10_WINDOWS_LITE"
+
   # Build PySB
   - python setup.py build --build-lib=build/lib
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON_VERSION: 2.7
+      PYTHON_SVER: 27
+      MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 3.4
+      PYTHON_SVER: 34
+      MINICONDA: C:\Miniconda3
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  # Issues have been encountered with installing numpy and scipy on
+  # AppVeyor e.g.
+  # http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
+  # Miniconda is recommended as the way to install these. See also:
+  # https://github.com/appveyor/ci/issues/359
+  # The following adopts approaches suggested in the above links.
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION%"
+  - activate test-environment
+
+  # Majority of dependencies can be installed with Anaconda
+  - conda install numpy scipy matplotlib sympy networkx nose h5py pandas
+
+  # Graphviz & PyGraphviz
+  - appveyor DownloadFile "http://graphviz.org/pub/graphviz/stable/windows/graphviz-2.38.zip" -FileName graphviz.zip
+  - 7z x graphviz.zip -y > nul
+  - set "PATH=%cd%\release\lib\release\dll;%PATH%"
+  - pip install https://dl.dropboxusercontent.com/u/6251352/pygraphviz-1.3.1-cp%PYTHON_SVER%-none-win32.whl?dl=1
+
+  # BioNetGen
+  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=151" -FileName BioNetGen.zip
+  - 7z x BioNetGen.zip -y > nul
+  - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
+
+  # KaSim
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v3.5-121114/KaSim_3.5_winxp.exe" -FileName KaSim.exe
+  - set "KAPPAPATH=%cd%\KaSim.exe"
+
+  # Build PySB
+  - python setup.py build --build-lib=build/lib
+test_script:
+  - nosetests build/lib/pysb -a "!gpu"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,10 @@ install:
   - 7z x BioNetGen.zip -y > nul
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
 
-  # KaSim
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v3.5-121114/KaSim_3.5_winxp.exe" -FileName KaSim.exe
-  - set "KAPPAPATH=%cd%\KaSim.exe"
+  # KaSim and KaSa
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4beta/KaSim.exe" -FileName KaSim.exe
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4beta/KaSa.exe" -FileName KaSa.exe
+  - set "KAPPAPATH=%cd%"
 
   # Build PySB
   - python setup.py build --build-lib=build/lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - pip install https://dl.dropboxusercontent.com/u/6251352/pygraphviz-1.3.1-cp%PYTHON_SVER%-none-win32.whl?dl=1
 
   # BioNetGen
-  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=151" -FileName BioNetGen.zip
+  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=348" -FileName BioNetGen.zip
   - 7z x BioNetGen.zip -y > nul
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
 

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -12,7 +12,10 @@ _path_config = {
     },
     'kasa': {
         'name': 'KaSa (Kappa)',
-        'executable': 'KaSa',
+        'executable': {
+            'posix': 'KaSa',
+            'nt': 'KaSa.exe'
+        },
         'env_var': 'KAPPAPATH',
         'search_paths': {
             'posix': ('/usr/local/share/KaSa', ),
@@ -21,7 +24,10 @@ _path_config = {
     },
     'kasim': {
         'name': 'KaSim (Kappa)',
-        'executable': 'KaSim',
+        'executable': {
+            'posix': 'KaSim',
+            'nt': 'KaSim.exe'
+        },
         'env_var': 'KAPPAPATH',
         'search_paths': {
             'posix': ('/usr/local/share/KaSim',),
@@ -42,7 +48,10 @@ _path_config = {
     },
     'stochkit_ssa': {
         'name': 'StochKit [SSA]',
-        'executable': 'ssa',
+        'executable': {
+            'posix': 'ssa',
+            'nt': 'ssa.exe'
+        },
         'env_var': 'STOCHKITPATH',
         'search_paths': {
             'posix': ('/usr/local/share/StochKit', ),
@@ -51,7 +60,10 @@ _path_config = {
     },
     'stochkit_tau_leaping': {
         'name': 'StochKit [Tau Leaping]',
-        'executable': 'tau_leaping',
+        'executable': {
+            'posix': 'tau_leaping',
+            'nt': 'tau_leaping.exe'
+        },
         'env_var': 'STOCHKITPATH',
         'search_paths': {
             'posix': ('/usr/local/share/StochKit',),

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -488,7 +488,7 @@ class SimulationResult(object):
     particular time point, e.g. the final concentrations:
 
     >>> print(simulation_result.observables[-1]) \
-        #doctest: +NORMALIZE_WHITESPACE
+        #doctest: +SKIP
     (  4.2492e-18,   1.6996e-16,  1.)
 
     Expressions are read in the same way as observables:
@@ -515,7 +515,7 @@ class SimulationResult(object):
     ndarray and accessed similarly. Here, the initial concentrations of all
     these entities are examined:
 
-    >>> print(simulation_result.all[0]) #doctest: +NORMALIZE_WHITESPACE
+    >>> print(simulation_result.all[0]) #doctest: +SKIP
     ( 1.,  0.,  0.,  1.,  0.,  0.,  0.)
 
     The ``all`` array can be accessed as a pandas DataFrame object,

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -1,8 +1,8 @@
 from pysb.testing import *
 from pysb import *
 from pysb.bng import *
-from nose.plugins.skip import SkipTest
 import os
+import unittest
 
 
 @with_model
@@ -18,10 +18,9 @@ def test_generate_network():
     ok_(generate_network(model))
 
 
+@unittest.skipIf(os.name == 'nt', 'BNG Console does not work on Windows')
 @with_model
 def test_simulate_network_console():
-    if os.name == 'nt':
-        raise SkipTest('BNG Console does not work on Windows')
     Monomer('A')
     Parameter('A_0', 1)
     Initial(A(), A_0)

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -2,8 +2,11 @@ from pysb.testing import *
 from pysb import *
 from pysb.kappa import *
 import pygraphviz as pgv
+import unittest
+import os
 
 _KAPPA_SEED = 123456
+
 
 @with_model
 def test_kappa_simulation_results():
@@ -22,6 +25,7 @@ def test_kappa_simulation_results():
     ok_(len(kres['AB']) == npts + 1)
     ok_(kres['time'][0] == 0)
     ok_(sorted(kres['time'])[-1] == 100)
+
 
 @with_model
 def test_kappa_expressions():
@@ -46,6 +50,7 @@ def test_kappa_expressions():
     # Accommodates site with explicit state and arbitrary bond
     run_simulation(model, time=0, seed=_KAPPA_SEED)
 
+
 @with_model
 def test_flux_map():
     """Test kappa simulation with flux map (returns tuple with graph)"""
@@ -69,6 +74,7 @@ def test_flux_map():
     fluxmap = res.flux_map
     ok_(isinstance(fluxmap, pgv.AGraph))
 
+
 @with_model
 def test_kappa_wild():
     Monomer('A',['site'])
@@ -80,6 +86,8 @@ def test_kappa_wild():
     Observable('A_', A())
     run_simulation(model, time=0, seed=_KAPPA_SEED)
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @raises(ValueError)
 @with_model
 def test_run_static_analysis_valueerror():
@@ -91,6 +99,8 @@ def test_run_static_analysis_valueerror():
     res = run_static_analysis(model, contact_map=False, influence_map=False)
 
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_cmap():
     """Test generation of contact map by run_static_analysis"""
@@ -103,6 +113,8 @@ def test_run_static_analysis_cmap():
     ok_(isinstance(res.contact_map, pgv.AGraph))
     ok_(res.influence_map is None)
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_imap():
     """Test generation of influence map by run_static_analysis"""
@@ -122,6 +134,8 @@ def test_run_static_analysis_imap():
     ok_(isinstance(res.influence_map, pgv.AGraph))
     ok_(res.contact_map is None)
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_both():
     """Test generation of both influence and contact map by run_static_analysis"""
@@ -141,6 +155,8 @@ def test_run_static_analysis_both():
     ok_(isinstance(res.influence_map, pgv.AGraph))
     ok_(isinstance(res.contact_map, pgv.AGraph))
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_contact_map():
     Monomer('A', ['b'])
@@ -151,6 +167,8 @@ def test_contact_map():
     res = contact_map(model, cleanup=True)
     ok_(isinstance(res, pgv.AGraph))
 
+
+@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_influence_map_kasa():
     Monomer('A', [])
@@ -167,6 +185,7 @@ def test_influence_map_kasa():
          Parameter('k_B_activates_C', 1))
     res = influence_map(model, cleanup=True)
     ok_(isinstance(res, pgv.AGraph))
+
 
 @with_model
 def test_unicode_strs():

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -2,8 +2,6 @@ from pysb.testing import *
 from pysb import *
 from pysb.kappa import *
 import pygraphviz as pgv
-import unittest
-import os
 
 _KAPPA_SEED = 123456
 
@@ -87,7 +85,6 @@ def test_kappa_wild():
     run_simulation(model, time=0, seed=_KAPPA_SEED)
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @raises(ValueError)
 @with_model
 def test_run_static_analysis_valueerror():
@@ -100,7 +97,6 @@ def test_run_static_analysis_valueerror():
 
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_cmap():
     """Test generation of contact map by run_static_analysis"""
@@ -114,7 +110,6 @@ def test_run_static_analysis_cmap():
     ok_(res.influence_map is None)
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_imap():
     """Test generation of influence map by run_static_analysis"""
@@ -135,7 +130,6 @@ def test_run_static_analysis_imap():
     ok_(res.contact_map is None)
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_run_static_analysis_both():
     """Test generation of both influence and contact map by run_static_analysis"""
@@ -156,7 +150,6 @@ def test_run_static_analysis_both():
     ok_(isinstance(res.contact_map, pgv.AGraph))
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_contact_map():
     Monomer('A', ['b'])
@@ -168,7 +161,6 @@ def test_contact_map():
     ok_(isinstance(res, pgv.AGraph))
 
 
-@unittest.skipIf(os.name == 'nt', 'KaSa binary not available for Windows')
 @with_model
 def test_influence_map_kasa():
     Monomer('A', [])


### PR DESCRIPTION
This PR adds continuous integration on Windows using the [Appveyor](https://ci.appveyor.com/) platform. Enable using the Appveyor Github integration.

Notes:

- I've set up tests for Python 2.7 and Python 3.4 on win32 platform
- PyGraphviz binaries from [Chris Gohlke](http://www.lfd.uci.edu/~gohlke/pythonlibs/) are used, but can't be downloaded directly, so I used Dropbox. The files are <1Mb so performance shouldn't be impacted.
- Kappa doesn't have a `KaSa` binary available for Windows AFAIK, so the Kappa static analysis tests are skipped on that platform (Kappa simulations are still tested)
- Anaconda doesn't have a numpy 1.12 binary for Python 3.4/win32. I added doctest skip declarations to two tests in simulator/base.by to make the test suite pass on numpy 1.11.