### PR TITLE
Kappa4 interface fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ before_install:
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
-- git checkout f87eada
+# KaSim version as of 5/1/2017
+- git checkout 0733210
 - make all
 - export KAPPAPATH=`pwd`
 - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_install:
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-- opam install ocamlfind --yes
+#- opam install ocamlfind --yes
+- opam install -y conf-which base-bytes
+- opam install -y ocamlbuild yojson
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
 - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-#- opam install ocamlfind --yes
 - opam install -y conf-which base-bytes
 - opam install -y ocamlbuild yojson
 # Install KaSim/KaSa

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ standard scientific Python libraries such as `NumPy`_, `SciPy`_ and `SymPy`_ to
 enable model simulation and analysis.
 
 .. _BNGL: http://www.bionetgen.org
-.. _Kappa: http://www.kappalanguage.org
+.. _Kappa: http://dev.executableknowledge.org
 .. _NumPy: http://numpy.scipy.org
 .. _SciPy: http://www.scipy.org
 .. _SymPy: http://sympy.org

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -922,7 +922,7 @@ hierarchical name of the module from which ``Model()`` is called, e.g.
 
 .. _BioNetGen: http://bionetgen.org/index.php/Documentation
 
-.. _Kappa: http://www.kappalanguage.org/documentation
+.. _Kappa: http://dev.executableknowledge.org/docs/KaSim-manual-master/KaSim_manual.htm
 
 .. _extrinsic apoptosis signaling: http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.0060299
 

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -408,12 +408,10 @@ def _parse_kasim_outfile(out_filename):
         array with the names of the observables.
     """
     try:
-        with open(out_filename, 'r') as fh:
-            while True:
-                header_line = fh.readline()
-                # Break when the first non-comment line is found
-                if not header_line.startswith('#'):
-                    break
+        fh = open(out_filename, 'r')
+        for header_line in fh:
+            if header_line[0] != '#':
+                break
 
         raw_names = [term.strip() for term in re.split(',', header_line)]
         column_names = []
@@ -434,7 +432,7 @@ def _parse_kasim_outfile(out_filename):
         dt = list(zip(column_names, ('float', ) * len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
-        arr = np.loadtxt(out_filename, dtype=float, skiprows=3, delimiter=',')
+        arr = np.loadtxt(fh, dtype=float, delimiter=',')
         recarr = arr.view(dt)
     except Exception as e:
         raise Exception("problem parsing KaSim outfile: " + str(e))

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -410,16 +410,17 @@ def _parse_kasim_outfile(out_filename):
 
     try:
         out_file = open(out_filename, 'r')
+        preamble_len = 2 # First 2 lines are comments
+        [out_file.readline() for i in range(preamble_len)]
 
-        line = out_file.readline().strip()  # Get the first line
+        header_line = out_file.readline().strip()  # Get the header line
         out_file.close()
-        line = line[2:]  # strip off opening '# '
-        raw_names = re.split(' ', line)
+        raw_names = [term.strip() for term in re.split(',', header_line)]
         column_names = []
 
         # Get rid of the quotes surrounding the observable names
         for raw_name in raw_names:
-            mo = re.match("'(.*)'", raw_name)
+            mo = re.match('"(.*)"', raw_name)
             if (mo):
                 column_names.append(mo.group(1))
             else:
@@ -429,7 +430,7 @@ def _parse_kasim_outfile(out_filename):
         dt = list(zip(column_names, ('float', ) * len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
-        arr = np.loadtxt(out_filename, dtype=float, skiprows=1)
+        arr = np.loadtxt(out_filename, dtype=float, skiprows=3)
         recarr = arr.view(dt)
     except Exception as e:
         raise Exception("problem parsing KaSim outfile: " + str(e))

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -73,11 +73,14 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
         The model to simulate/analyze using KaSim.
     time : number
         The amount of time (in arbitrary units) to run a simulation.
-        Identical to the -t argument when using KaSim at the command line.
+        Identical to the -u time -l argument when using KaSim at the command
+        line.
         Default value is 10000. If set to 0, no simulation will be run.
     points : integer
         The number of data points to collect for plotting.
-        Identical to the -p argument when using KaSim at the command line.
+        Note that this is not identical to the -p argument of KaSim when
+        called from the command line, which denotes plot period (time interval
+        between points in plot).
         Default value is 200. Note that the number of points actually returned
         by the simulator will be points + 1 (including the 0 point).
     cleanup : boolean
@@ -138,8 +141,12 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
     fm_filename = base_filename + '_fm.dot'
     out_filename = base_filename + '.out'
 
-    args = ['-i', kappa_filename, '-t', str(time), '-p', str(points),
-            '-o', out_filename]
+    if points == 0:
+        raise ValueError('The number of data points cannot be zero.')
+    plot_period = (1.0 * time / points) if time > 0 else 1.0
+
+    args = ['-i', kappa_filename, '-u', 'time', '-l', str(time),
+            '-p', '%.5f' % plot_period, '-o', out_filename]
 
     if seed:
         args.extend(['-seed', str(seed)])

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -421,8 +421,12 @@ def _parse_kasim_outfile(out_filename):
         # Get rid of the quotes surrounding the observable names
         for raw_name in raw_names:
             mo = re.match('"(.*)"', raw_name)
-            if (mo):
-                column_names.append(mo.group(1))
+            if mo:
+                name = mo.group(1)
+                # Rename the time column to remain backwards compatible
+                if name == '[T]':
+                    name = 'time'
+                column_names.append(name)
             else:
                 column_names.append(raw_name)
 
@@ -430,7 +434,7 @@ def _parse_kasim_outfile(out_filename):
         dt = list(zip(column_names, ('float', ) * len(column_names)))
 
         # Load the output file as a numpy record array, skip the name row
-        arr = np.loadtxt(out_filename, dtype=float, skiprows=3)
+        arr = np.loadtxt(out_filename, dtype=float, skiprows=3, delimiter=',')
         recarr = arr.view(dt)
     except Exception as e:
         raise Exception("problem parsing KaSim outfile: " + str(e))

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -143,7 +143,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
 
     if points == 0:
         raise ValueError('The number of data points cannot be zero.')
-    plot_period = (1.0 * time / points) if time > 0 else 1.0
+    plot_period = (float(time) / points) if time > 0 else 1.0
 
     args = ['-i', kappa_filename, '-u', 'time', '-l', str(time),
             '-p', '%.5f' % plot_period, '-o', out_filename]
@@ -407,14 +407,14 @@ def _parse_kasim_outfile(out_filename):
         simulation. Data for the observables can be accessed by indexing the
         array with the names of the observables.
     """
-
     try:
-        out_file = open(out_filename, 'r')
-        preamble_len = 2 # First 2 lines are comments
-        [out_file.readline() for i in range(preamble_len)]
+        with open(out_filename, 'r') as fh:
+            while True:
+                header_line = fh.readline()
+                # Break when the first non-comment line is found
+                if not header_line.startswith('#'):
+                    break
 
-        header_line = out_file.readline().strip()  # Get the header line
-        out_file.close()
         raw_names = [term.strip() for term in re.split(',', header_line)]
         column_names = []
 

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -267,18 +267,19 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
     # Contact map args:
     if contact_map:
         cm_args = ['--compute-contact-map', '--output-contact-map',
-                   os.path.basename(cm_filename)]
+                   os.path.basename(cm_filename),
+                   '--output-contact-map-directory', base_directory]
     else:
         cm_args = ['--no-compute-contact-map']
     # Influence map args:
     if influence_map:
         im_args = ['--compute-influence-map', '--output-influence-map',
-                   os.path.basename(im_filename)]
+                   os.path.basename(im_filename),
+                   '--output-influence-map-directory', base_directory]
     else:
         im_args = ['--no-compute-influence-map']
     # Full arg list
-    args = [kappa_filename, '--output-directory', base_directory] \
-            + cm_args + im_args
+    args = [kappa_filename] + cm_args + im_args
 
     # Generate the Kappa model code from the PySB model and write it to
     # the Kappa file:

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -15,8 +15,8 @@ _path_config = {
         'executable': 'KaSa',
         'env_var': 'KAPPAPATH',
         'search_paths': {
-            'posix': ('/usr/local/share/KaSim', ),
-            'nt': ('c:/Program Files/KaSim', )
+            'posix': ('/usr/local/share/KaSa', ),
+            'nt': ('c:/Program Files/KaSa', )
         }
     },
     'kasim': {

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -21,7 +21,6 @@ def test_kappa_simulation_results():
     Observable('AB', A(b=1) % B(b=1))
     npts = 200
     kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
-    import ipdb; ipdb.set_trace()
     ok_(len(kres['time']) == npts + 1)
     ok_(len(kres['AB']) == npts + 1)
     ok_(kres['time'][0] == 0)
@@ -40,6 +39,8 @@ def test_kappa_expressions():
     Rule('dimerize_rev',
          A(site=('u', 1)) % A(site=('u',1)) >>
          A(site='u') + A(site='u'), kr)
+    # We need an arbitrary observable here to get a Kappa output file
+    Observable('A_obs', A())
     # Accommodates Expression in kappa simulation
     run_simulation(model, time=0)
 

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -21,6 +21,7 @@ def test_kappa_simulation_results():
     Observable('AB', A(b=1) % B(b=1))
     npts = 200
     kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
+    import ipdb; ipdb.set_trace()
     ok_(len(kres['time']) == npts + 1)
     ok_(len(kres['AB']) == npts + 1)
     ok_(kres['time'][0] == 0)


### PR DESCRIPTION
This PR introduces updates to the Kappa (KaSim and KaSa) interface in PySB to make simulations and static analysis (generating contact maps and influence maps) compatible with the 4th generation Kappa tools. 
- The executable for static analysis changed from KaSim to KaSa
- The output folders for contact map and influence map have to be specified separately
- The parameterization of KaSim changed, most importantly with respect to specifying the number of time points to simulate vs intervals between returned samples (the -p option of KaSim)
- The output format of KaSim changed and this required changes in reading in the results
- The prerequisites of compiling Kappa changed and these are updated in the Travis config

Note that KaSim doesn't produce an output file if no Observables are declared, resulting in run_simulation to error. This change in KaSim behavior is not addressed here and a solution could be implemented in a follow-up.  