### PR TITLE
Fix StochKitSimulator for models w/ expressions

### DIFF
--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -190,11 +190,12 @@ class StochKitExporter(Exporter):
         # Parameters
         params = etree.Element('ParametersList')
         for p_id, param in enumerate(self.model.parameters):
-            if param.name == 'vol':
-                param.rename('__vol')
+            p_name = param.name
+            if p_name == 'vol':
+                p_name = '__vol'
             p_value = param.value if param_values is None else \
                 param_values[p_id]
-            params.append(self._parameter_to_element(param.name, p_value))
+            params.append(self._parameter_to_element(p_name, p_value))
         # Default volume parameter value
         params.append(self._parameter_to_element('vol', 1.0))
 

--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -8,7 +8,7 @@ For information on how to use the model exporters, see the documentation
 for :py:mod:`pysb.export`.
 """
 from pysb.export import Exporter
-from pysb.core import as_complex_pattern, Expression
+from pysb.core import as_complex_pattern, Expression, Parameter
 from pysb.bng import generate_equations
 import numpy as np
 import sympy
@@ -69,11 +69,19 @@ class StochKitExporter(Exporter):
         e.append(descriptionElement)
 
         typeElement = etree.Element('Type')
-        typeElement.text = 'customized'
-        e.append(typeElement)
-        functionElement = etree.Element('PropensityFunction')
-        functionElement.text = propensity_fxn
-        e.append(functionElement)
+        if isinstance(propensity_fxn, (Parameter, float)):
+            typeElement.text = 'mass-action'
+            e.append(typeElement)
+            rateElement = etree.Element('Rate')
+            rateElement.text = propensity_fxn.name if isinstance(
+                propensity_fxn, Parameter) else str(propensity_fxn)
+            e.append(rateElement)
+        else:
+            typeElement.text = 'customized'
+            e.append(typeElement)
+            functionElement = etree.Element('PropensityFunction')
+            functionElement.text = propensity_fxn
+            e.append(functionElement)
 
         reactantElement = etree.Element('Reactants')
 
@@ -182,6 +190,8 @@ class StochKitExporter(Exporter):
         # Parameters
         params = etree.Element('ParametersList')
         for p_id, param in enumerate(self.model.parameters):
+            if param.name == 'vol':
+                param.rename('__vol')
             p_value = param.value if param_values is None else \
                 param_values[p_id]
             params.append(self._parameter_to_element(param.name, p_value))
@@ -201,7 +211,7 @@ class StochKitExporter(Exporter):
         pattern = re.compile("(__s\d+)\*\*(\d+)")
         for rxn_id, rxn in enumerate(self.model.reactions):
             rxn_name = 'Rxn%d' % rxn_id
-            rxn_desc = 'Rules: %s' % rxn["rule"]
+            rxn_desc = 'Rules: %s' % str(rxn["rule"])
 
             reactants = defaultdict(int)
             products = defaultdict(int)
@@ -227,6 +237,58 @@ class StochKitExporter(Exporter):
                 rate = re.sub(r'\b%s\b' % e.name,
                               expr_strings[e.name],
                               rate)
+
+            total_reactants = sum(reactants.values())
+            rxn_params = rxn["rate"].atoms(Parameter)
+            rate = None
+            if total_reactants <= 2 and len(rxn_params) == 1:
+                # Try to parse as mass action to avoid compiling custom
+                # propensity functions in StochKit (slow for big models)
+                rxn_param = rxn_params.pop()
+                putative_rate = sympy.Mul(*[sympy.symbols(r) ** r_stoich for
+                                            r, r_stoich in
+                                            reactants.items()]) * rxn_param
+
+                rxn_floats = rxn["rate"].atoms(sympy.Float)
+                rate_mul = 1.0
+                if len(rxn_floats) == 1:
+                    rate_mul = next(iter(rxn_floats))
+                    putative_rate *= rate_mul
+
+                if putative_rate == rxn["rate"]:
+                    # Reaction is mass-action, set rate to a Parameter or float
+                    if len(rxn_floats) == 0:
+                        rate = rxn_param
+                    elif len(rxn_floats) == 1:
+                        rate = rxn_param.value * float(rate_mul)
+
+                    if rate is not None and len(reactants) == 1 and \
+                            max(reactants.values()) == 2:
+                        # Need rate * 2 in addition to any rate factor
+                        rate = (rate.value if isinstance(rate, Parameter)
+                                else rate) * 2.0
+
+            if rate is None:
+                # Custom propensity function needed
+
+                rxn_atoms = rxn["rate"].atoms()
+
+                # replace terms like __s**2 with __s*(__s-1)
+                rate = str(rxn["rate"])
+
+                matches = pattern.findall(rate)
+                for m in matches:
+                    repl = m[0]
+                    for i in range(1, int(m[1])):
+                        repl += "*(%s-%d)" % (m[0], i)
+                    rate = re.sub(pattern, repl, rate, count=1)
+
+                # expand only expressions used in the rate eqn
+                for e in {sym for sym in rxn_atoms
+                          if isinstance(sym, Expression)}:
+                    rate = re.sub(r'\b%s\b' % e.name,
+                                  expr_strings[e.name],
+                                  rate)
 
             reacs.append(self._reaction_to_element(rxn_name,
                                                    rxn_desc,

--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -205,7 +205,9 @@ class StochKitExporter(Exporter):
         expr_strings = {
             e.name: '(%s)' % sympy.ccode(
                 e.expand_expr(expand_observables=True)
-            ) for e in self.model.expressions}
+            )
+            for e in self.model.expressions
+        }
 
         # Reactions
         reacs = etree.Element('ReactionsList')

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -142,21 +142,7 @@ class ScipyOdeSimulator(Simulator):
             # Substitute expanded parameter formulas for any named expressions
             for e in self._model.expressions:
                 eqns = re.sub(r'\b(%s)\b' % e.name, '(' + sympy.ccode(
-                    e.expand_expr()) + ')', eqns)
-
-            # Substitute sums of observable species that could've been added
-            # by expressions
-            for obs in self._model.observables:
-                obs_string = ''
-                for i in range(len(obs.coefficients)):
-                    if i > 0:
-                        obs_string += "+"
-                    if obs.coefficients[i] > 1:
-                        obs_string += str(obs.coefficients[i]) + "*"
-                    obs_string += "__s" + str(obs.species[i])
-                if len(obs.coefficients) > 1:
-                    obs_string = '(' + obs_string + ')'
-                eqns = re.sub(r'\b(%s)\b' % obs.name, obs_string, eqns)
+                    e.expand_expr(expand_observables=True)) + ')', eqns)
 
             # Substitute 'y[i]' for 'si'
             eqns = re.sub(r'\b__s(\d+)\b',

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -73,13 +73,13 @@ class StochKitSimulator(Simulator):
 
     >>> print(simulation_result.observables[0]['A_total']) \
         #doctest: +ELLIPSIS
-    [ 1.  0.  0.  0.  0.  0.]
+    [ 1.  0.  0.  0.  0.]
 
     A_total trajectory for second run
 
     >>> print(simulation_result.observables[1]['A_total']) \
         #doctest: +ELLIPSIS
-    [ 1.  1.  1.  1.  0.  0.]
+    [ 1.  1.  1.  0.  0.]
 
     For further information on retrieving trajectories (species,
     observables, expressions over time) from the ``simulation_result``

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -191,7 +191,7 @@ class StochKitSimulator(Simulator):
                     traj_dir, f)) for f in sorted(os.listdir(traj_dir))])
             except Exception as e:
                 raise SimulatorException(
-                    "Error reading StochKit trajectories: {1}".format(e))
+                    "Error reading StochKit trajectories: {0}".format(e))
 
             if len(trajectories) == 0 or len(stderr) != 0:
                 raise SimulatorException("Solver execution failed: \

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import tempfile
 from pysb.pathfinder import get_path
+from pysb.logging import EXTENDED_DEBUG
 
 
 class StochKitSimulator(Simulator):
@@ -148,9 +149,11 @@ class StochKitSimulator(Simulator):
             prefix_outdir = os.path.join(self._outdir, 'output_{}'.format(i))
 
             # Export model file
+            stoch_xml = StochKitExporter(self._model).export(
+                self.initials[i], self.param_values[i])
+            self._logger.log(EXTENDED_DEBUG, 'StochKit XML:\n' + stoch_xml)
             with open(fname, 'w') as f:
-                f.write(StochKitExporter(self._model).export(
-                    self.initials[i], self.param_values[i]))
+                f.write(stoch_xml)
 
             # Assemble the argument list
             args = '--model {} --out-dir {} -t {:f} -i {:d}'.format(
@@ -191,7 +194,8 @@ class StochKitSimulator(Simulator):
                     traj_dir, f)) for f in sorted(os.listdir(traj_dir))])
             except Exception as e:
                 raise SimulatorException(
-                    "Error reading StochKit trajectories: {0}".format(e))
+                    "Error reading StochKit trajectories: {0}"
+                    "\nSTDOUT:{1}\nSTDERR:{2}".format(e, stdout, stderr))
 
             if len(trajectories) == 0 or len(stderr) != 0:
                 raise SimulatorException("Solver execution failed: \

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -154,7 +154,7 @@ class StochKitSimulator(Simulator):
 
             # Assemble the argument list
             args = '--model {} --out-dir {} -t {:f} -i {:d}'.format(
-                fname, prefix_outdir, t, t_length)
+                fname, prefix_outdir, t, t_length - 1)
 
             # If we are using local mode, shell out and run StochKit
             # (SSA or Tau-leaping or ODE)

--- a/pysb/tests/test_simulator_stochkit.py
+++ b/pysb/tests/test_simulator_stochkit.py
@@ -1,6 +1,6 @@
 from pysb.export.stochkit import StochKitExporter
 from pysb.simulator import StochKitSimulator
-from pysb.examples import robertson, earm_1_0
+from pysb.examples import robertson, earm_1_0, expression_observables
 import numpy as np
 from pysb.core import as_complex_pattern
 
@@ -32,3 +32,10 @@ def test_stochkit_earm_multi_initials():
     # Check we have two repeats of each initial
     assert np.allclose(df.loc[(slice(None), 0), '__s%d' % unbound_L_index],
                        [3000, 3000, 1500, 1500])
+
+
+def test_stochkit_expressions():
+    model = expression_observables.model
+    tspan = np.linspace(0, 100, 10)
+    sim = StochKitSimulator(model, tspan=tspan)
+    sim.run()

--- a/pysb/tests/test_simulator_stochkit.py
+++ b/pysb/tests/test_simulator_stochkit.py
@@ -36,6 +36,6 @@ def test_stochkit_earm_multi_initials():
 
 def test_stochkit_expressions():
     model = expression_observables.model
-    tspan = np.linspace(0, 100, 10)
+    tspan = np.linspace(0, 100, 11)
     sim = StochKitSimulator(model, tspan=tspan)
-    sim.run()
+    assert np.allclose(sim.run().tout, tspan)


### PR DESCRIPTION
* Enable simulation of models with expressions on the `StochKitSimulator` class
* Add an `expand_observables` argument to `Expression.expand_expr()`, which expands Observables into species, reducing code duplication
* The `StochKitExporter` is now much faster for large models
* Reactions which are mass action according to the StochKit definition are now exported as mass action in the StochKit XML. This means that custom propensity functions don't have to be compiled for these reactions, reducing StochKit compile time for large models. It also means that mass action only models can be run using the Windows StochKit Lite, which doesn't have custom propensity function (non mass action) capability.