### PR TITLE
Pattern matcher and model test suite

### DIFF
--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -7,9 +7,11 @@ PySB Modules Reference
    core.rst
    integrate.rst
    simulator.rst
+   modeltests.rst
    bng.rst
    kappa.rst
    macros.rst
+   pattern.rst
    tools/render.rst
    importers/index.rst
    export/index.rst

--- a/doc/modules/modeltests.rst
+++ b/doc/modules/modeltests.rst
@@ -1,0 +1,5 @@
+Testing PySB Models (:py:mod:`pysb.testing.modeltests`)
+=======================================================
+
+.. automodule:: pysb.testing.modeltests
+  :members:

--- a/doc/modules/pattern.rst
+++ b/doc/modules/pattern.rst
@@ -1,0 +1,5 @@
+Pattern matching against PySB models (:py:mod:`pysb.pattern`)
+=============================================================
+
+.. automodule:: pysb.pattern
+  :members:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -591,11 +591,11 @@ class ComplexPattern(object):
                 i += 1
         node_count = autoinc()
 
-        class WildTester(object):
+        class AnyBondTester(object):
             def __eq__(self, other):
                 return not isinstance(other, Component) and other != NO_BOND
 
-        wild_tester = WildTester()
+        any_bond_tester = AnyBondTester()
 
         bond_edges = collections.defaultdict(list)
         g = nx.Graph()
@@ -628,7 +628,7 @@ class ComplexPattern(object):
                 g.add_edge(mon_node_id, mon_site_id)
                 state = None
                 bond_num = None
-                if state_or_bond is ANY:
+                if state_or_bond is WILD:
                     continue
                 elif isinstance(state_or_bond, (str, unicode)):
                     state = state_or_bond
@@ -639,11 +639,11 @@ class ComplexPattern(object):
                 elif isinstance(state_or_bond, int):
                     bond_num = state_or_bond
 
-                if state_or_bond is WILD or bond_num is WILD:
-                    bond_num = wild_tester
-                    wild_tester_id = next(node_count)
-                    g.add_node(wild_tester_id, id=wild_tester)
-                    g.add_edge(mon_site_id, wild_tester_id)
+                if state_or_bond is ANY or bond_num is ANY:
+                    bond_num = any_bond_tester
+                    any_bond_tester_id = next(node_count)
+                    g.add_node(any_bond_tester_id, id=any_bond_tester)
+                    g.add_edge(mon_site_id, any_bond_tester_id)
 
                 if state is not None:
                     mon_site_state_id = next(node_count)
@@ -667,9 +667,9 @@ class ComplexPattern(object):
         for site_nodes in bond_edges.values():
             if len(site_nodes) == 1:
                 # Treat dangling bond as WILD
-                wild_tester_id = next(node_count)
-                g.add_node(wild_tester_id, id=wild_tester)
-                g.add_edge(site_nodes[0], wild_tester_id)
+                any_bond_tester_id = next(node_count)
+                g.add_node(any_bond_tester_id, id=any_bond_tester)
+                g.add_edge(site_nodes[0], any_bond_tester_id)
             for n1, n2 in itertools.combinations(site_nodes, 2):
                 g.add_edge(n1, n2)
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -688,19 +688,37 @@ class ComplexPattern(object):
         Use of this method on non-concrete ComplexPatterns was previously
         allowed, but is now deprecated.
         """
-        from pysb.pattern import SimplePatternMatcher
+        from pysb.pattern import match_complex_pattern
         # Didn't implement __eq__ to avoid confusion with __ne__ operator used
         # for Rule building
 
         # Check both patterns are concrete
-        exact = True
         if not self.is_concrete() or not other.is_concrete():
             warnings.warn("is_equivalent_to() will only work with concrete "
                           "patterns in a future version", DeprecationWarning)
-            exact = False
 
-        return SimplePatternMatcher.match_complex_pattern(self, other,
-                                                          exact=exact)
+        return match_complex_pattern(self, other, exact=True)
+
+    def matches(self, other):
+        """
+        Compare another ComplexPattern against this one
+
+        Parameters
+        ----------
+        other: ComplexPattern
+            A ComplexPattern to match against self
+
+        Returns
+        -------
+        bool
+            True if other matches self; False otherwise.
+
+        """
+        if not self.is_concrete():
+            raise ValueError('matches() requires self to be a concrete '
+                             'pattern')
+        from pysb.pattern import match_complex_pattern
+        return match_complex_pattern(other, self, exact=False)
 
     def copy(self):
         """
@@ -861,6 +879,14 @@ class ReactionPattern(object):
         else:
             return 'None'
 
+    def matches(self, other):
+        """
+        Match the 'other' ReactionPattern against this one
+
+        See :func:`pysb.pattern.match_reaction_pattern` for details
+        """
+        from pysb.pattern import match_reaction_pattern
+        return match_reaction_pattern(other, self)
 
 
 class RuleExpression(object):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -410,14 +410,14 @@ class MonomerPattern(object):
         # assume __init__ did a thorough enough job of error checking that this is is all we need to do
         return len(self.site_conditions) == len(self.monomer.sites)
 
-    def as_graph(self):
+    def _as_graph(self):
         """
         Convert MonomerPattern to networkx graph, caching the result
 
-        See :func:`ComplexPattern.as_graph` for implementation details
+        See :func:`ComplexPattern._as_graph` for implementation details
         """
         if self._graph is None:
-            self._graph = as_complex_pattern(self).as_graph()
+            self._graph = as_complex_pattern(self)._as_graph()
 
         return self._graph
 
@@ -530,7 +530,7 @@ class ComplexPattern(object):
             all(mp.is_site_concrete() for mp in self.monomer_patterns)
         return mp_concrete_ok or compartment_ok
 
-    def as_graph(self):
+    def _as_graph(self):
         """
         Return the ComplexPattern represented as a networkx graph
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -593,7 +593,8 @@ class ComplexPattern(object):
 
         class WildTester(object):
             def __eq__(self, other):
-                return other != NO_BOND
+                return not isinstance(other, Component) and other != NO_BOND
+
         wild_tester = WildTester()
 
         bond_edges = collections.defaultdict(list)

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -1,0 +1,764 @@
+import collections
+from .core import ComplexPattern, MonomerPattern, Monomer, \
+    ReactionPattern, ANY, WILD, as_complex_pattern
+import networkx as nx
+from networkx.algorithms.isomorphism.vf2userfunc import GraphMatcher
+from networkx.algorithms.isomorphism import categorical_node_match
+import numpy as np
+
+
+class SimplePatternMatcher(object):
+    """ Methods for one-off pattern matching without caching """
+    @classmethod
+    def _get_bonds_in_pattern(cls, pat):
+        bonds_used = set()
+
+        def _get_bonds_in_monomer_pattern(mp):
+            for sc in mp.site_conditions.values():
+                if isinstance(sc, int):
+                    bonds_used.add(sc)
+                elif not isinstance(sc, (str, unicode)) and \
+                        isinstance(sc, collections.Iterable):
+                    [bonds_used.add(b) for b in sc if isinstance(b, int)]
+
+        if pat is None:
+            return bonds_used
+        if isinstance(pat, MonomerPattern):
+            _get_bonds_in_monomer_pattern(pat)
+        elif isinstance(pat, ComplexPattern):
+            for mp in pat.monomer_patterns:
+                _get_bonds_in_monomer_pattern(mp)
+        else:
+            raise ValueError('Unknown pattern type: %s' % type(pat))
+
+        return bonds_used
+
+    @staticmethod
+    def _match_graphs(pattern, candidate, exact):
+        node_matcher = categorical_node_match('id', default=None)
+        if exact:
+            return nx.is_isomorphic(pattern.as_graph(),
+                                    candidate.as_graph(),
+                                    node_match=node_matcher)
+        else:
+            return GraphMatcher(
+                candidate.as_graph(), pattern.as_graph(),
+                node_match=node_matcher
+            ).subgraph_is_isomorphic()
+
+    @classmethod
+    def match_complex_pattern(cls, pattern, candidate, exact=False):
+        """
+        Compare two ComplexPatterns against each other
+
+        Parameters
+        ----------
+        pattern: pysb.ComplexPattern
+        candidate: pysb.Complex.Pattern
+        exact: bool
+            Set to True for exact matches (i.e. species equivalence)
+
+        Returns
+        -------
+        True if pattern matches candidate, False otherwise
+        """
+        if exact:
+            if not pattern.is_concrete():
+                raise ValueError('Pattern must be concrete for '
+                                 'exact matching: {}'.format(pattern))
+            if not candidate.is_concrete():
+                raise ValueError('Candidate must be concrete for '
+                                 'exact matching: {}'.format(candidate))
+
+        if exact and len(pattern.monomer_patterns) != len(
+                candidate.monomer_patterns):
+            return False
+
+        # Compare the monomer counts in the patterns so we can fail fast
+        # without having to compare bonds
+        mons_pat = collections.Counter([mp.monomer for mp in \
+                pattern.monomer_patterns])
+        mons_cand = collections.Counter([mp.monomer for mp in \
+                candidate.monomer_patterns])
+
+        for mon, mon_count_cand in mons_cand.items():
+            mon_count_pat = mons_pat.get(mon, 0)
+            if exact and mon_count_cand != mon_count_pat:
+                return False
+            if mon_count_pat > mon_count_cand:
+                return False
+
+        # If we've got this far, we'll need to do a full pattern match
+        # by searching for a graph isomorphism
+        return cls._match_graphs(pattern, candidate, exact=exact)
+
+    @classmethod
+    def match_reaction_pattern(cls, pattern, candidate):
+        """
+        Compare two ReactionPatterns against each other
+
+        Parameters
+        ----------
+        pattern: pysb.ReactionPattern
+        candidate: pysb.ReactionPattern
+
+        Returns
+        -------
+        True if pattern matches candidate, False otherwise.
+
+        """
+        if len(pattern.complex_patterns) > len(candidate.complex_patterns):
+            return False
+
+        matches = []
+        for cplx_pat in pattern.complex_patterns:
+            matches_this = [SimplePatternMatcher.match_complex_pattern(
+                cplx_pat, cand_cplx_pat) for cand_cplx_pat in
+                candidate.complex_patterns]
+            matches_this = set(np.where(matches_this)[0])
+            if len(matches_this) == 0:
+                return False
+            matches.append(matches_this)
+
+        # If a unique 1:1 mapping exists, a match is assured
+        if len(set.intersection(*matches)) == 0:
+            return True
+
+        # Find the maximum matching in a bipartite graph representing the
+        # two sets of ComplexPatterns
+        g = nx.Graph()
+        g.add_nodes_from(['p%d' % n for n in
+                         range(len(pattern.complex_patterns))], bipartite=0)
+        g.add_nodes_from(['c%d' % n for n in
+                         range(len(candidate.complex_patterns))], bipartite=1)
+        for src_pat_id, src_pat_matches in enumerate(matches):
+            g.add_edges_from([('p%d' % src_pat_id, 'c%d' % cand_pat_id) for
+                              cand_pat_id in src_pat_matches])
+
+        return (len(nx.bipartite.maximum_matching(g)) // 2) == len(
+            pattern.complex_patterns)
+
+
+def monomers_from_pattern(pattern):
+    """ Return the set of monomers used in a pattern """
+    if isinstance(pattern, ReactionPattern):
+        return set.union(*[monomers_from_pattern(cp)
+                           for cp in pattern.complex_patterns])
+    if isinstance(pattern, ComplexPattern):
+        return set([mp.monomer for mp in pattern.monomer_patterns])
+    elif isinstance(pattern, MonomerPattern):
+        return {pattern.monomer}
+    elif isinstance(pattern, Monomer):
+        return {pattern}
+    else:
+        raise Exception('Unsupported pattern type: %s' % type(pattern))
+
+
+class SpeciesPatternMatcher(object):
+    """
+    Match a pattern against a model's species list
+
+    Examples
+    --------
+
+    Create a PatternMatcher for the EARM 1.0 model
+
+    >>> from pysb.examples.earm_1_0 import model
+    >>> from pysb.bng import generate_equations
+    >>> from pysb.pattern import SpeciesPatternMatcher
+    >>> from pysb import ANY, WILD, Model, Monomer, as_complex_pattern
+    >>> generate_equations(model)
+    >>> spm = SpeciesPatternMatcher(model)
+
+    Assign two monomers to variables (only needed when importing a model
+    instead of defining one interactively)
+
+    >>> Bax4 = model.monomers['Bax4']
+    >>> Bcl2 = model.monomers['Bcl2']
+
+    Search using a Monomer
+
+    >>> spm.match(Bax4)
+    [Bax4(b=None), Bax4(b=1) % Bcl2(b=1), Bax4(b=1) % Mito(b=1)]
+    >>> spm.match(Bcl2) # doctest:+NORMALIZE_WHITESPACE
+    [Bax2(b=1) % Bcl2(b=1),
+    Bax4(b=1) % Bcl2(b=1),
+    Bcl2(b=None),
+    Bcl2(b=1) % MBax(b=1)]
+
+    Search using a MonomerPattern (ANY and WILD keywords can be used)
+
+    >>> spm.match(Bax4(b=WILD))
+    [Bax4(b=1) % Bcl2(b=1), Bax4(b=1) % Mito(b=1)]
+    >>> spm.match(Bcl2(b=WILD))
+    [Bax2(b=1) % Bcl2(b=1), Bax4(b=1) % Bcl2(b=1), Bcl2(b=1) % MBax(b=1)]
+
+    Search using a ComplexPattern
+
+    >>> spm.match(Bax4(b=1) % Bcl2(b=1))
+    [Bax4(b=1) % Bcl2(b=1)]
+    >>> spm.match(Bax4() % Bcl2())
+    [Bax4(b=1) % Bcl2(b=1)]
+
+    Contrived example to test a site with both a bond and state defined
+
+    >>> model = Model(_export=False)
+    >>> A = Monomer('A', ['a'], {'a': ['u', 'p']}, _export=False)
+    >>> model.add_component(A)
+    >>> species = [                                                     \
+            A(a=None),                                                  \
+            A(a='u'),                                                   \
+            A(a=1) % A(a=1),                                            \
+            A(a=('u', 1)) % A(a=('u', 1)),                              \
+            A(a=('p', 1)) % A(a=('p', 1))                               \
+        ]
+    >>> model.species = [as_complex_pattern(sp) for sp in species]
+    >>> spm2 = SpeciesPatternMatcher(model)
+    >>> spm2.match(A()) # doctest:+NORMALIZE_WHITESPACE
+    [A(a=None), A(a='u'), A(a=1) % A(a=1), A(a=('u', 1)) % A(a=('u', 1)),
+     A(a=('p', 1)) % A(a=('p', 1))]
+    >>> spm2.match(A(a='u'))
+    [A(a='u')]
+    >>> spm2.match(A(a=('u', ANY)))
+    [A(a='u'), A(a=('u', 1)) % A(a=('u', 1))]
+    >>> spm2.match(A(a=('u', WILD)))
+    [A(a=('u', 1)) % A(a=('u', 1))]
+    """
+    def __init__(self, model, species=None):
+        self.model = model
+        if not species and not model.species:
+            raise Exception('Model needs species list - run '
+                            'generate_equations() first')
+
+        if not species:
+            species = model.species
+
+        self.species = species
+
+        self._species_cache = collections.defaultdict(set)
+        for idx, sp in enumerate(species):
+            self._add_species(idx, sp)
+
+    def _add_species(self, idx, sp):
+        if sp.compartment:
+            raise NotImplementedError
+        for mp in sp.monomer_patterns:
+            if mp.compartment:
+                raise NotImplementedError
+            self._species_cache[mp.monomer].add(idx)
+
+    def add_species(self, species, check_duplicate=True):
+        """
+        Add a species to the search list without adding to the model
+
+        Parameters
+        ----------
+        species
+        check_duplicate
+
+        Returns
+        -------
+
+        """
+        if check_duplicate and self.match(species, exact=True):
+            return
+        self.species.append(species)
+        self._add_species(len(self.species) - 1, species)
+
+    def match(self, pattern, index=False, exact=False):
+        """
+        Match a pattern against the list of species
+
+        Parameters
+        ----------
+        pattern: pysb.Monomer or pysb.MonomerPattern or pysb.ComplexPattern
+        index: bool
+            If True, return species numerical index, rather than species itself
+        exact: bool
+            Treat Match as exact equivalence, not a pattern match (i.e. must be
+            concrete if a MonomerPattern or ComplexPattern)
+
+        Returns
+        -------
+        list of pysb.ComplexPattern or list of int
+            A list of species matching the pattern is returned, unless
+            index=True, in which case a list of the numerical indices of
+            matching species is returned instead
+        """
+        if not isinstance(pattern, (Monomer, MonomerPattern, ComplexPattern)):
+            raise ValueError('A Monomer, MonomerPattern or ComplexPattern is '
+                             'required to match species')
+
+        monomers = monomers_from_pattern(pattern)
+
+        if exact:
+            if isinstance(pattern, (Monomer, MonomerPattern)):
+                num_mon_pats = 1
+            else:
+                num_mon_pats = len(pattern.monomer_patterns)
+        else:
+            # Don't check the number of monomer patterns in search
+            # candidates if we're not doing an exact match of the species
+            num_mon_pats = None
+
+        shortlist, shortlist_indexes = self._species_containing_monomers(
+            monomers, num_mon_pats)
+
+        # If pattern is a Monomer, we're done
+        if isinstance(pattern, Monomer):
+            return shortlist_indexes if index else shortlist
+        else:
+            return [(shortlist_indexes[idx] if index else sp) for idx, sp in
+                    enumerate(shortlist) if
+                    SimplePatternMatcher.match_complex_pattern(
+                        as_complex_pattern(pattern), sp, exact=exact
+                    )]
+
+    def _species_containing_monomers(self, monomer_list, num_mon_pats=None):
+        """
+        Identifies species containing a list of monomers
+
+        Parameters
+        ----------
+        monomer_list: list of Monomers
+            A list of monomers with which to search the model's species
+        num_mon_pats: int or None
+            Restrict matches to species with exactly the specified number of
+            MonomerPatterns
+
+        Returns
+        -------
+        Model species containing all of the monomers in the list
+        """
+        sp_indexes = set.intersection(*[self._species_cache[mon] for mon in
+                                        monomer_list])
+        if num_mon_pats:
+            retval = zip(*[(self.species[sp], sp) for sp in sp_indexes
+                           if len(self.species[sp].monomer_patterns)
+                           == num_mon_pats])
+            return retval if retval else ((), ())
+        else:
+            return [self.species[sp] for sp in sp_indexes], list(sp_indexes)
+
+    def rules_fired_by_species(self, rules_to_consider=None):
+        """
+        Filter a list of rules (reactant side) by a list of species
+
+        Parameters
+        ----------
+        rules_to_consider: list of pysb.Rule or None
+            A list of rules to use
+
+        Returns
+        -------
+        dict
+            Dictionary of PySB rules whose reactants contain at least one of
+            the species in the model. Keys are PySB rules, values are the
+            species matching the reactant side of those rules.
+        """
+        if rules_to_consider is None:
+            rules_to_consider = self.model.rules
+        rules_fired = collections.OrderedDict()
+        for r in rules_to_consider:
+            rp = r.reactant_pattern
+            if len(rp.complex_patterns) == 0:
+                # Synthesis rules are always fired
+                rules_fired[r] = []
+            else:
+                species_fired = self.species_fired_by_reactant_pattern(rp)
+                if species_fired:
+                    rules_fired[r] = species_fired
+        return rules_fired
+
+    def species_fired_by_reactant_pattern(self, reaction_pattern):
+        """
+        Get list of species matching a reactant pattern
+
+        Parameters
+        ----------
+        reaction_pattern: pysb.ReactionPattern
+
+        Returns
+        -------
+        list of pysb.ComplexPattern
+            List of species matching the reactant pattern
+        """
+        species_fired = []
+
+        for i, cp in enumerate(reaction_pattern.complex_patterns):
+            species_fired_this_cp = self.match(cp)
+            if not species_fired_this_cp:
+                return []
+            else:
+                species_fired.append(set(species_fired_this_cp))
+
+        return species_fired
+
+
+class RulePatternMatcher(object):
+    """
+    Match a pattern against a model's species list
+
+    Methods are provided to match against rule reactants, products or both.
+    Searches can be Monomers, MonomerPatterns, ComplexPatterns or
+    ReactionPatterns.
+
+    Examples
+    --------
+
+    Create a PatternMatcher for the EARM 1.0 model
+
+    >>> from pysb.examples.earm_1_0 import model
+    >>> from pysb.pattern import RulePatternMatcher
+    >>> rpm = RulePatternMatcher(model)
+
+    Assign some monomers to variables (only needed when importing a model
+    instead of defining one interactively)
+
+    >>> AMito, mCytoC, mSmac, cSmac = [model.monomers[m] for m in \
+        ('AMito', 'mCytoC', 'mSmac', 'cSmac')]
+
+    Search using a Monomer
+
+    >>> rpm.match_reactants(AMito) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('bind_mCytoC_AMito', AMito(b=None) + mCytoC(b=None) <>
+        AMito(b=1) % mCytoC(b=1), kf20, kr20),
+    Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
+        AMito(b=None) + ACytoC(b=None), kc20),
+    Rule('bind_mSmac_AMito', AMito(b=None) + mSmac(b=None) <>
+        AMito(b=1) % mSmac(b=1), kf21, kr21),
+    Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
+        AMito(b=None) + ASmac(b=None), kc21)]
+
+    >>> rpm.match_products(mSmac) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('bind_mSmac_AMito', AMito(b=None) + mSmac(b=None) <>
+        AMito(b=1) % mSmac(b=1), kf21, kr21)]
+
+    Search using a MonomerPattern
+
+    >>> rpm.match_reactants(AMito(b=1)) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
+        AMito(b=None) + ACytoC(b=None), kc20),
+    Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
+        AMito(b=None) + ASmac(b=None), kc21)]
+
+    >>> rpm.match_rules(cSmac(b=1)) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('inhibit_cSmac_by_XIAP', cSmac(b=None) + XIAP(b=None) <>
+        cSmac(b=1) % XIAP(b=1), kf28, kr28)]
+
+    Search using a ComplexPattern
+
+    >>> rpm.match_reactants(AMito() % mSmac()) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
+        AMito(b=None) + ASmac(b=None), kc21)]
+
+    >>> rpm.match_rules(AMito(b=1) % mCytoC(b=1)) \
+        # doctest:+NORMALIZE_WHITESPACE
+    [Rule('bind_mCytoC_AMito', AMito(b=None) + mCytoC(b=None) <>
+        AMito(b=1) % mCytoC(b=1), kf20, kr20),
+    Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
+        AMito(b=None) + ACytoC(b=None), kc20)]
+
+    Search using a ReactionPattern
+
+    >>> rpm.match_reactants(mCytoC() + mSmac())
+    []
+
+    >>> rpm.match_reactants(AMito() + mCytoC()) # doctest:+NORMALIZE_WHITESPACE
+    [Rule('bind_mCytoC_AMito', AMito(b=None) + mCytoC(b=None) <>
+        AMito(b=1) % mCytoC(b=1), kf20, kr20)]
+
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+        self._reactant_cache = collections.defaultdict(set)
+        self._product_cache = collections.defaultdict(set)
+
+        for rule in model.rules:
+            for cache, rp in ((self._reactant_cache, rule.reactant_pattern),
+                              (self._product_cache, rule.product_pattern)):
+                for cp in rp.complex_patterns:
+                    if cp.compartment:
+                        raise NotImplementedError
+                    for mp in cp.monomer_patterns:
+                        if mp.compartment:
+                            raise NotImplementedError
+                        cache[mp.monomer].add(rule.name)
+
+    def match_reactants(self, pattern):
+        return self._match_reaction_patterns(pattern, 'reactant')
+
+    def match_products(self, pattern):
+        return self._match_reaction_patterns(pattern, 'product')
+
+    def match_rules(self, pattern):
+        return [r for r in self.model.rules if
+                r in self.match_reactants(pattern) or
+                r in self.match_products(pattern)]
+
+    def _match_reaction_patterns(self, pattern, reaction_side):
+        if not isinstance(pattern, (Monomer, MonomerPattern, ComplexPattern,
+                                    ReactionPattern)):
+            raise ValueError('A Monomer, MonomerPattern, ComplexPattern or '
+                             'ReactionPattern required to match rules')
+
+        monomers = monomers_from_pattern(pattern)
+
+        if reaction_side == 'reactant':
+            cache = self._reactant_cache
+
+            def pat_fn(r):
+                return r.reactant_pattern
+        elif reaction_side == 'product':
+            cache = self._product_cache
+
+            def pat_fn(r):
+                return r.product_pattern
+        else:
+            raise Exception('reaction_side must be "reactant" or "product"')
+
+        shortlist = self._cache_containing_monomers(cache, monomers)
+
+        # If pattern is a Monomer, we're done
+        if isinstance(pattern, Monomer):
+            return shortlist
+
+        if isinstance(pattern, (MonomerPattern, ComplexPattern)):
+            new_shortlist = []
+            for rule in shortlist:
+                reaction_pattern = pat_fn(rule)
+                if self._match_complex_pattern_to_reaction_pattern(
+                        as_complex_pattern(pattern), reaction_pattern):
+                    new_shortlist.append(rule)
+
+            return new_shortlist
+
+        else:
+            return [rule for rule in shortlist if
+                    SimplePatternMatcher.match_reaction_pattern(
+                        pattern, pat_fn(rule))]
+
+    @classmethod
+    def _match_complex_pattern_to_reaction_pattern(cls, pattern, test_pattern):
+        for cp in test_pattern.complex_patterns:
+            if SimplePatternMatcher.match_complex_pattern(pattern, cp):
+                return True
+        return False
+
+    def _cache_containing_monomers(self, cache, monomer_list):
+        """
+        Identifies rules containing a list of monomers
+
+        Parameters
+        ----------
+        monomer_list: list of Monomers
+            A list of monomers with which to search the model's rules
+
+        Returns
+        -------
+        Model rules containing all of the monomers in the list
+
+        """
+        rule_names = set.intersection(*[cache[mon] for mon in
+                                        monomer_list])
+        return [r for r in self.model.rules if r.name in rule_names]
+
+
+class ReactionPatternMatcher(object):
+    """
+    Match a pattern against a model's reactions list
+
+    Methods are provided to match against reaction reactants, products or
+    both. Searches can be Monomers, MonomerPatterns, ComplexPatterns or
+    ReactionPatterns.
+
+    Examples
+    --------
+
+    Create a PatternMatcher for the EARM 1.0 model
+
+    >>> from pysb.examples.earm_1_0 import model
+    >>> from pysb.bng import generate_equations
+    >>> from pysb.pattern import ReactionPatternMatcher
+    >>> generate_equations(model)
+    >>> rpm = ReactionPatternMatcher(model)
+
+    Assign some monomers to variables (only needed when importing a model
+    instead of defining one interactively)
+
+    >>> AMito, mCytoC, mSmac, cSmac = [model.monomers[m] for m in \
+                                       ('AMito', 'mCytoC', 'mSmac', 'cSmac')]
+
+    Search using a Monomer
+
+    >>> rpm.match_products(mSmac) # doctest:+NORMALIZE_WHITESPACE
+    [Rxn (<>):
+        Reactants: {'__s15': mSmac(b=None), '__s45': AMito(b=None)}
+        Products: {'__s47': AMito(b=1) % mSmac(b=1)}
+        Rate: __s15*__s45*kf21 - __s47*kr21
+        Rules: [Rule('bind_mSmac_AMito', AMito(b=None) + mSmac(b=None) <>
+                AMito(b=1) % mSmac(b=1), kf21, kr21)]]
+
+    Search using a MonomerPattern
+
+    >>> rpm.match_reactants(AMito(b=WILD)) # doctest:+NORMALIZE_WHITESPACE
+    [Rxn (>>):
+        Reactants: {'__s46': AMito(b=1) % mCytoC(b=1)}
+        Products: {'__s45': AMito(b=None), '__s48': ACytoC(b=None)}
+        Rate: __s46*kc20
+        Rules: [Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
+                AMito(b=None) + ACytoC(b=None), kc20)],
+     Rxn (>>):
+        Reactants: {'__s47': AMito(b=1) % mSmac(b=1)}
+        Products: {'__s45': AMito(b=None), '__s49': ASmac(b=None)}
+        Rate: __s47*kc21
+        Rules: [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
+                AMito(b=None) + ASmac(b=None), kc21)]]
+
+    >>> rpm.match_products(cSmac(b=WILD)) # doctest:+NORMALIZE_WHITESPACE
+    [Rxn (<>):
+        Reactants: {'__s7': XIAP(b=None), '__s51': cSmac(b=None)}
+        Products: {'__s53': XIAP(b=1) % cSmac(b=1)}
+        Rate: __s51*__s7*kf28 - __s53*kr28
+        Rules: [Rule('inhibit_cSmac_by_XIAP', cSmac(b=None) + XIAP(b=None) <>
+                cSmac(b=1) % XIAP(b=1), kf28, kr28)]]
+
+    Search using a ComplexPattern
+
+    >>> rpm.match_reactants(AMito() % mSmac()) # doctest:+NORMALIZE_WHITESPACE
+    [Rxn (>>):
+        Reactants: {'__s47': AMito(b=1) % mSmac(b=1)}
+        Products: {'__s45': AMito(b=None), '__s49': ASmac(b=None)}
+        Rate: __s47*kc21
+        Rules: [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
+                AMito(b=None) + ASmac(b=None), kc21)]]
+
+    >>> rpm.match_reactions(AMito(b=3) % mCytoC(b=3)) \
+    # doctest:+NORMALIZE_WHITESPACE
+    [Rxn (<>):
+        Reactants: {'__s14': mCytoC(b=None), '__s45': AMito(b=None)}
+        Products: {'__s46': AMito(b=1) % mCytoC(b=1)}
+        Rate: __s14*__s45*kf20 - __s46*kr20
+        Rules: [Rule('bind_mCytoC_AMito', AMito(b=None) + mCytoC(b=None) <>
+                AMito(b=1) % mCytoC(b=1), kf20, kr20)],
+     Rxn (>>):
+        Reactants: {'__s46': AMito(b=1) % mCytoC(b=1)}
+        Products: {'__s45': AMito(b=None), '__s48': ACytoC(b=None)}
+        Rate: __s46*kc20
+        Rules: [Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
+                AMito(b=None) + ACytoC(b=None), kc20)]]
+    """
+    def __init__(self, model, species_pattern_matcher=None):
+        self.model = model
+
+        # In this cache, our caches map species to reactions
+        self._reactant_cache = collections.defaultdict(set)
+        self._product_cache = collections.defaultdict(set)
+
+        if not species_pattern_matcher:
+            self.spm = SpeciesPatternMatcher(model)
+
+        for r_id, rxn in enumerate(model.reactions_bidirectional):
+            for cache, species_ids in (
+                    (self._reactant_cache, rxn['reactants']),
+                    (self._product_cache, rxn['products'])):
+                for sp_id in species_ids:
+                    sp = model.species[sp_id]
+                    if sp.compartment:
+                        raise NotImplementedError
+                    cache[sp].add(r_id)
+
+    def match_reactants(self, pattern):
+        return self._match_reactions_against_cache(pattern, 'reactant')
+
+    def match_products(self, pattern):
+        return self._match_reactions_against_cache(pattern, 'product')
+
+    def match_reactions(self, pattern):
+        return self._match_reactions_against_cache(pattern, 'both')
+
+    def _match_reactions_against_cache(self, pattern, reaction_side):
+        species = self.spm.match(pattern)
+
+        rxn_ids = set()
+        if reaction_side in ['reactant', 'both']:
+            rxn_ids.update(*[self._reactant_cache[sp] for sp in species])
+
+        if reaction_side in ['product', 'both']:
+            rxn_ids.update(*[self._product_cache[sp] for sp in species])
+        rxn_ids = list(rxn_ids)
+        rxn_ids.sort()
+
+        return [Reaction(rxn_dict=self.model.reactions_bidirectional[rxn_id],
+                         model=self.model) for rxn_id in rxn_ids]
+
+
+class Reaction(object):
+    __slots__ = ['_rxn_dict', 'reactants', 'model', 'products', 'species']
+    """
+    Store reactions in object form for pretty-printing
+    """
+    def __init__(self, rxn_dict=None, model=None, species=None):
+        self._rxn_dict = rxn_dict
+
+        if model is None:
+            raise ValueError('Must specify model or species list')
+
+        self.model = model
+
+        if species:
+            self.species = species
+        else:
+            self.species = model.species
+
+        self.reactants = collections.defaultdict(int)
+        self.products = collections.defaultdict(int)
+
+        for r_id in rxn_dict['reactants']:
+            self.reactants[r_id] += 1
+
+        for p_id in rxn_dict['products']:
+            self.products[p_id] += 1
+
+    @property
+    def reversible(self):
+        return self._rxn_dict.get('reversible', None)
+
+    @property
+    def reverse(self):
+        return self._rxn_dict.get('reverse', None)
+
+    @property
+    def rules(self):
+        return [self.model.rules[r] for r in self._rxn_dict['rule']]
+
+    def add_rule(self, rule):
+        if rule.name not in self._rxn_dict['rule']:
+            self._rxn_dict['rule'].append(rule.name)
+
+    @property
+    def rate(self):
+        return self._rxn_dict['rate']
+
+    def __repr__(self):
+        return 'Rxn (%s): \n    Reactants: %s\n    Products: %s\n    ' \
+               'Rate: %s\n    Rules: %s' % (
+                    '<>' if self.reversible else ('<<' if self.reverse else
+                        '>>'),
+                    self._repr_species_dict(self.reactants),
+                    self._repr_species_dict(self.products),
+                    self.rate,
+                    self.rules
+               )
+
+    def __cmp__(self, other):
+        try:
+            return self._rxn_dict == other._rxn_dict
+        except AttributeError:
+            return False
+
+    def _repr_species_dict(self, species_dict):
+        return '{%s}' % ', '.join(["'__s%d': %s" % (k, self.species[k])
+                                   for k in sorted(species_dict.keys())])

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -1,6 +1,6 @@
 import collections
 from .core import ComplexPattern, MonomerPattern, Monomer, \
-    ReactionPattern, WILD, as_complex_pattern
+    ReactionPattern, ANY, as_complex_pattern
 import networkx as nx
 from networkx.algorithms.isomorphism.vf2userfunc import GraphMatcher
 from networkx.algorithms.isomorphism import categorical_node_match
@@ -230,8 +230,8 @@ class SpeciesPatternMatcher(object):
     Search using a MonomerPattern (ANY and WILD keywords can be used)
 
     >>> spm.match(Bax4(b=WILD))
-    [Bax4(b=1) % Bcl2(b=1), Bax4(b=1) % Mito(b=1)]
-    >>> spm.match(Bcl2(b=WILD))
+    [Bax4(b=None), Bax4(b=1) % Bcl2(b=1), Bax4(b=1) % Mito(b=1)]
+    >>> spm.match(Bcl2(b=ANY))
     [Bax2(b=1) % Bcl2(b=1), Bax4(b=1) % Bcl2(b=1), Bcl2(b=1) % MBax(b=1)]
 
     Search using a ComplexPattern
@@ -261,9 +261,9 @@ class SpeciesPatternMatcher(object):
     >>> spm2.match(A(a='u'))
     [A(a='u')]
     >>> spm2.match(A(a=('u', ANY)))
-    [A(a='u'), A(a=('u', 1)) % A(a=('u', 1))]
-    >>> spm2.match(A(a=('u', WILD)))
     [A(a=('u', 1)) % A(a=('u', 1))]
+    >>> spm2.match(A(a=('u', WILD)))
+    [A(a='u'), A(a=('u', 1)) % A(a=('u', 1))]
     """
     def __init__(self, model, species=None):
         self.model = model
@@ -705,7 +705,7 @@ class ReactionPatternMatcher(object):
 
     Search using a MonomerPattern
 
-    >>> rpm.match_reactants(AMito(b=WILD)) # doctest:+NORMALIZE_WHITESPACE
+    >>> rpm.match_reactants(AMito(b=ANY)) # doctest:+NORMALIZE_WHITESPACE
     [Rxn (>>):
         Reactants: {'__s46': AMito(b=1) % mCytoC(b=1)}
         Products: {'__s45': AMito(b=None), '__s48': ACytoC(b=None)}
@@ -719,7 +719,7 @@ class ReactionPatternMatcher(object):
         Rules: [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
                 AMito(b=None) + ASmac(b=None), kc21)]]
 
-    >>> rpm.match_products(cSmac(b=WILD)) # doctest:+NORMALIZE_WHITESPACE
+    >>> rpm.match_products(cSmac(b=ANY)) # doctest:+NORMALIZE_WHITESPACE
     [Rxn (<>):
         Reactants: {'__s7': XIAP(b=None), '__s51': cSmac(b=None)}
         Products: {'__s53': XIAP(b=1) % cSmac(b=1)}

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -63,12 +63,12 @@ def _match_graphs(pattern, candidate, exact):
     """ Compare two pattern graphs for isomorphism """
     node_matcher = categorical_node_match('id', default=None)
     if exact:
-        return nx.is_isomorphic(pattern.as_graph(),
-                                candidate.as_graph(),
+        return nx.is_isomorphic(pattern._as_graph(),
+                                candidate._as_graph(),
                                 node_match=node_matcher)
     else:
         return GraphMatcher(
-            candidate.as_graph(), pattern.as_graph(),
+            candidate._as_graph(), pattern._as_graph(),
             node_match=node_matcher
         ).subgraph_is_isomorphic()
 

--- a/pysb/testing/modeltests.py
+++ b/pysb/testing/modeltests.py
@@ -1,0 +1,389 @@
+from __future__ import print_function
+import pysb
+import abc
+from pysb.core import SelfExporter
+from pysb.pattern import SpeciesPatternMatcher, ReactionPatternMatcher, \
+    RulePatternMatcher
+
+
+class ModelAssertionFailure(Exception):
+    def __init__(self, assertion, model, message=None):
+        self.assertion = assertion
+        self.model = model
+        self.message = message
+
+    def __repr__(self):
+        base_msg = '%s on model %s failed' % (self.assertion,
+                                              self.model.name)
+        if self.message:
+            return base_msg + ': ' + str(self.message)
+        else:
+            return base_msg
+
+    def __str__(self):
+        return repr(self)
+
+
+class TestSuite(object):
+    """
+    A suite of tests for checking properties of a model
+
+    There are two modes of operation: building a test suite using add() and
+    executing all the tests at once with check_all(), or executing tests
+    immediately with check().
+
+    Examples
+    --------
+
+    Create a test suite for the EARM 1.0 model:
+
+    >>> from pysb.testing.modeltests import TestSuite, SpeciesExists, \
+        SpeciesDoesNotExist
+    >>> from pysb.bng import generate_equations
+    >>> from pysb.examples.earm_1_0 import model
+    >>> ts = TestSuite(model)
+
+    Create variables for model components (not needed for models defined
+    interactively):
+
+    >>> AMito, mCytoC, mSmac, cSmac, L, CPARP = [model.monomers[m] for m in \
+                                       ('AMito', 'mCytoC', 'mSmac', 'cSmac', \
+                                        'L', 'CPARP')]
+
+    Add some assertions:
+
+    Check that AMito(b=1) % mSmac(b=1) exists in the species graph (note this
+    doesn't guarantee the species will actually be producted/consumed/change
+    in concentration; that depends on the rate constants):
+
+    >>> ts.add(SpeciesExists(AMito(b=1) % mSmac(b=1)))
+
+    This is the opposite check, that the complex above doesn't exist,
+    which should of course fail:
+
+    >>> ts.add(SpeciesDoesNotExist(AMito(b=1) % mSmac(b=1)))
+
+    We can also specify that species matching a pattern should never exist
+    in a model. For example, we shouldn't ever be producing unbound
+    ligand in the EARM 1.0 model:
+
+    >>> ts.add(SpeciesNeverProduct(L(b=None)))
+
+    We could also have used SpeciesOnlyReactant. The difference is the
+    latter checks for an appearance as a reactant, whereas
+    SpeciesNeverProduct would pass whether the species appeared as a
+    reactant or not.
+
+    >>> ts.add(SpeciesOnlyReactant(L(b=None)))
+
+    CPARP is an output in this model, so it should appear as a product but
+    never as a reactant:
+
+    >>> ts.add(SpeciesOnlyProduct(CPARP()))
+
+    When we're ready, we can generate the reactions and check the assertions:
+
+    >>> generate_equations(model)
+    >>> ts.check_all()  # doctest:+ELLIPSIS
+    SpeciesExists(AMito() % mSmac())...OK...
+    SpeciesDoesNotExist(AMito() % mSmac())...FAIL...
+      [AMito(b=1) % mSmac(b=1)]...
+    SpeciesExists(AMito(b=1) % mCytoC(b=1))...OK...
+    SpeciesNeverProduct(L(b=None))...OK...
+    SpeciesOnlyProduct(CPARP())...OK...
+
+    We can also execute any test immediately without adding it to the test
+    suite (note that some tests require a reaction network to be generated):
+
+    >>> ts.check(SpeciesExists(L(b=None)))
+    True
+    """
+    _KNOWN_CACHES = {'species_pattern_matcher': SpeciesPatternMatcher,
+                     'rule_pattern_matcher': RulePatternMatcher,
+                     'reaction_pattern_matcher': ReactionPatternMatcher}
+    _COL = {'OK': '\033[92m', 'FAIL': '\033[91m', 'END': '\033[0m'}
+
+    def __init__(self, model=None):
+        self._caches = {}
+        self.assertions = []
+        self._model = model
+        if model:
+            self._model = model
+        elif SelfExporter.default_model:
+            self._model = SelfExporter.default_model
+        else:
+            raise Exception('A model must be specified explicitly if the '
+                            'PySB self-exporter is not in use')
+
+    @property
+    def model(self):
+        return self._model
+
+    @model.setter
+    def model(self, model):
+        """ Changing the model invalidates any caches """
+        self._caches = {}
+        self._model = model
+
+    def _ensure_required_caches(self, assertion):
+        for cache in assertion.required_caches:
+            if cache not in self._KNOWN_CACHES.keys():
+                raise Exception('Unknown assertion cache: %s' % cache)
+            self._caches[cache] = self._KNOWN_CACHES[cache](self.model)
+
+    def add(self, assertion):
+        self.assertions.append(assertion)
+
+    def check(self, assertion):
+        """
+        Checks an assertion immediately without adding it to the test suite
+
+        Parameters
+        ----------
+        assertion: ModelAssertion
+            An instance of the ModelAssertion subclass
+
+        Returns
+        -------
+        True if assertion succeeded or raises a ModelAssertionFailure
+        exception if not
+        """
+
+        self._ensure_required_caches(assertion)
+        return assertion.check(self.model, **{name: self._caches[name]
+                                              for name in
+                                              assertion.required_caches})
+
+    def check_all(self, stop_on_exception=False):
+        """Runs all assertions in the test suite"""
+        for a in self.assertions:
+            print('%s... ' % repr(a), end="")
+            try:
+                self.check(a)
+                print('%sOK%s' % (self._COL['OK'], self._COL['END']))
+            except ModelAssertionFailure as e:
+                print('%sFAIL%s' % (self._COL['FAIL'], self._COL['END']))
+                print('  ' + str(e.message))
+                if stop_on_exception:
+                    return
+            except Exception as e:
+                print('%sERROR%s' % (self._COL['FAIL'], self._COL['END']))
+                print('  ' + str(e))
+                if stop_on_exception:
+                    return
+
+
+class ModelAssertion(object):
+    """
+    Base class for model assertions
+    """
+    @abc.abstractmethod
+    def __init__(self, *args, **kwargs):
+        self.required_caches = set()
+        self._last_result = None
+
+    def __repr__(self):
+        return '%s()' % self.__class__.__name__
+
+    @abc.abstractmethod
+    def check(self, model, **kwargs):
+        if not isinstance(model, pysb.Model):
+            raise ValueError('model should be an instance of pysb.Model')
+
+
+def _negated_subclass(assertion_class, class_name):
+    """
+    Creates a negated version of an assertion class through subclassing
+
+    Parameters
+    ----------
+    assertion_class: class
+        ModelAssertion or its subclasses (not an instance)
+
+    Returns
+    -------
+    A negated version of the ModelAssertion class
+
+    """
+    class NegatedSubclass(assertion_class):
+        """
+        Negated version of :class:`.{}`
+        """.format(assertion_class.__class__.__name__)
+
+        def check(self, model, **kwargs):
+            try:
+                super(self.__class__, self).check(model, **kwargs)
+            except ModelAssertionFailure:
+                return True
+
+            raise ModelAssertionFailure(assertion=self, model=model,
+                                        message=self._last_result)
+
+    NegatedSubclass.__name__ = class_name
+    return NegatedSubclass
+
+
+class ReactionNetworkAssertion(ModelAssertion):
+    """
+    Base class for reaction network assertions
+
+    Checks the reaction network has been generated
+    """
+    def __init__(self, *args, **kwargs):
+        super(ReactionNetworkAssertion, self).__init__(*args, **kwargs)
+
+    @abc.abstractmethod
+    def check(self, model, **kwargs):
+        super(ReactionNetworkAssertion, self).check(model)
+        if not model.species:
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Reaction network has not '
+                                                'been generated yet')
+
+
+class SpeciesAssertion(ReactionNetworkAssertion):
+    """
+    Class for checking species within a reaction network
+    """
+    def __init__(self, *args, **kwargs):
+        super(SpeciesAssertion, self).__init__(*args, **kwargs)
+        self.required_caches.add('species_pattern_matcher')
+        self.pattern = args[0]
+
+    @abc.abstractmethod
+    def check(self, model, **kwargs):
+        super(SpeciesAssertion, self).check(model)
+
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.pattern)
+
+
+class SpeciesExists(SpeciesAssertion):
+    """
+    Checks a species pattern exists in the list of species
+    """
+    def check(self, model, **kwargs):
+        self._last_result = kwargs['species_pattern_matcher'].match(
+            self.pattern)
+        if self._last_result:
+            return True
+        else:
+            raise ModelAssertionFailure(assertion=self, model=model)
+
+
+SpeciesDoesNotExist = _negated_subclass(SpeciesExists, 'SpeciesDoesNotExist')
+
+
+class ReactionAssertion(ReactionNetworkAssertion):
+    def __init__(self, *args, **kwargs):
+        super(ReactionAssertion, self).__init__(*args, **kwargs)
+        self.required_caches.add('reaction_pattern_matcher')
+        self.pattern = args[0]
+
+    @abc.abstractmethod
+    def check(self, model, **kwargs):
+        super(ReactionAssertion, self).check(model)
+
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.pattern)
+
+
+class SpeciesIsProduct(ReactionAssertion):
+    """
+    Checks a species pattern appears on the product side of a reaction
+    """
+    def check(self, model, **kwargs):
+        self._last_result = kwargs[
+            'reaction_pattern_matcher'].match_products(self.pattern)
+        if not self._last_result:
+            raise ModelAssertionFailure(assertion=self, model=model)
+        else:
+            return True
+
+SpeciesNeverProduct = _negated_subclass(SpeciesIsProduct, 'SpeciesNeverProduct')
+
+
+class SpeciesIsReactant(ReactionAssertion):
+    """
+    Checks a species pattern appears on the reactant side of a reaction
+    """
+    def check(self, model, **kwargs):
+        self._last_result = kwargs[
+            'reaction_pattern_matcher'].match_reactants(self.pattern)
+        if self._last_result:
+            raise ModelAssertionFailure(assertion=self, model=model,
+                                        message=self._last_result)
+        else:
+            return True
+
+SpeciesNeverReactant = _negated_subclass(SpeciesIsReactant,
+                                         'SpeciesNeverReactant')
+
+
+class SpeciesOnlyProduct(ReactionAssertion):
+    """ Checks a species appears as a product but never as a reactant """
+    def check(self, model, **kwargs):
+        rpm = kwargs['reaction_pattern_matcher']
+        if not rpm.match_products(self.pattern):
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Does not appear as product')
+        as_reactant = rpm.match_reactants(self.pattern)
+        if as_reactant:
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Appears as reactant:' +
+                                                str(as_reactant))
+
+        return True
+
+
+class SpeciesOnlyReactant(ReactionAssertion):
+    """ Checks a species appears as a reactant but never as a product """
+
+    def check(self, model, **kwargs):
+        rpm = kwargs['reaction_pattern_matcher']
+        if not rpm.match_reactants(self.pattern):
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Does not appear as reactant')
+        as_product = rpm.match_products(self.pattern)
+        if as_product:
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Appears as product: ' +
+                                                str(as_product))
+
+        return True
+
+
+class RuleAssertion(ModelAssertion):
+    def __init__(self, *args, **kwargs):
+        super(RuleAssertion, self).__init__(*args, **kwargs)
+        self.required_caches.add('rule_pattern_matcher')
+        self.pattern = args[0]
+
+    @abc.abstractmethod
+    def check(self, model, **kwargs):
+        super(RuleAssertion, self).check(model)
+
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.pattern)
+
+
+class AllObservablesInRules(RuleAssertion):
+    def check(self, model, **kwargs):
+        rpm = kwargs['rule_pattern_matcher']
+        unmatched_observables = []
+        for obs in model.observables:
+            matches = rpm.match_rules(obs.reaction_pattern)
+            if not matches:
+                unmatched_observables.append(obs)
+        if unmatched_observables:
+            raise ModelAssertionFailure(assertion=self,
+                                        model=model,
+                                        message='Unmatched Observables: ' +
+                                                str(unmatched_observables))
+
+        return True

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -175,3 +175,43 @@ def test_complex_pattern_equivalence_compartments():
     # Check that enable_synth_deg is idempotent
     model.enable_synth_deg()
     assert len(model.initial_conditions) == 2
+
+@with_model
+def test_complex_pattern_equivalence_state():
+    """Ensure CP equivalence handles site states."""
+    Monomer('A', ['s', 't'], {'t': ['x', 'y', 'z']})
+    cp0 = A(s=1, t='x') % A(s=1, t='y')
+    cp1 = A(s=1, t='y') % A(s=1, t='x')
+    cp2 = A(s=1, t='x') % A(s=1, t='z')
+    cp3 = A(s=1, t='z') % A(s=1, t='y')
+    _check_pattern_equivalence((cp0, cp1))
+    _check_pattern_equivalence((cp0, cp2), False)
+    _check_pattern_equivalence((cp0, cp3), False)
+
+@with_model
+def test_complex_pattern_equivalence_bond_state():
+    """Ensure CP equivalence handles bond and state on the same site."""
+    Monomer('A', ['s'], {'s': ['x', 'y', 'z']})
+    cp0 = A(s=('x', 1)) % A(s=('y', 1))
+    cp1 = A(s=('y', 1)) % A(s=('x', 1))
+    cp2 = A(s=('z', 1)) % A(s=('y', 1))
+    cp3 = A(s='x') % A(s='y')
+    _check_pattern_equivalence((cp0, cp1))
+    _check_pattern_equivalence((cp0, cp2), False)
+    _check_pattern_equivalence((cp0, cp3), False)
+
+@with_model
+def test_complex_pattern_equivalence_bond_numbering():
+    """Ensure CP equivalence is insensitive to bond numbers."""
+    Monomer('A', ['s'])
+    cp0 = A(s=1) % A(s=1)
+    cp1 = A(s=2) % A(s=2)
+    _check_pattern_equivalence((cp0, cp1))
+
+@with_model
+def test_complex_pattern_equivalence_monomer_pattern_ordering():
+    """Ensure CP equivalence is insensitive to MP order."""
+    Monomer('A', ['s1', 's2'])
+    cp0 = A(s1=1, s2=2) % A(s1=2, s2=1)
+    cp1 = A(s1=2, s2=1) % A(s1=1, s2=2)
+    _check_pattern_equivalence((cp0, cp1))

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -176,6 +176,7 @@ def test_complex_pattern_equivalence_compartments():
     model.enable_synth_deg()
     assert len(model.initial_conditions) == 2
 
+
 @with_model
 def test_complex_pattern_equivalence_state():
     """Ensure CP equivalence handles site states."""
@@ -187,6 +188,7 @@ def test_complex_pattern_equivalence_state():
     _check_pattern_equivalence((cp0, cp1))
     _check_pattern_equivalence((cp0, cp2), False)
     _check_pattern_equivalence((cp0, cp3), False)
+
 
 @with_model
 def test_complex_pattern_equivalence_bond_state():
@@ -200,6 +202,7 @@ def test_complex_pattern_equivalence_bond_state():
     _check_pattern_equivalence((cp0, cp2), False)
     _check_pattern_equivalence((cp0, cp3), False)
 
+
 @with_model
 def test_complex_pattern_equivalence_bond_numbering():
     """Ensure CP equivalence is insensitive to bond numbers."""
@@ -208,6 +211,7 @@ def test_complex_pattern_equivalence_bond_numbering():
     cp1 = A(s=2) % A(s=2)
     _check_pattern_equivalence((cp0, cp1))
 
+
 @with_model
 def test_complex_pattern_equivalence_monomer_pattern_ordering():
     """Ensure CP equivalence is insensitive to MP order."""
@@ -215,3 +219,27 @@ def test_complex_pattern_equivalence_monomer_pattern_ordering():
     cp0 = A(s1=1, s2=2) % A(s1=2, s2=1)
     cp1 = A(s1=2, s2=1) % A(s1=1, s2=2)
     _check_pattern_equivalence((cp0, cp1))
+
+
+@with_model
+def test_complex_pattern_equivalence_compartments():
+    """Ensure CP equivalence is insensitive to Compartment"""
+    Monomer('A', ['s1'])
+    Compartment('C')
+    cp0 = (A(s1=1) % A(s1=1)) ** C
+    cp1 = (A(s1=1) ** C) % (A(s1=1) ** C)
+    _check_pattern_equivalence((cp0, cp1))
+
+
+@with_model
+def test_reaction_pattern_match_complex_pattern_ordering():
+    """Ensure CP equivalence is insensitive to MP order."""
+    Monomer('A', ['s1', 's2'])
+    cp0 = A(s1=1, s2=2) % A(s1=2, s2=1)
+    cp1 = A(s1=2, s2=1) % A(s1=1, s2=2)
+    rp0 = cp0 + cp1
+    rp1 = cp1 + cp0
+    rp2 = cp0 + cp0
+    assert rp0.matches(rp1)
+    assert rp1.matches(rp0)
+    assert rp2.matches(rp0)

--- a/pysb/tests/test_pattern.py
+++ b/pysb/tests/test_pattern.py
@@ -1,9 +1,10 @@
-from pysb.pattern import SpeciesPatternMatcher
+from pysb.pattern import SpeciesPatternMatcher, match_complex_pattern
 from pysb.examples import robertson, bax_pore, bax_pore_sequential, \
     earm_1_3, kinase_cascade, bngwiki_egfr_simple
 from pysb.bng import generate_equations
 from nose.tools import assert_raises
-from pysb import as_complex_pattern, as_reaction_pattern, ANY
+from pysb import as_complex_pattern, as_reaction_pattern, ANY, WILD, \
+    Monomer
 import collections
 
 
@@ -30,6 +31,14 @@ def test_species_pattern_matcher():
     )
     assert len(sp_sets) == 1
     assert len(sp_sets[0]) == 12
+
+
+def test_wildcards():
+    a_wild = as_complex_pattern(Monomer('A', ['b'], _export=False)(b=WILD))
+    b_mon = as_complex_pattern(Monomer('B', _export=None))
+
+    # B() should not match A(b=WILD)
+    assert not match_complex_pattern(b_mon, a_wild)
 
 
 def check_all_species_generated(model):

--- a/pysb/tests/test_pattern.py
+++ b/pysb/tests/test_pattern.py
@@ -1,0 +1,72 @@
+from pysb.pattern import SpeciesPatternMatcher
+from pysb.examples import robertson, bax_pore, bax_pore_sequential, \
+    earm_1_3, kinase_cascade, bngwiki_egfr_simple
+from pysb.bng import generate_equations
+from nose.tools import assert_raises
+from pysb import as_complex_pattern, as_reaction_pattern, ANY
+import collections
+
+
+def test_species_pattern_matcher():
+    # See also SpeciesPatternMatcher doctests
+
+    # Check that SpeciesPatternMatcher raises exception if model has no species
+    model = robertson.model
+    model.reset_equations()
+    assert_raises(Exception, SpeciesPatternMatcher, model)
+
+    model = bax_pore.model
+    generate_equations(model)
+    spm = SpeciesPatternMatcher(model)
+    BAX = model.monomers['BAX']
+    sp_sets = spm.species_fired_by_reactant_pattern(
+        as_reaction_pattern(BAX(t1=None, t2=None))
+    )
+    assert len(sp_sets) == 1
+    assert len(sp_sets[0]) == 2
+
+    sp_sets = spm.species_fired_by_reactant_pattern(
+        as_reaction_pattern(BAX(t1=ANY, t2=ANY))
+    )
+    assert len(sp_sets) == 1
+    assert len(sp_sets[0]) == 12
+
+
+def check_all_species_generated(model):
+    """Check the lists of rules and triggering species match BNG"""
+    generate_equations(model)
+    spm = SpeciesPatternMatcher(model)
+    try:
+        src_idx = model.get_species_index(as_complex_pattern(
+            model.monomers['__source']()
+        ))
+    except KeyError:
+        src_idx = None
+
+    # Get the rules and species firing them using the pattern matcher
+    species_produced = collections.defaultdict(set)
+    for rule, rp_species in spm.rule_firing_species().items():
+        if rp_species:
+            for sp_list in rp_species:
+                for sp in sp_list:
+                    species_produced[rule.name].add(
+                        model.get_species_index(sp))
+        else:
+            # If the reactant species is empty, mark the generating species
+            # as the __source monomer to match BNG
+            species_produced[rule.name].add(src_idx)
+
+    # Get the equivalent dictionary of {rule name: [reactant species]} from BNG
+    species_bng = collections.defaultdict(set)
+    for rxn in model.reactions:
+        for rule in rxn['rule']:
+            species_bng[rule].update(rxn['reactants'])
+
+    # Our output should match BNG
+    assert species_produced == species_bng
+
+
+def test_all_species_generated():
+    for model in [bax_pore, earm_1_3, bax_pore_sequential, kinase_cascade,
+                  bngwiki_egfr_simple]:
+        yield (check_all_species_generated, model.model)

--- a/pysb/tests/test_pattern.py
+++ b/pysb/tests/test_pattern.py
@@ -27,10 +27,10 @@ def test_species_pattern_matcher():
     assert len(sp_sets[0]) == 2
 
     sp_sets = spm.species_fired_by_reactant_pattern(
-        as_reaction_pattern(BAX(t1=ANY, t2=ANY))
+        as_reaction_pattern(BAX(t1=WILD, t2=ANY))
     )
     assert len(sp_sets) == 1
-    assert len(sp_sets[0]) == 12
+    assert len(sp_sets[0]) == 10
 
 
 def test_wildcards():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def main():
                     'pysb.testing', 'pysb.tests'],
           scripts=['scripts/pysb_export'],
           # We should really specify some minimum versions here.
-          install_requires=['numpy', 'scipy', 'sympy'],
+          install_requires=['numpy', 'scipy', 'sympy', 'networkx'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
                          'pandas', 'theano', 'h5py'],


### PR DESCRIPTION
Add a pattern matching engine (pattern.py) and a model test suite built off of that engine (testing/modeltests.py).

# Pattern Matching Engine

The pattern engine uses a graph-based implementation with networkx for checking pattern isomorphism. It can do one off matching (`SimplePatternMatcher` class) or repeated lookups (`SpeciesPatternMatcher`, `ReactionPatternMatcher` and `RulePatternMatcher`) which create lookup caches for fast repeated pattern matching. See the docstring examples in those classes for details. The framework is designed for large numbers of tests against a fixed list of species/reactions/rules (typically, those from a single model). Thus, the functions typically try to "fail fast" (i.e. reject putative matches quickly, where possible, by performing computationally simpler checks first).

The core of the system is a new [networkx](https://networkx.github.io/)-based graph representation of ComplexPatterns (see `ComplexPattern.as_graph()` documentation for implementation details). Patterns can then be checked for exact equality (species equivalence) using a graph isomorphism check, or for subgraph equality (for matching a pattern against species) using a subgraph isomorphism check. This is implemented in `SimplePatternMatcher.match_complex_pattern()`.

ReactionPatterns are matched by checking pairwise combinations of the two ReactionPatterns' sets of ComplexPatterns. If there's a one-to-one match, the match is trivially True, if there are  multiple possible matches, we need to check if a match is possible without reusing the same ComplexPattern. This can be done by encoding the two sets of ComplexPatterns in a bipartite graph and checking for a maximum matching. More details are in the `SimplePatternMatcher.match_reaction_pattern()` docstring.

`SpeciesPatternMatcher` is used for cache-backed comparison of patterns against a list of species (typically, the list of species in a model). Internally, a `_species_cache` is created which creates a Monomer->list of species mapping for rapid lookup. We can then extract the list of monomers in the test pattern, retrieve matching species for each of those monomers in the `_species_cache`, and take the intersection. This allows us to rapidly create a shortlist of candidate matches before doing full graph-based isomorphism comparison (which is computationally expensive).

The `ReactionPatternMatcher` and `RulePatternMatcher` work in a similar vein. These matchers have cache tables mapping Monomer->list of reactions/rules for the reaction and pattern sides separately, as we often want to check just one side of a reaction/rule.

# Model Test Suite

The model test suite allows checking of model assumptions as assertions, e.g. that certain species are generated or not generated, or appear only as reactants or only as products. These may be useful for large models or those with complicated rule sets. See the docstring examples in `TestSuite` for details.

This builds on the pattern matching suite defined above, and can be used interactively or as part of a model's unit tests. The user creates a `TestSuite` instance, and then adds any desired tests on the model's species list, rule set, or reaction network. In principle, these tests could check any other aspect of a model, by implementing new checks as subclasses of `ModelAssertion`. Several checks are implemented "out of the box", e.g. `SpeciesOnlyProduct` (a species appears only on the product side of all reactions), and `AllObservablesInRules` (checks all model observables are specified in at least one rule).

Resolves: pysb/pysb#13