### PR TITLE
Fix SimulationResult.all with unicode obs/exprs

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -679,10 +679,10 @@ class SimulationResult(object):
             sp_names = ['__s%d' % i for i in range(len(self._model.species))]
             yfull_dtype = zip(sp_names, itertools.repeat(float))
             if len(self._model.observables):
-                yfull_dtype += zip(self._model.observables.keys(),
+                yfull_dtype += zip(self._yobs[0].dtype.names,
                                    itertools.repeat(float))
             if len(self._model.expressions_dynamic()):
-                yfull_dtype += zip(self._model.expressions_dynamic().keys(),
+                yfull_dtype += zip(self._yexpr[0].dtype.names,
                                    itertools.repeat(float))
             yfull = []
             # loop over simulations

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -679,11 +679,9 @@ class SimulationResult(object):
             sp_names = ['__s%d' % i for i in range(len(self._model.species))]
             yfull_dtype = zip(sp_names, itertools.repeat(float))
             if len(self._model.observables):
-                yfull_dtype += zip(self._yobs[0].dtype.names,
-                                   itertools.repeat(float))
+                yfull_dtype += self._yobs[0].dtype.descr
             if len(self._model.expressions_dynamic()):
-                yfull_dtype += zip(self._yexpr[0].dtype.names,
-                                   itertools.repeat(float))
+                yfull_dtype += self._yexpr[0].dtype.descr
             yfull = []
             # loop over simulations
             for n in range(self.nsims):

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -291,6 +291,8 @@ def test_unicode_obsname_ascii():
     rob_copy.observables[0].name = u'A_total'
     sim = ScipyOdeSimulator(rob_copy)
     simres = sim.run(tspan=t)
+    simres.all
+    simres.dataframe
 
 
 if sys.version_info[0] < 3:
@@ -313,6 +315,8 @@ def test_unicode_exprname_ascii():
     rob_copy.add_component(expr)
     sim = ScipyOdeSimulator(rob_copy)
     simres = sim.run(tspan=t)
+    simres.all
+    simres.dataframe
 
 
 if sys.version_info[0] < 3:


### PR DESCRIPTION
This patch fixes `SimulationResult.all` when any observable or expression has a unicode name, and amends the unit tests to check `.all` works.

Fixes #290 
