### PR TITLE
Save and load SimulationResults to HDF5 files

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1212,6 +1212,14 @@ class Model(object):
                 component._do_export()
             self.initial_conditions = model_copy.initial_conditions
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # The stoichiometry matrix, as a numpy array, is problematic to pickle
+        # in a cross-Python-version-compatible way. Since it's regenerated on
+        # demand anyway, we can just clear it here.
+        state['_stoichiometry_matrix'] = None
+        return state
+
     def __setstate__(self, state):
         # restore the 'model' weakrefs on all components
         self.__dict__.update(state)

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -11,6 +11,7 @@ import pickle
 from pysb import __version__ as PYSB_VERSION
 from datetime import datetime
 import dateutil.parser
+import copy
 
 try:
     import pandas as pd
@@ -562,16 +563,16 @@ class SimulationResult(object):
                  model=None, initials=None, param_values=None):
         if simulator:
             simulator._logger.debug('SimulationResult constructor started')
-            self._param_values = simulator.param_values
+            self._param_values = simulator.param_values.copy()
             try:
-                self._initials = simulator.initials
+                self._initials = simulator.initials.copy()
             except SimulatorException:
                 # Network free simulations don't have initials list, only dict
-                self._initials = simulator.initials_dict
-            self._model = simulator._model
+                self._initials = simulator.initials_dict.copy()
+            self._model = copy.deepcopy(simulator._model)
             self.simulator_class = simulator.__class__
-            self.init_kwargs = simulator._init_kwargs
-            self.run_kwargs = simulator._run_kwargs
+            self.init_kwargs = copy.deepcopy(simulator._init_kwargs)
+            self.run_kwargs = copy.deepcopy(simulator._run_kwargs)
         else:
             self._param_values = param_values
             self._initials = initials

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -781,6 +781,8 @@ class SimulationResult(object):
         """
         List of trajectory sets. The first dimension contains observables.
         """
+        if not self._model.observables:
+            raise ValueError('Model has no observables')
         return self._squeeze_output(self._yobs)
 
     @property
@@ -788,6 +790,8 @@ class SimulationResult(object):
         """
         List of trajectory sets. The first dimension contains expressions.
         """
+        if not self._model.expressions_dynamic():
+            raise ValueError('Model has no dynamic expressions')
         return self._squeeze_output(self._yexpr)
 
     @property

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -868,10 +868,10 @@ class SimulationResult(object):
             # Get or create the group
             try:
                 grp = hdf.create_group(group_name)
-                grp.attrs['model'] = enpickle(self._model)
+                grp.create_dataset('_model', data=enpickle(self._model))
             except ValueError:
                 grp = hdf[group_name]
-                model = pickle.loads(grp.attrs['model'])
+                model = pickle.loads(grp['_model'][()])
                 if model.name != self._model.name:
                     raise ValueError('SimulationResult model has name "{}", '
                                      'but the model in HDF5 file group "{}" '
@@ -949,11 +949,12 @@ class SimulationResult(object):
 
             if dataset_name is None:
                 datasets = grp.keys()
+                datasets.remove('_model')
                 if len(datasets) > 1:
                     raise ValueError("dataset_name must be specified when "
                                      "group contains more than one dataset. "
                                      "Options are: {}".format(str(datasets)))
-                dataset_name = grp.keys()[0]
+                dataset_name = datasets[0]
 
             dset = grp[dataset_name]
 
@@ -986,7 +987,7 @@ class SimulationResult(object):
 
             simres = cls(
                 simulator=None,
-                model=pickle.loads(grp.attrs['model']),
+                model=pickle.loads(grp['_model'][()]),
                 initials=initials,
                 param_values=np.array(dset['param_values']),
                 tout=np.array(dset['tout']),

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -1029,14 +1029,9 @@ class SimulationResult(object):
             except KeyError:
                 initials = pickle.loads(dset['initials_dict'][()])
 
-            if sys.version_info[0] < 3:
-                model = pickle.loads(grp['_model'][()])
-            else:
-                model = pickle.loads(grp['_model'][()], encoding='latin1')
-
             simres = cls(
                 simulator=None,
-                model=model,
+                model=pickle.loads(grp['_model'][()]),
                 initials=initials,
                 param_values=np.array(dset['param_values']),
                 tout=np.array(dset['tout']),

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -663,10 +663,10 @@ class SimulationResult(object):
                                     '%s names not allowed' % name_type
                         raise ValueError(error_msg)
 
-        yobs_dtype = zip(obs_names, itertools.repeat(float)) if obs_names \
-            else float
-        yexpr_dtype = zip(expr_names, itertools.repeat(float)) if expr_names \
-            else float
+        yobs_dtype = (list(zip(obs_names, itertools.repeat(float)))
+                      if obs_names else float)
+        yexpr_dtype = (list(zip(expr_names, itertools.repeat(float)))
+                       if expr_names else float)
 
         if observables_and_expressions:
             # Observables and expression values are used as supplied
@@ -974,12 +974,12 @@ class SimulationResult(object):
                     raise ValueError("group_name must be specified when file "
                                      "contains more than one group. Options "
                                      "are: {}".format(str(groups)))
-                group_name = hdf.keys()[0]
+                group_name = next(iter(hdf))
 
             grp = hdf[group_name]
 
             if dataset_name is None:
-                datasets = grp.keys()
+                datasets = list(grp.keys())
                 datasets.remove('_model')
                 if len(datasets) > 1:
                     raise ValueError("dataset_name must be specified when "

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -12,6 +12,7 @@ from pysb import __version__ as PYSB_VERSION
 from datetime import datetime
 import dateutil.parser
 import copy
+from warnings import warn
 
 try:
     import pandas as pd
@@ -848,12 +849,12 @@ class SimulationResult(object):
             have complex expressions which take a long time to compute.
         """
         if h5py is None:
-            raise Exception('Please "pip install h5py" for this feature')
+            raise Exception('Please install the h5py package for this feature')
 
         if self._y is None and not include_obs_exprs:
-            raise ValueError('This SimulationResult has no trajectories - '
-                             'you will need to set include_obs_exprs=True if '
-                             'you wish to save observables and expressions')
+            warn('This SimulationResult has no trajectories - '
+                 'you will need to set include_obs_exprs=True if '
+                 'you wish to save observables and expressions')
 
         if group_name is None:
             group_name = self._model.name

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import dateutil.parser
 import copy
 from warnings import warn
+import sys
 try:
     basestring
 except NameError:
@@ -1028,9 +1029,14 @@ class SimulationResult(object):
             except KeyError:
                 initials = pickle.loads(dset['initials_dict'][()])
 
+            if sys.version_info[0] < 3:
+                model = pickle.loads(grp['_model'][()])
+            else:
+                model = pickle.loads(grp['_model'][()], encoding='latin1')
+
             simres = cls(
                 simulator=None,
-                model=pickle.loads(grp['_model'][()]),
+                model=model,
                 initials=initials,
                 param_values=np.array(dset['param_values']),
                 tout=np.array(dset['tout']),

--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -74,7 +74,8 @@ class BngSimulator(Simulator):
         """
         super(BngSimulator, self).run(tspan=tspan,
                                       initials=initials,
-                                      param_values=param_values
+                                      param_values=param_values,
+                                      _run_kwargs=locals()
                                       )
 
         if method not in self._SIMULATOR_TYPES:

--- a/pysb/simulator/cupsoda.py
+++ b/pysb/simulator/cupsoda.py
@@ -224,7 +224,8 @@ class CupSodaSimulator(Simulator):
            concentrations and parameter values defined in the model.
         """
         super(CupSodaSimulator, self).run(tspan=tspan, initials=initials,
-                                          param_values=param_values)
+                                          param_values=param_values,
+                                          _run_kwargs=[])
 
         # Create directories for cupSODA input and output files
         self.outdir = tempfile.mkdtemp(prefix=self._prefix + '_',

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -374,7 +374,8 @@ class ScipyOdeSimulator(Simulator):
         """
         super(ScipyOdeSimulator, self).run(tspan=tspan,
                                            initials=initials,
-                                           param_values=param_values)
+                                           param_values=param_values,
+                                           _run_kwargs=[])
         n_sims = len(self.param_values)
         trajectories = np.ndarray((n_sims, len(self.tspan),
                               len(self._model.species)))

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -255,7 +255,8 @@ class StochKitSimulator(Simulator):
         """
         super(StochKitSimulator, self).run(tspan=tspan,
                                            initials=initials,
-                                           param_values=param_values)
+                                           param_values=param_values,
+                                           _run_kwargs=locals())
 
         self._logger.info('Running StochKit with {:d} parameter sets, '
                           '{:d} repeats ({:d} simulations total)'.format(

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -1,7 +1,10 @@
 from pysb.simulator import ScipyOdeSimulator
 from pysb.simulator.base import SimulationResult
-from pysb.examples import tyson_oscillator
+from pysb.examples import tyson_oscillator, robertson
 import numpy as np
+import tempfile
+from nose.tools import assert_raises
+from pandas.util.testing import assert_frame_equal
 
 
 def test_simres_dataframe():
@@ -37,3 +40,63 @@ def test_simres_dataframe():
 
     assert df2.shape == (len(tspan1) + len(tspan3),
                          len(model.species) + len(model.observables))
+
+
+def test_save_load():
+    tspan = np.linspace(0, 100, 101)
+    model = tyson_oscillator.model
+    sim = ScipyOdeSimulator(model, integrator='lsoda')
+    simres = sim.run(tspan=tspan, param_values={'k6': 1.0})
+
+    sim_rob = ScipyOdeSimulator(robertson.model, integrator='lsoda')
+    simres_rob = sim_rob.run(tspan=tspan)
+
+    with tempfile.NamedTemporaryFile() as tf:
+        simres.save(tf.name, dataset_name='test', append=True)
+
+        # Try to reload when file contains only one dataset and group
+        SimulationResult.load(tf.name)
+
+        simres.save(tf.name, append=True)
+
+        # Trying to overwrite an existing dataset gives a ValueError
+        assert_raises(ValueError, simres.save, tf.name, append=True)
+
+        # Trying to write to an existing file without append gives an IOError
+        assert_raises(IOError, simres.save, tf.name)
+
+        # Trying to write a SimulationResult to the same group with a
+        # different model name results in a ValueError
+        assert_raises(ValueError, simres_rob.save, tf.name,
+                      dataset_name='robertson', group_name=model.name,
+                      append=True)
+
+        simres_rob.save(tf.name, append=True)
+
+        # Trying to load from a file with more than one group without
+        # specifying group_name should raise a ValueError
+        assert_raises(ValueError, SimulationResult.load, tf.name)
+
+        # Trying to load from a group with more than one dataset without
+        # specifying a dataset_name should raise a ValueError
+        assert_raises(ValueError, SimulationResult.load, tf.name,
+                      group_name=model.name)
+
+        # Load should succeed when specifying group_name and dataset_name
+        simres_load = SimulationResult.load(tf.name, group_name=model.name,
+                                            dataset_name='test')
+
+    assert np.allclose(simres.species, simres_load.species)
+    assert np.allclose(simres.tout, simres_load.tout)
+    assert np.allclose(simres.param_values, simres_load.param_values)
+    assert np.allclose(simres.initials, simres_load.initials)
+    assert_frame_equal(simres.dataframe, simres_load.dataframe)
+
+    assert simres.squeeze == simres_load.squeeze
+    assert simres.simulator_class == simres_load.simulator_class
+    assert simres.simulator_kwargs == simres_load.simulator_kwargs
+    assert simres.n_sims_per_parameter_set == \
+           simres_load.n_sims_per_parameter_set
+    assert simres._model.name == simres_load._model.name
+    assert simres.creation_date == simres_load.creation_date
+    assert simres.pysb_version == simres_load.pysb_version

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -4,7 +4,6 @@ from pysb.examples import tyson_oscillator, robertson, expression_observables
 import numpy as np
 import tempfile
 from nose.tools import assert_raises
-from pandas.util.testing import assert_frame_equal
 
 
 def test_simres_dataframe():
@@ -61,7 +60,7 @@ def test_save_load():
 
     # NFsim with expressions
     nfsim2 = BngSimulator(expression_observables.model)
-    nfres2 = nfsim2.run(n_runs=1, method='nf', tspan=np.linspace(0, 1, 24))
+    nfres2 = nfsim2.run(n_runs=1, method='nf', tspan=np.linspace(0, 100, 11))
 
     with tempfile.NamedTemporaryFile() as tf:
         simres.save(tf.name, dataset_name='test', append=True)
@@ -117,7 +116,7 @@ def test_save_load():
     _check_resultsets_equal(simres, simres_load)
     _check_resultsets_equal(nfres1, nfres1_load)
     _check_resultsets_equal(nfres2, nfres2_load)
-        
+
 
 def _check_resultsets_equal(res1, res2):
     try:
@@ -127,16 +126,20 @@ def _check_resultsets_equal(res1, res2):
         pass
     assert np.allclose(res1.tout, res2.tout)
     assert np.allclose(res1.param_values, res2.param_values)
+    
     if isinstance(res1.initials, np.ndarray):
         assert np.allclose(res1.initials, res2.initials)
     else:
         for k, v in res1.initials.items():
             assert np.allclose(res1.initials[k], v)
-    assert_frame_equal(res1.dataframe, res2.dataframe)
+
+    assert np.allclose(res1._yobs_view, res1._yobs_view)
+    assert np.allclose(res1._yexpr_view, res2._yexpr_view)
 
     assert res1.squeeze == res2.squeeze
     assert res1.simulator_class == res2.simulator_class
-    assert res1.simulator_kwargs == res2.simulator_kwargs
+    assert res1.init_kwargs == res2.init_kwargs
+    assert res1.run_kwargs == res2.run_kwargs
     assert res1.n_sims_per_parameter_set == \
            res2.n_sims_per_parameter_set
     assert res1._model.name == res2._model.name

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -134,7 +134,8 @@ def _check_resultsets_equal(res1, res2):
             assert np.allclose(res1.initials[k], v)
 
     assert np.allclose(res1._yobs_view, res1._yobs_view)
-    assert np.allclose(res1._yexpr_view, res2._yexpr_view)
+    if res1._model.expressions_dynamic():
+        assert np.allclose(res1._yexpr_view, res2._yexpr_view)
 
     assert res1.squeeze == res2.squeeze
     assert res1.simulator_class == res2.simulator_class

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -4,6 +4,7 @@ from pysb.examples import tyson_oscillator, robertson, expression_observables
 import numpy as np
 import tempfile
 from nose.tools import assert_raises
+import os
 
 
 def test_simres_dataframe():
@@ -63,6 +64,9 @@ def test_save_load():
     nfres2 = nfsim2.run(n_runs=1, method='nf', tspan=np.linspace(0, 100, 11))
 
     with tempfile.NamedTemporaryFile() as tf:
+        if os.name == 'nt':
+            # Cannot have two file handles on Windows
+            tf.close()
         simres.save(tf.name, dataset_name='test', append=True)
 
         # Try to reload when file contains only one dataset and group

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -45,6 +45,8 @@ def test_simres_dataframe():
 def test_save_load():
     tspan = np.linspace(0, 100, 101)
     model = tyson_oscillator.model
+    test_unicode_name = u'Hello \u2603 and \U0001f4a9!'
+    model.name = test_unicode_name
     sim = ScipyOdeSimulator(model, integrator='lsoda')
     simres = sim.run(tspan=tspan, param_values={'k6': 1.0})
 
@@ -104,6 +106,7 @@ def test_save_load():
         # Load should succeed when specifying group_name and dataset_name
         simres_load = SimulationResult.load(tf.name, group_name=model.name,
                                             dataset_name='test')
+        assert simres_load._model.name == test_unicode_name
 
         # Saving network free results requires include_obs_exprs=True,
         # otherwise a warning should be raised

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -58,6 +58,10 @@ def test_save_load():
     # NFsim without expressions
     nfsim1 = BngSimulator(robertson.model)
     nfres1 = nfsim1.run(n_runs=2, method='nf', tspan=np.linspace(0, 1))
+    # Test attribute saving (text, float, list)
+    nfres1.custom_attrs['note'] = 'NFsim without expressions'
+    nfres1.custom_attrs['pi'] = 3.14
+    nfres1.custom_attrs['some_list'] = [1, 2, 3]
 
     # NFsim with expressions
     nfsim2 = BngSimulator(expression_observables.model)
@@ -105,7 +109,7 @@ def test_save_load():
         # otherwise a warning should be raised
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            nfres1.save(tf.name, append=True)
+            nfres1.save(tf.name, dataset_name='nfsim_no_obs', append=True)
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
 
@@ -153,5 +157,6 @@ def _check_resultsets_equal(res1, res2):
     assert res1.n_sims_per_parameter_set == \
            res2.n_sims_per_parameter_set
     assert res1._model.name == res2._model.name
-    assert res1.creation_date == res2.creation_date
+    assert res1.timestamp == res2.timestamp
     assert res1.pysb_version == res2.pysb_version
+    assert res1.custom_attrs == res2.custom_attrs

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def main():
           install_requires=['numpy', 'scipy', 'sympy'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas', 'theano'],
+                         'pandas', 'theano', 'h5py'],
           cmdclass=cmdclass,
           use_2to3=True,
           keywords=['systems', 'biology', 'model', 'rules'],


### PR DESCRIPTION
This PR implements `SimulationResult.save()` and `.load()` functions, using an HDF5-based file format. HDF5 is a hierarchical, binary storage format well suited to storing matrix-like data. This implementation uses the h5py package.

The file format stores not only the simulation trajectories, but also metadata relevant to archiving, such as the model itself, simulation settings, parameter and initial condition values, simulation date/time, and PySB version.

The goals are to aid reproducibility and to facilitate exchange of simulation data.