### PR TITLE
ScipyOdeSimulator lambdify and theano support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 - conda update --yes conda
 - conda install --yes -c omnia python="$TRAVIS_PYTHON_VERSION"
     numpy scipy matplotlib sympy networkx nose h5py pexpect pandas pygraphviz=1.3 theano
+- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install weave; fi
 - pip install python-coveralls
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 - export PATH="$HOME/miniconda/bin:$PATH"
 - conda update --yes conda
 - conda install --yes -c omnia python="$TRAVIS_PYTHON_VERSION"
-    numpy scipy matplotlib sympy networkx nose h5py pexpect pandas pygraphviz=1.3
+    numpy scipy matplotlib sympy networkx nose h5py pexpect pandas pygraphviz=1.3 theano
 - pip install python-coveralls
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc

--- a/doc/examples/robertson_standalone.py
+++ b/doc/examples/robertson_standalone.py
@@ -8,7 +8,8 @@ Analysis: An Introduction, J. Walsh, ed., Academic Press, 1966, pp. 178-182.
 # exported from PySB model 'robertson'
 
 import numpy
-import scipy.weave, scipy.integrate
+import weave
+import scipy.integrate
 import collections
 import itertools
 import distutils.errors
@@ -17,7 +18,7 @@ import distutils.errors
 _use_inline = False
 # try to inline a C statement to see if inline is functional
 try:
-    scipy.weave.inline('int i;', force=1)
+    weave.inline('int i;', force=1)
     _use_inline = True
 except distutils.errors.CompileError:
     pass
@@ -61,7 +62,7 @@ class Model(object):
         
         def ode_rhs(self, t, y, p):
             ydot = self.ydot
-            scipy.weave.inline(r'''                
+            weave.inline(r'''
                 ydot[0] = -p[0]*y[0] + p[2]*y[1]*y[2];
                 ydot[1] = p[0]*y[0] - p[1]*pow(y[1], 2) - p[2]*y[1]*y[2];
                 ydot[2] = p[1]*pow(y[1], 2);

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -114,7 +114,8 @@ class PythonExporter(Exporter):
         output.write("# exported from PySB model '%s'\n" % self.model.name)
         output.write(pad(r"""
             import numpy
-            import scipy.weave, scipy.integrate
+            import weave
+            import scipy.integrate
             import collections
             import itertools
             import distutils.errors
@@ -123,7 +124,7 @@ class PythonExporter(Exporter):
             _use_inline = False
             # try to inline a C statement to see if inline is functional
             try:
-                scipy.weave.inline('int i;', force=1)
+                weave.inline('int i;', force=1)
                 _use_inline = True
             except distutils.errors.CompileError:
                 pass
@@ -179,7 +180,7 @@ class PythonExporter(Exporter):
         output.write(pad(r"""
             def ode_rhs(self, t, y, p):
                 ydot = self.ydot
-                scipy.weave.inline(r'''%s''', ['ydot', 't', 'y', 'p'])
+                weave.inline(r'''%s''', ['ydot', 't', 'y', 'p'])
                 return ydot
             """, 8) % (pad('\n' + code_eqs, 16) + ' ' * 16))
         output.write("    else:\n")

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,8 +1,8 @@
 import inspect
 import warnings
 import pysb
+import sympy
 from sympy.printing import StrPrinter
-from sympy.logic.boolalg import BooleanTrue
 
 # Alias basestring under Python 3 for forwards compatibility
 try:
@@ -256,7 +256,7 @@ class BngPrinter(StrPrinter):
         super(BngPrinter, self).__init__(settings)
 
     def _print_Piecewise(self, expr):
-        if type(expr.args[-1][1]) != BooleanTrue:
+        if expr.args[-1][1] is not sympy.true:
             raise NotImplementedError('Piecewise statements are only '
                                       'supported if convertible to BNG if '
                                       'statements')

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,7 +1,6 @@
 import inspect
 import warnings
 import pysb
-import sympy
 from sympy.printing import StrPrinter
 from sympy.logic.boolalg import BooleanTrue
 

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -254,7 +254,7 @@ def setup_module(module):
     """Doctest fixture for nose."""
     # Distutils' temp directory creation code has a more-or-less unsuppressable
     # print to stdout which will break the doctest which triggers it (via
-    # scipy.weave.inline). So here we run an end-to-end test of the inlining
+    # weave.inline). So here we run an end-to-end test of the inlining
     # system to get that print out of the way at a point where it won't matter.
     # As a bonus, the test harness is suppressing writes to stdout at this time
     # anyway so the message is just swallowed silently.

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -158,7 +158,8 @@ class ScipyOdeSimulator(Simulator):
             def rhs(t, y, p):
                 ydot = self.ydot
                 # note that the evaluated code sets ydot as a side effect
-                weave_inline(code_eqs, ['ydot', 't', 'y', 'p'])
+                weave_inline(code_eqs, ['ydot', 't', 'y', 'p'],
+                             extra_compile_args=['-w'])
                 return ydot
 
         if use_theano or not self._use_inline:
@@ -236,7 +237,8 @@ class ScipyOdeSimulator(Simulator):
 
                 def jacobian(t, y, p):
                     jac = self.jac
-                    weave_inline(jac_eqs, ['jac', 't', 'y', 'p'])
+                    weave_inline(jac_eqs, ['jac', 't', 'y', 'p'],
+                                 extra_compile_args=['-w'])
                     return jac
             else:
                 jac_eqs_py = sympy.lambdify(self._symbols, jac_matrix, "numpy")

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -2,8 +2,8 @@ from pysb.simulator.base import Simulator, SimulatorException, SimulationResult
 import scipy.integrate
 try:
     # weave is not available under Python 3.
-    from scipy.weave import inline as weave_inline
-    import scipy.weave.build_tools
+    from weave import inline as weave_inline
+    import weave.build_tools
 except ImportError:
     weave_inline = None
 try:
@@ -291,7 +291,7 @@ class ScipyOdeSimulator(Simulator):
     @classmethod
     def _test_inline(cls):
         """
-        Detect whether scipy.weave.inline is functional.
+        Detect whether weave.inline is functional.
 
         Produces compile warnings, which we suppress by capturing STDERR.
         """
@@ -307,7 +307,7 @@ class ScipyOdeSimulator(Simulator):
                     weave_inline('int i=0; i=i;', force=1,
                                  extra_compile_args=extra_compile_args)
                     cls._use_inline = True
-            except (scipy.weave.build_tools.CompileError,
+            except (weave.build_tools.CompileError,
                     distutils.errors.CompileError, ImportError):
                 pass
 

--- a/pysb/tests/test_expressions.py
+++ b/pysb/tests/test_expressions.py
@@ -71,5 +71,5 @@ def test_piecewise_expression():
     Rule('A_deg', A() >> None, A_deg_expr)
     generate_equations(model)
     t = np.linspace(0, 1000, 100)
-    sol = Solver(model, t)
+    sol = Solver(model, t, use_analytic_jacobian=True)
     sol.run()

--- a/pysb/tests/test_expressions.py
+++ b/pysb/tests/test_expressions.py
@@ -3,6 +3,8 @@ from pysb.testing import *
 from pysb.bng import *
 from pysb.integrate import Solver
 import numpy as np
+from sympy import Piecewise
+
 
 @with_model
 def test_ic_expression_with_two_parameters():
@@ -56,4 +58,18 @@ def test_nested_expression():
     generate_equations(model)
     t = np.linspace(0, 1000, 100)
     sol = Solver(model, t, use_analytic_jacobian=True)
+    sol.run()
+
+@with_model
+def test_piecewise_expression():
+    Monomer('A')
+    Observable('A_total', A())
+    Expression('A_deg_expr', Piecewise((0, A_total < 400.0),
+                                       (0.001, A_total < 500.0),
+                                       (0.01, True)))
+    Initial(A(), Parameter('A_0', 1000))
+    Rule('A_deg', A() >> None, A_deg_expr)
+    generate_equations(model)
+    t = np.linspace(0, 1000, 100)
+    sol = Solver(model, t)
     sol.run()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def main():
           install_requires=['numpy', 'scipy', 'sympy'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas'],
+                         'pandas', 'theano'],
           cmdclass=cmdclass,
           use_2to3=True,
           keywords=['systems', 'biology', 'model', 'rules'],


### PR DESCRIPTION
This PR replaces the previous `eval` mechanism for ODE evaluation in `ScipyOdeSimulator` with `lambdify`, allowing some extra rate laws which would previously fail, e.g. `Piecewise` expressions (see new unit test `test_piecewise_expression`). It is >30% faster on the time_scipy_lsoda benchmark for me vs current master (553eadc).

Experimental [theano](http://deeplearning.net/software/theano/) support is also added, and can be enabled using a `use_theano=True` argument to the `ScipyOdeSimulator` constructor. Theano has some interesting capabilities like GPU offloading which might help with large, complex expression sets, but it needs more testing and benchmarking to establish which simulation scenarios it's appropriate for.

The PR also slightly cleans up the BNG generator code by subclassing sympy's `StrPrinter`.