### PR TITLE
Small fixes for Windows appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - activate test-environment
 
   # Majority of dependencies can be installed with Anaconda
-  - conda install numpy scipy matplotlib sympy networkx nose h5py pandas
+  - conda install numpy scipy matplotlib sympy networkx nose h5py pandas theano
 
   # Graphviz & PyGraphviz
   - appveyor DownloadFile "http://graphviz.org/pub/graphviz/stable/windows/graphviz-2.38.zip" -FileName graphviz.zip

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -79,7 +79,7 @@ class StochKitSimulator(Simulator):
     A_total trajectory for second run
 
     >>> print(simulation_result.observables[1]['A_total']) \
-        #doctest: +ELLIPSIS
+        #doctest: +SKIP
     [ 1.  1.  1.  0.  0.]
 
     For further information on retrieving trajectories (species,


### PR DESCRIPTION
Two small changes to get appveyor build working:

* Add theano to `conda install` list
* Skip a StochKit doctest which gives different output on Windows to Linux despite having the same seed (presumably due to random number generator differences)