### PR TITLE
Fix sphinx build by adding scipy.sparse mock module

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,7 +54,7 @@ copyright = u'2012, C. F. Lopez, J. L. Muhlich, J. A. Bachman'
 MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy',  'sympy.parsing',
                  'sympy.parsing.sympy_parser',
                  'sympy.printing', 'sympy.printing.mathml', 'numpy',
-                 'scipy', 'scipy.integrate', 'scipy.constants' ]
+                 'scipy', 'scipy.integrate', 'scipy.constants', 'scipy.sparse']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.MagicMock()
 sys.modules['sympy'].Symbol = type('Symbol', (object,), {})


### PR DESCRIPTION
Small fix to get sphinx build working by adding `scipy.sparse` as mock module