### PR TITLE
Fix link rot in appveyor config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
 - chmod +x miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
-- conda update --yes conda
+# Install conda 4.3.21 to avoid conda/weave issue (see #297 discussion)
+- conda install --yes conda==4.3.21
 - conda install --yes -c omnia python="$TRAVIS_PYTHON_VERSION"
     numpy scipy matplotlib sympy networkx nose h5py pexpect pandas pygraphviz=1.3 theano
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install weave; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
   - if "%PYTHON_VERSION%"=="3.4" pip install https://www.dropbox.com/s/g51cnau5nlww9fc/pygraphviz-1.3.1-cp34-none-win32.whl?dl=1
 
   # BioNetGen
-  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=348" -FileName BioNetGen.zip
+  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip
   - 7z x BioNetGen.zip -y > nul
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,8 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 2.7
-      PYTHON_SVER: 27
       MINICONDA: C:\Miniconda
     - PYTHON_VERSION: 3.4
-      PYTHON_SVER: 34
       MINICONDA: C:\Miniconda3
 
 init:
@@ -33,7 +31,8 @@ install:
   - appveyor DownloadFile "http://graphviz.org/pub/graphviz/stable/windows/graphviz-2.38.zip" -FileName graphviz.zip
   - 7z x graphviz.zip -y > nul
   - set "PATH=%cd%\release\lib\release\dll;%PATH%"
-  - pip install https://dl.dropboxusercontent.com/u/6251352/pygraphviz-1.3.1-cp%PYTHON_SVER%-none-win32.whl?dl=1
+  - if "%PYTHON_VERSION%"=="2.7" pip install https://www.dropbox.com/s/fixts2t9l082r2o/pygraphviz-1.3.1-cp27-none-win32.whl?dl=1
+  - if "%PYTHON_VERSION%"=="3.4" pip install https://www.dropbox.com/s/g51cnau5nlww9fc/pygraphviz-1.3.1-cp34-none-win32.whl?dl=1
 
   # BioNetGen
   - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/?smd_process_download=1&download_id=348" -FileName BioNetGen.zip


### PR DESCRIPTION
The download links for pygraphviz were broken due to the discontinuation of public Dropbox folders, and the link for BioNetGen was updated on the remote server to point to a newer version than desired for PySB (2.3.0 vs 2.2.6). These links have been updated to fix our appveyor continuous integration.