### PR TITLE
Improve control over weave.inline console output

### DIFF
--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -248,14 +248,3 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
                             verbose=verbose, **integrator_options)
     simres = sim.run(param_values=param_values, initials=y0)
     return simres.all
-
-
-def setup_module(module):
-    """Doctest fixture for nose."""
-    # Distutils' temp directory creation code has a more-or-less unsuppressable
-    # print to stdout which will break the doctest which triggers it (via
-    # weave.inline). So here we run an end-to-end test of the inlining
-    # system to get that print out of the way at a point where it won't matter.
-    # As a bonus, the test harness is suppressing writes to stdout at this time
-    # anyway so the message is just swallowed silently.
-    ScipyOdeSimulator._test_inline()

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -152,7 +152,7 @@ class ScipyOdeSimulator(Simulator):
         # logging system, the threshold must be lower than DEBUG or else the
         # Nose logcapture plugin will cause the warnings to be shown and tests
         # will fail due to unexpected output.
-        if True or not self._logger.isEnabledFor(EXTENDED_DEBUG):
+        if not self._logger.isEnabledFor(EXTENDED_DEBUG):
             extra_compile_args.append('-w')
 
         if self._use_inline and not use_theano:


### PR DESCRIPTION
Our logging framework now controls the various output produced by weave.inline
and the C compiler. Due to some misbehavior within distutils, we need to
dynamically monkey-patch its internal logging framework to achieve this.
C compiler warning messages now become visible at log level DEBUG.

Due to these changes, the nose setup_module function in pysb.integrate is no
longer needed and has been removed.

Also an unrelated bug in ScipyOdeSimulator's Jacobian calculation was fixed.