### PR TITLE
Sensitivity analysis code fix for matplotlib 2.1

### DIFF
--- a/pysb/tools/sensitivity_analysis.py
+++ b/pysb/tools/sensitivity_analysis.py
@@ -582,7 +582,10 @@ class InitialsSensitivity(object):
 
         # create boxplot of single parameter sensitivities
         ax2 = plt.subplot(gs2[1])
-        ax2.boxplot(sens_ij_nm[::-1], vert=False, labels=None, showfliers=True,
+        ax2.boxplot([np.array(mat).flatten() for mat in sens_ij_nm[::-1]],
+                    vert=False,
+                    labels=None,
+                    showfliers=True,
                     whis='range')
         ax2.set_xlim(v_min - 2, v_max + 2)
         if x_axis_label is not None:


### PR DESCRIPTION
MPL 2.1's `boxplot` function now checks the dimensionality
of the array passed to it, so we need to `flatten` the entries
with numpy to make it compatible.