### PR TITLE
Fix some Python 2/3 compatibility issues

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -668,7 +668,7 @@ class ComplexPattern(object):
                 bond_num = None
                 if state_or_bond is WILD:
                     continue
-                elif isinstance(state_or_bond, (str, unicode)):
+                elif isinstance(state_or_bond, basestring):
                     state = state_or_bond
                 elif isinstance(state_or_bond, collections.Iterable) and len(
                         state_or_bond) == 2:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1994,7 +1994,11 @@ class KeywordMeta(type):
     def __str__(cls):
         return repr(cls)
 
-class Keyword(object): __metaclass__ = KeywordMeta
+
+# Define Keyword class with KeywordMeta metaclass in a Python 2 and 3
+# compatible way
+class Keyword(KeywordMeta("KeywordMetaBase", (object, ), {})):
+    pass
 
 # The keywords.
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1889,7 +1889,7 @@ class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
         return [c for c in self]
 
     def items(self):
-        return zip(self.keys(), self)
+        return list(zip(self.keys(), self))
 
     def index(self, c):
         # We can implement this in O(1) ourselves, whereas the Sequence mixin

--- a/pysb/jacobian.py
+++ b/pysb/jacobian.py
@@ -68,7 +68,7 @@ class JacobianGenerator(object):
     def generate_variables(self):
         self.emit("VARIABLE")
         self.indent()
-        obs_names = self.model.observable_groups.keys()
+        obs_names = list(self.model.observable_groups.keys())
         for obs_group in self.make_groups(obs_names, 5):
             self.emit(', '.join(obs_group) + ' AS NOTYPE')
         var_names = ['s%d' % i for i in range(len(self.model.species))]
@@ -79,7 +79,7 @@ class JacobianGenerator(object):
     def generate_equations(self):
         self.emit("EQUATION")
         self.indent()
-        obs_names = self.model.observable_groups.keys()
+        obs_names = list(self.model.observable_groups.keys())
         obs_exprs = [' + '.join('%g * s%s' % g for g in self.model.observable_groups[name]) for name in obs_names]
         for obs in zip(obs_names, obs_exprs):
             self.emit('%s = %s;' % obs)

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -1023,8 +1023,8 @@ def catalyze_complex(enzyme, e_site, substrate, s_site, product, klist, m1=None,
             #If the given binding site is only present in one monomer in the complex:
         if m1==None:
             #Build up ComplexPattern for use in rule (with state of given binding site specified).
-            s1complexpatub = specsitesdict.keys()[0]({site1:None})
-            s1complexpatb = specsitesdict.keys()[0]({site1:50})
+            s1complexpatub = list(specsitesdict.keys())[0]({site1:None})
+            s1complexpatb = list(specsitesdict.keys())[0]({site1:50})
             for monomer in s1.monomer_patterns:
                 if monomer not in specsitesdict.keys():
                     s1complexpatub %= monomer
@@ -2320,3 +2320,4 @@ def assemble_chain_sequential_base(base, basesite, subunit, site1, site2, max_si
 if __name__ == "__main__":
     import doctest
     doctest.testmod()
+

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -5,6 +5,11 @@ import networkx as nx
 from networkx.algorithms.isomorphism.vf2userfunc import GraphMatcher
 from networkx.algorithms.isomorphism import categorical_node_match
 import numpy as np
+try:
+    basestring
+except NameError:
+    # Under Python 3, do not pretend that bytes are a valid string
+    basestring = str
 
 
 def get_bonds_in_pattern(pat):
@@ -42,7 +47,7 @@ def get_bonds_in_pattern(pat):
         for sc in mp.site_conditions.values():
             if isinstance(sc, int):
                 bonds_used.add(sc)
-            elif not isinstance(sc, (str, unicode)) and \
+            elif not isinstance(sc, basestring) and \
                     isinstance(sc, collections.Iterable):
                 [bonds_used.add(b) for b in sc if isinstance(b, int)]
 

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -157,7 +157,7 @@ class Simulator(object):
         except SimulatorException:
             # Network free simulators
             if self._initials:
-                return len(self._initials.values()[0])
+                return len(list(self._initials.values())[0])
             else:
                 return 1
 

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -852,7 +852,7 @@ class SimulationResult(object):
         """
         if self._yfull is None:
             sp_names = ['__s%d' % i for i in range(len(self._model.species))]
-            yfull_dtype = zip(sp_names, itertools.repeat(float))
+            yfull_dtype = list(zip(sp_names, itertools.repeat(float)))
             if len(self._model.observables):
                 yfull_dtype += self._yobs[0].dtype.descr
             if len(self._model.expressions_dynamic()):
@@ -888,7 +888,7 @@ class SimulationResult(object):
         if self.nsims == 1 and self.squeeze:
             idx = pd.Index(times, name='time')
         else:
-            idx = pd.MultiIndex.from_tuples(zip(sim_ids, times),
+            idx = pd.MultiIndex.from_tuples(list(zip(sim_ids, times)),
                                             names=['simulation', 'time'])
         simdata = self.all
         if not isinstance(simdata, np.ndarray):

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -151,8 +151,8 @@ class StochKitSimulator(Simulator):
             # Export model file
             stoch_xml = StochKitExporter(self._model).export(
                 self.initials[i], self.param_values[i])
-            self._logger.log(EXTENDED_DEBUG, 'StochKit XML:\n' + stoch_xml)
-            with open(fname, 'w') as f:
+            self._logger.log(EXTENDED_DEBUG, 'StochKit XML:\n%s' % stoch_xml)
+            with open(fname, 'wb') as f:
                 f.write(stoch_xml)
 
             # Assemble the argument list

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -152,7 +152,7 @@ class StochKitSimulator(Simulator):
             stoch_xml = StochKitExporter(self._model).export(
                 self.initials[i], self.param_values[i])
             self._logger.log(EXTENDED_DEBUG, 'StochKit XML:\n%s' % stoch_xml)
-            with open(fname, 'wb') as f:
+            with open(fname, 'wt') as f:
                 f.write(stoch_xml)
 
             # Assemble the argument list

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -115,7 +115,7 @@ def test_reversible_synth_deg():
     Monomer('A')
     Parameter('k_synth', 2.0)
     Parameter('k_deg', 1.0)
-    Rule('synth_deg', A() <> None, k_deg, k_synth)
+    Rule('synth_deg', A() | None, k_deg, k_synth)
     assert synth_deg.is_synth()
     assert synth_deg.is_deg()
     generate_equations(model)

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ class build_py(setuptools.command.build_py.build_py):
 
 def main():
 
-    cmdclass = {'build_py': build_py}
-    cmdclass.update(versioneer.get_cmdclass())
+    cmdclass = versioneer.get_cmdclass()
+    cmdclass['build_py'] = build_py
 
     setup(name='pysb',
           version=versioneer.get_version(),

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,14 @@
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup
-import setuptools.command.build_py
 
 import versioneer
 
 import sys, os, subprocess, re
 
-class build_py(setuptools.command.build_py.build_py):
-    # Simplest way to use a specific list of fixers. Note use_2to3_fixers will
-    # be ignored.
-    fixer_names = ['lib2to3.fixes.fix_ne']
-
 def main():
 
     cmdclass = versioneer.get_cmdclass()
-    cmdclass['build_py'] = build_py
 
     setup(name='pysb',
           version=versioneer.get_version(),
@@ -38,7 +31,6 @@ def main():
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
                          'pandas', 'theano', 'h5py'],
           cmdclass=cmdclass,
-          use_2to3=True,
           keywords=['systems', 'biology', 'model', 'rules'],
           classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This PR fixes some Python 2/3 compatibility problems in an attempt to solve #271. Note that currently
- The `pysb.macros.assemble_chain_sequential_base` doctest is failing in Python 3
- The `pysb.macros.chain_species_base` doctest is failing in Python 3

these will need to be diagnosed and fixed before merging.

I found that the 2to3 issue mentioned in #271 was due to setup.py, where ```
cmdclass.update(versioneer.get_cmdclass())``` overwrote the `build_py` entry of `cmdclass` causing _all_ 2to3 fixes to be applied. This PR first gets the versioneer cmdclasses and then overwrites the `build_py` entry with the custom `build_py` class defined in setup.py. This fixes the issue with 2to3 but might have side effects relevant to versioning that I am not aware of.