### PR TITLE
Unpersist Simulator.run() arguments

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -143,10 +143,7 @@ class Simulator(object):
         if isinstance(initials_or_params, np.ndarray):
             return len(initials_or_params)
 
-        try:
-            first_entry = next(initials_or_params.values())  # Python 3
-        except TypeError:
-            first_entry = initials_or_params.values()[0]  # Python 2
+        first_entry = next(iter(initials_or_params.values()))
 
         try:
             return len(first_entry)  # First entry is iterable

--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -100,7 +100,7 @@ class BngSimulator(Simulator):
                                          'spaced starting at t=0')
             additional_args['t_end'] = self.tspan[-1]
             additional_args['n_steps'] = len(self.tspan) - 1
-            model_additional_species = self.model.species
+            model_additional_species = self.initials_dict.keys()
         else:
             additional_args['sample_times'] = self.tspan
             model_additional_species = None

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -358,8 +358,9 @@ class ScipyOdeSimulator(Simulator):
         Run a simulation and returns the result (trajectories)
 
         .. note::
-            ``tspan``, ``initials`` and ``param_values`` values supplied to
-            this method will persist to future :func:`run` calls.
+            In early versions of the Simulator class, ``tspan``, ``initials``
+            and ``param_values`` supplied to this method persisted to future
+            :func:`run` calls. This is no longer the case.
 
         Parameters
         ----------

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -215,8 +215,9 @@ class StochKitSimulator(Simulator):
         Run a simulation and returns the result (trajectories)
 
         .. note::
-            ``tspan``, ``initials`` and ``param_values`` values supplied to
-            this method will persist to future :func:`run` calls.
+            In early versions of the Simulator class, ``tspan``, ``initials``
+            and ``param_values`` supplied to this method persisted to future
+            :func:`run` calls. This is no longer the case.
 
         Parameters
         ----------

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -98,7 +98,7 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
 
         initials = [10, 20, 0]
         simres = self.sim.run(initials=initials)
-        assert np.allclose(self.sim.initials[0], initials)
+        assert np.allclose(simres.initials[0], initials)
         assert np.allclose(simres.observables['A_free'][0], 10)
 
     def test_y0_as_ndarray(self):
@@ -108,11 +108,18 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
 
     def test_y0_as_dictionary_monomer_species(self):
         """Test y0 with model-defined species."""
+        self.sim.initials = {self.mon('A')(a=None): 17}
+        base_initials = self.sim.initials
+        assert base_initials[0][0] == 17
+
         simres = self.sim.run(initials={self.mon('A')(a=None): 10,
                                self.mon('B')(b=1) % self.mon('A')(a=1): 0,
                                self.mon('B')(b=None): 0})
-        assert np.allclose(self.sim.initials, [10, 0, 0])
+        assert np.allclose(simres.initials, [10, 0, 0])
         assert np.allclose(simres.observables['A_free'][0], 10)
+
+        # Initials should reset to base values
+        assert np.allclose(self.sim.initials, base_initials)
 
     def test_y0_as_dictionary_with_bound_species(self):
         """Test y0 with dynamically generated species."""
@@ -134,13 +141,21 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
 
     def test_param_values_as_list_ndarray(self):
         """Test param_values as a list and ndarray."""
+        orig_param_values = self.sim.param_values
         param_values = [50, 60, 70, 0, 0]
-        self.sim.run(param_values=param_values)
+        self.sim.param_values = param_values
+        simres = self.sim.run()
         assert np.allclose(self.sim.param_values, param_values)
-        # Same thing, but with a numpy array
+        assert np.allclose(simres.param_values, param_values)
+        # Reset to original param values
+        self.sim.param_values = orig_param_values
+
+        # Same thing, but with a numpy array, applied as a run argument
         param_values = np.asarray([55, 65, 75, 0, 0])
-        self.sim.run(param_values=param_values)
-        assert np.allclose(self.sim.param_values, param_values)
+        simres = self.sim.run(param_values=param_values)
+        assert np.allclose(simres.param_values, param_values)
+        # param_values should reset to originals after the run
+        assert np.allclose(self.sim.param_values, orig_param_values)
 
     @raises(IndexError)
     def test_param_values_invalid_dictionary_key(self):
@@ -157,18 +172,54 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
 
 
 class TestScipySimulatorSequential(TestScipySimulatorBase):
-    def test_sequential_runs(self):
+    def test_sequential_initials(self):
         simres = self.sim.run()
+        orig_initials = self.sim.initials
 
         new_initials = [10, 20, 30]
         simres = self.sim.run(initials=new_initials)
-        assert np.allclose(simres.species[0], new_initials)
 
+        # Check that single-run initials applied properly to the result
+        assert np.allclose(simres.species[0], new_initials)
+        assert np.allclose(simres.initials, new_initials)
+        # Check that the single-run initials were removed after the run
+        assert np.allclose(self.sim.initials, orig_initials)
+
+    def test_sequential_param_values(self):
+        orig_param_values = self.sim.param_values
         new_param_values = {'kbindAB': 0}
-        simres = self.sim.run(param_values=new_param_values)
+        new_initials = [15, 25, 35]
+        simres = self.sim.run(param_values=new_param_values,
+                              initials=new_initials)
         # No new AB_complex should be formed
-        assert np.allclose(simres.observables['AB_complex'], 30)
+        assert np.allclose(simres.observables['AB_complex'], new_initials[2])
         assert simres.nsims == 1
+        # Original param_values should be restored after run
+        assert np.allclose(self.sim.param_values, orig_param_values)
+
+        # Check that per-run param override works when a base param
+        # dictionary is also specified
+        self.sim.param_values = new_param_values
+        base_param_values = new_param_values
+        new_param_values = {'ksynthB': 50}
+        simres = self.sim.run(param_values=new_param_values)
+        # Check that new param value override applied
+        assert np.allclose(simres.param_values[0][1],
+                           new_param_values['ksynthB'])
+        # Check that simulator reverts to base param values
+        assert np.allclose(self.sim.param_values[0][2],
+                           base_param_values['kbindAB'])
+        # Reset to original param values
+        self.sim.param_values = orig_param_values
+
+    def test_sequential_tspan(self):
+        tspan = np.linspace(0, 10, 11)
+        orig_tspan = self.sim.tspan
+        simres = self.sim.run(tspan=tspan)
+        # Check that new tspan applied properly
+        assert np.allclose(simres.tout, tspan)
+        # Check that simulator instance reset to original tspan
+        assert np.allclose(self.sim.tspan, orig_tspan)
 
 
 class TestScipySimulatorMultiple(TestScipySimulatorBase):
@@ -181,8 +232,9 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
         simres = self.sim.run(initials=initials, param_values=param_values)
         assert np.allclose(simres.species[0][0], initials[0])
         assert np.allclose(simres.species[1][0], initials[1])
-        assert np.allclose(self.sim.param_values[0], param_values[0])
-        assert np.allclose(self.sim.param_values[1], param_values[1])
+
+        assert np.allclose(simres.param_values[0], param_values[0])
+        assert np.allclose(simres.param_values[1], param_values[1])
 
         assert simres.nsims == 2
 
@@ -190,12 +242,41 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
         df = simres.dataframe
         all = simres.all
 
+        # Try overriding above lists of initials/params with dicts
+        self.sim.initials = initials
+        self.sim.param_values = param_values
+        simres = self.sim.run(
+            initials={self.mon('A')(a=None): [103, 104]},
+            param_values={'ksynthA': [101, 102]})
+        # Simulator initials and params should not persist run() overrides
+        assert np.allclose(self.sim.initials, initials)
+        assert np.allclose(self.sim.param_values, param_values)
+        # Create the expected initials/params arrays and compare to result
+        initials = np.array(initials)
+        initials[:, 0] = [103, 104]
+        param_values = np.array(param_values)
+        param_values[:, 0] = [101, 102]
+        assert np.allclose(simres.initials, initials)
+        assert np.allclose(simres.param_values, param_values)
+
+    @raises(ValueError)
+    def test_run_initials_different_length_to_base(self):
+        initials = [[10, 20, 30, 40], [50, 60, 70, 80]]
+        self.sim.initials = initials
+        self.sim.run(initials=initials[0])
+
+    @raises(ValueError)
+    def test_run_params_different_length_to_base(self):
+        param_values = [[55, 65, 75, 0, 0, 1],
+                        [90, 100, 110, 5, 6, 7]]
+        self.sim.param_values = param_values
+        self.sim.run(param_values=param_values[0])
+
     def test_param_values_dict(self):
         param_values = {'A_init': [0, 100]}
         initials = {self.model.monomers['B'](b=None): [250, 350]}
 
         simres = self.sim.run(param_values=param_values)
-        print(simres.dataframe.loc[0, 0]['A_free'])
         assert np.allclose(simres.dataframe.loc[(slice(None), 0.0), 'A_free'],
                            [0, 100])
 
@@ -211,7 +292,7 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
         assert np.allclose(simres.dataframe.loc[(slice(None), 0.0), 'B_free'],
                            [250, 350])
 
-    @raises(SimulatorException)
+    @raises(ValueError)
     def test_initials_and_param_values_differing_lengths(self):
         initials = [[10, 20, 30, 40], [50, 60, 70, 80]]
         param_values = [[55, 65, 75, 0, 0],
@@ -289,7 +370,7 @@ def test_earm_integration():
         ScipyOdeSimulator._use_inline = True
 
 
-@raises(SimulatorException)
+@raises(ValueError)
 def test_simulation_no_tspan():
     ScipyOdeSimulator(robertson.model).run()
 


### PR DESCRIPTION
Previously, tspan, initials, and param_values supplied to
Simulator.run() calls persisted to future run calls, which seems
unintuitive. This commit makes these arguments persist only for the
duration of the run() call. It also refactors some of the more
convoluted logic for setting initials/param_values and adds a few
unit tests.

Fixes: #267 