### PR TITLE
Pin mkl to fix Appveyor Python 3.4 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ install:
 
   # Majority of dependencies can be installed with Anaconda
   - conda install numpy scipy matplotlib sympy networkx nose h5py pandas theano
+    mkl=2017.0.3
 
   # Graphviz & PyGraphviz
   - appveyor DownloadFile "http://graphviz.org/pub/graphviz/stable/windows/graphviz-2.38.zip" -FileName graphviz.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,8 @@ install:
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
 
   # KaSim and KaSa
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4beta/KaSim.exe" -FileName KaSim.exe
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4beta/KaSa.exe" -FileName KaSa.exe
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/old-V4beta/KaSim.exe" -FileName KaSim.exe
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/old-V4beta/KaSa.exe" -FileName KaSa.exe
   - set "KAPPAPATH=%cd%"
 
   # StochKit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
     mkl=2017.0.3
 
   # Graphviz & PyGraphviz
-  - appveyor DownloadFile "http://graphviz.org/pub/graphviz/stable/windows/graphviz-2.38.zip" -FileName graphviz.zip
+  - appveyor DownloadFile "https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.zip" -FileName graphviz.zip
   - 7z x graphviz.zip -y > nul
   - set "PATH=%cd%\release\lib\release\dll;%PATH%"
   - if "%PYTHON_VERSION%"=="2.7" pip install https://www.dropbox.com/s/fixts2t9l082r2o/pygraphviz-1.3.1-cp27-none-win32.whl?dl=1


### PR DESCRIPTION
Our Appveyor Python 3.4 builds are currently failing.

The build was using mkl=2017.0.4, which was erroring with "DLL
load failed" as described here:
https://github.com/numpy/numpy/issues/9933

For the time being we can get our Appveyor build working again
by pinning mkl to 2017.0.3. Hopefully upstream will fix soon.

Edit: Also updated the graphviz download URL, since the old one stopped working today