### PR TITLE
Add warning if using ScipyOdeSimulator w/o weave

### DIFF
--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -197,6 +197,13 @@ class ScipyOdeSimulator(Simulator):
                     on_unused_input='ignore'
                 )
             else:
+                self._logger.warning(
+                    "This system of ODEs will be evaluated in pure Python. "
+                    "This may be slow for large models. You may wish to "
+                    "install the 'weave' package (which compiles ODEs to C "
+                    "code for speed), or use the experimental use_theano=True "
+                    "flag (also compiles to C, with advanced options e.g. for "
+                    "GPU offloading).")
                 code_eqs_py = sympy.lambdify(self._symbols,
                                              sympy.flatten(ode_mat))
 


### PR DESCRIPTION
I'm finding that many users of PySB are not aware they can install the
additional "weave" package for a significant speed boost to the
ScipyOdeSimulator. This PR adds a warning if pure Python (lambdify)
mode is being used, to instruct users they may wish to install
weave or use the experimental theano mode.