### PR TITLE
Cython support for ScipyOdeSimulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 - export PATH="$HOME/miniconda/bin:$PATH"
 - conda install --yes -c conda-forge python="$TRAVIS_PYTHON_VERSION"
     numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
-    pydot coveralls mock
+    pydot coveralls mock cython
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install weave; fi
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 
   # Majority of dependencies can be installed with Anaconda
   - conda install -c conda-forge "numpy>=1.14" scipy matplotlib sympy
-    networkx nose h5py pandas theano mkl pydot mock
+    networkx nose h5py pandas theano mkl pydot mock cython
 
   # Graphviz & PyGraphviz
   - appveyor DownloadFile "https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.zip" -FileName graphviz.zip

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup
-
 import versioneer
 
-import sys, os, subprocess, re
 
 def main():
 
@@ -29,7 +27,7 @@ def main():
           install_requires=['numpy', 'scipy', 'sympy', 'networkx'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas', 'theano', 'h5py', 'mock'],
+                         'pandas', 'theano', 'h5py', 'mock', 'cython'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],
           classifiers=[
@@ -45,6 +43,7 @@ def main():
             'Topic :: Scientific/Engineering :: Mathematics',
             ],
           )
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adds Cython support to ScipyOdeSimulator. This is useful because our
current ODE compilation backend (weave) does not support Python 3;
Cython does.

The ODE compilation system backend can be specified by a new
`eqn_mode` argument: `cython`, `weave`, `theano` or `python`.
If left as None (default), the system will try to use `weave`,
then `cython`, then `python`.
If the auto-detect falls back on `python` mode, a warning is shown
that the simulation may be slow, and recommends the user install
`cython` or `weave`.