### PR TITLE
Verify site states in MonomerPatterns

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -302,6 +302,15 @@ class Monomer(Component):
         return value
 
 
+def _check_state(monomer, site, state):
+    """ Check a monomer site allows the specified state """
+    if state not in monomer.site_states[site]:
+        args = state, monomer.name, site, monomer.site_states[site]
+        template = "Invalid state choice '{}' in Monomer {}, site {}. Valid " \
+                   "state choices: {}"
+        raise ValueError(template.format(*args))
+
+
 class MonomerPattern(object):
 
     """
@@ -340,17 +349,6 @@ class MonomerPattern(object):
     state for that site, i.e. \"don't write, don't care\".
 
     """
-    @staticmethod
-    def _check_state(monomer, site, state):
-        if state not in monomer.site_states[site]:
-            raise ValueError("Invalid state choice \"{}\" in Monomer {}, "
-                             "site {}. Valid state choices: {}".format(
-                state,
-                monomer.name,
-                site,
-                monomer.site_states[site]
-            ))
-
     def __init__(self, monomer, site_conditions, compartment):
         # ensure all keys in site_conditions are sites in monomer
         unknown_sites = [site for site in site_conditions
@@ -372,13 +370,13 @@ class MonomerPattern(object):
                  all(isinstance(s, int) for s in state):
                 continue
             elif isinstance(state, basestring):
-                self.__class__._check_state(monomer, site, state)
+                _check_state(monomer, site, state)
                 continue
             elif isinstance(state, tuple) and \
                  isinstance(state[0], basestring) and \
                  (isinstance(state[1], int) or state[1] is WILD or \
                   state[1] is ANY):
-                self.__class__._check_state(monomer, site, state[0])
+                _check_state(monomer, site, state[0])
                 continue
             elif state is ANY:
                 continue

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -340,6 +340,16 @@ class MonomerPattern(object):
     state for that site, i.e. \"don't write, don't care\".
 
     """
+    @staticmethod
+    def _check_state(monomer, site, state):
+        if state not in monomer.site_states[site]:
+            raise ValueError("Invalid state choice \"{}\" in Monomer {}, "
+                             "site {}. Valid state choices: {}".format(
+                state,
+                monomer.name,
+                site,
+                monomer.site_states[site]
+            ))
 
     def __init__(self, monomer, site_conditions, compartment):
         # ensure all keys in site_conditions are sites in monomer
@@ -362,11 +372,13 @@ class MonomerPattern(object):
                  all(isinstance(s, int) for s in state):
                 continue
             elif isinstance(state, basestring):
+                self.__class__._check_state(monomer, site, state)
                 continue
             elif isinstance(state, tuple) and \
                  isinstance(state[0], basestring) and \
                  (isinstance(state[1], int) or state[1] is WILD or \
                   state[1] is ANY):
+                self.__class__._check_state(monomer, site, state[0])
                 continue
             elif state is ANY:
                 continue

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -63,6 +63,15 @@ def test_monomer_rename_non_self_exported_model():
 
 
 @with_model
+def test_invalid_state():
+    Monomer('A', ['a', 'b'], {'a': ['a1', 'a2'], 'b': ['b1']})
+    # Specify invalid state in Monomer.__call__
+    assert_raises(ValueError, A, a='spam')
+    # Specify invalid state in MonomerPattern.__call__
+    assert_raises(ValueError, A(a='a1'), b='spam')
+
+
+@with_model
 def test_initial():
     Monomer('A', ['s'])
     Parameter('A_0')


### PR DESCRIPTION
`MonomerPattern.__init__` should verify that any strings (states) given
in site_conditions are allowable for that monomer. E.g. for this
Monomer:

    Monomer('A', ['x'], {'x': ['spam', 'eggs']})

This now raises an exception:

    A(x='foo')

Fixes: #90