### PR TITLE
Fix ComplexPattern.__call__ for duplicate monomers

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -744,11 +744,9 @@ class ComplexPattern(object):
         kwargs = extract_site_conditions(conditions, **kwargs)
 
         # Ensure we don't have more than one of any Monomer in our patterns.
-        mp_monomer = lambda mp: id(mp.monomer)
-        patterns_sorted = sorted(self.monomer_patterns, key=mp_monomer)
-        pgroups = itertools.groupby(patterns_sorted, mp_monomer)
-        pcounts = [(monomer, sum(1 for mp in mps)) for monomer, mps in pgroups]
-        dup_monomers = [monomer.name for monomer, count in pcounts if count > 1]
+        mon_counts = collections.Counter(mp.monomer.name for mp in
+                                         self.monomer_patterns)
+        dup_monomers = [mon for mon, count in mon_counts.items() if count > 1]
         if dup_monomers:
             raise DuplicateMonomerError("ComplexPattern has duplicate "
                                         "Monomers: " + str(dup_monomers))

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -108,6 +108,12 @@ def test_monomerpattern():
     A = Monomer('A',sites=['a'],site_states={'a':['u','p']},_export=False)
     Aw = A(a=('u', ANY))
 
+
+@with_model
+def test_duplicate_monomer_error():
+    A = Monomer('A', ['a'])
+    assert_raises(DuplicateMonomerError, (A(a=1) % A(a=1)), a=2)
+
 @with_model
 def test_observable_constructor_with_monomer():
     A = Monomer('A', _export=False)


### PR DESCRIPTION
This should (and now does) raise a `DuplicateMonomerError`

Fixes: #183