### PR TITLE
Fix reversible synth/deg rules

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1174,11 +1174,15 @@ class Rule(Component):
 
     def is_synth(self):
         """Return a bool indicating whether this is a synthesis rule."""
-        return len(self.reactant_pattern.complex_patterns) == 0
+        return len(self.reactant_pattern.complex_patterns) == 0 or \
+            (self.is_reversible and
+             len(self.product_pattern.complex_patterns) == 0)
 
     def is_deg(self):
         """Return a bool indicating whether this is a degradation rule."""
-        return len(self.product_pattern.complex_patterns) == 0
+        return len(self.product_pattern.complex_patterns) == 0 or \
+            (self.is_reversible and
+             len(self.reactant_pattern.complex_patterns) == 0)
 
     def __repr__(self):
         ret = '%s(%s, %s, %s' % \

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -87,9 +87,9 @@ class BngGenerator(object):
             label = r.name + ':'
             react_p = r.reactant_pattern
             prod_p = r.product_pattern
-            if r.is_synth():
+            if not react_p.complex_patterns:
                 react_p = None
-            if r.is_deg():
+            if not prod_p.complex_patterns:
                 prod_p = None
             reactants_code = format_reactionpattern(react_p)
             products_code = format_reactionpattern(prod_p)

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -111,6 +111,17 @@ def test_zero_order_synth_no_initials():
 
 
 @with_model
+def test_reversible_synth_deg():
+    Monomer('A')
+    Parameter('k_synth', 2.0)
+    Parameter('k_deg', 1.0)
+    Rule('synth_deg', A() <> None, k_deg, k_synth)
+    assert synth_deg.is_synth()
+    assert synth_deg.is_deg()
+    generate_equations(model)
+
+
+@with_model
 def test_nfsim():
     Monomer('A', ['a'])
     Monomer('B', ['b'])


### PR DESCRIPTION
This PR fixes `Rule.is_synth()` and `Rule.is_deg()` for reversible
synth/deg rules of the form

    Rule('synth_deg', None <> A(), k_synth, k_deg)