### PR TITLE
Dangling bond detection for ReactionPattern

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -895,6 +895,8 @@ class ReactionPattern(object):
 
     def __init__(self, complex_patterns):
         self.complex_patterns = complex_patterns
+        from pysb.pattern import check_dangling_bonds
+        check_dangling_bonds(self)
 
     def __add__(self, other):
         if isinstance(other, MonomerPattern):
@@ -1981,6 +1983,9 @@ class RedundantSiteConditionsError(ValueError):
             ("Site conditions may be specified as EITHER keyword arguments "
              "OR a single dict"))
 
+
+class DanglingBondError(ValueError):
+    pass
 
 # Some light infrastructure for defining symbols that act like "keywords", i.e.
 # they are immutable singletons that stringify to their own name. Regular old

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -574,7 +574,7 @@ def bind_complex(s1, site1, s2, site2, klist, m1=None, m2=None):
                         maxint = stateint
         match = 'N'
         for monomer in s2.monomer_patterns:
-            if m2 != None:
+            if m2 is not None:
                 if m2.site_conditions == monomer.site_conditions and m2.monomer.name == monomer.monomer.name:
                     match = 'Y'
             for site, stateint in monomer.site_conditions.items():

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -80,17 +80,13 @@ def get_bonds_in_pattern(pat):
     Examples
     --------
 
-    These examples convert the set to a list for testing purposes only (sets
-    print differently on Python 2 vs Python 3). This is not necessary for
-    end users.
-
     >>> A = Monomer('A', ['b1', 'b2'], _export=False)
-    >>> list(get_bonds_in_pattern(A(b1=None, b2=None)))
-    []
-    >>> list(get_bonds_in_pattern(A(b1=1) % A(b2=1)))
-    [1]
-    >>> list(get_bonds_in_pattern(A(b1=1) % A(b1=2, b2=1) % A(b1=2)))
-    [1, 2]
+    >>> get_bonds_in_pattern(A(b1=None, b2=None)) == set()
+    True
+    >>> get_bonds_in_pattern(A(b1=1) % A(b2=1)) == {1}
+    True
+    >>> get_bonds_in_pattern(A(b1=1) % A(b1=2, b2=1) % A(b1=2)) == {1, 2}
+    True
     """
     return set(get_half_bonds_in_pattern(pat))
 

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -302,3 +302,10 @@ def test_concreteness():
     Compartment('cell')
     assert not C().is_concrete()
     assert (C() ** cell).is_concrete()
+
+
+@with_model
+def test_dangling_bond():
+    Monomer('A', ['a'])
+    Parameter('kf', 1.0)
+    assert_raises(DanglingBondError, as_reaction_pattern, A(a=1) % A(a=None))

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -195,7 +195,10 @@ def test_kappa_error():
     # Model with a dangling bond should raise a KasimInterfaceError
     Monomer('A', ['b'])
     Monomer('B', ['b'])
-    Rule('A_binds_B', A(b=None) + B(b=None) >> A(b=1) % B(b=None),
-         Parameter('k_A_binds_B', 1))
     Initial(A(b=None), Parameter('A_0', 100))
-    assert_raises(KasimInterfaceError, run_simulation, model, time=10)
+
+    # Can't model this as a PySB rule, since it would generate a
+    # DanglingBondError. Directly inject kappa code for rule instead.
+    assert_raises(KasimInterfaceError, run_simulation, model, time=10,
+                  perturbation="'A_binds_B' A(b),B(b) -> A(b!1),B(b) @ "
+                               "'k_A_binds_B'")


### PR DESCRIPTION
A dangling bond is when a specified bond has no binding partner, e.g.

```python
A(a=None) % A(a=1)
```

Patterns with dangling bonds are disallowed in Kappa and pending deprecation in BioNetGen. This PR adds dangling bond detection when `ReactionPattern` patterns, allowing users to detect these mistakes early (before network generation).