### PR TITLE
Kappa 4 support, expression improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ before_install:
 # First install ocamlfind via opam (needed to build KaSim/KaSa)
 - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
 - opam install -y conf-which base-bytes
-- opam install -y ocamlbuild yojson
+- opam install -y ocamlbuild yojson result
 # Install KaSim/KaSa
 - git clone https://github.com/Kappa-Dev/KaSim.git
 - cd KaSim
-# KaSim version as of 5/1/2017
-- git checkout 0733210
+# KaSim version 4.0
+- git checkout v4.0rc1
 - make all
 - export KAPPAPATH=`pwd`
 - cd ../

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,9 @@ install:
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
 
   # KaSim and KaSa
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/old-V4beta/KaSim.exe" -FileName KaSim.exe
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/old-V4beta/KaSa.exe" -FileName KaSa.exe
-  - set "KAPPAPATH=%cd%"
+  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4.0rc1/Kappapp.and.CLI.for.Windows.zip" -FileName Kappa.zip
+  - 7z x Kappa.zip -y > nul
+  - set "KAPPAPATH=%cd%\KappaBin\bin"
 
   # StochKit
   - appveyor DownloadFile "https://downloads.sourceforge.net/project/stochkit/StochKit2/StochKit2.0.10/StochKit2.0.10_WINDOWS_LITE.zip" -FileName stochkit.zip

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -467,8 +467,18 @@ class MonomerPattern(object):
             return ReactionPattern([ComplexPattern([self], None), ComplexPattern([other], None)])
         if isinstance(other, ComplexPattern):
             return ReactionPattern([ComplexPattern([self], None), other])
-        elif other == None:
-            return as_reaction_pattern(self)
+        elif other is None:
+            rp = as_reaction_pattern(self)
+            rp.complex_patterns.append(None)
+            return rp
+        else:
+            return NotImplemented
+
+    def __radd__(self, other):
+        if other is None:
+            rp = as_reaction_pattern(self)
+            rp.complex_patterns = [None] + rp.complex_patterns
+            return rp
         else:
             return NotImplemented
 
@@ -809,14 +819,23 @@ class ComplexPattern(object):
             site_map[site].site_conditions[site] = condition
         return cp
 
-
     def __add__(self, other):
         if isinstance(other, ComplexPattern):
             return ReactionPattern([self, other])
         elif isinstance(other, MonomerPattern):
             return ReactionPattern([self, ComplexPattern([other], None)])
-        elif other == None:
-            return as_reaction_pattern(self)
+        elif other is None:
+            rp = as_reaction_pattern(self)
+            rp.complex_patterns.append(None)
+            return rp
+        else:
+            return NotImplemented
+
+    def __radd__(self, other):
+        if other is None:
+            rp = as_reaction_pattern(self)
+            rp.complex_patterns = [None] + rp.complex_patterns
+            return rp
         else:
             return NotImplemented
 

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -3,6 +3,7 @@ import warnings
 import pysb
 import sympy
 from sympy.printing import StrPrinter
+from pysb.kappa import KappaDot
 
 # Alias basestring under Python 3 for forwards compatibility
 try:
@@ -194,6 +195,8 @@ def format_complexpattern(cp):
     return ret
 
 def format_monomerpattern(mp):
+    if isinstance(mp, KappaDot):
+        return '0'
     # sort sites in the same order given in the original Monomer
     site_conditions = sorted(mp.site_conditions.items(),
                              key=lambda x: mp.monomer.sites.index(x[0]))

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -3,7 +3,6 @@ import warnings
 import pysb
 import sympy
 from sympy.printing import StrPrinter
-from pysb.kappa import KappaDot
 
 # Alias basestring under Python 3 for forwards compatibility
 try:
@@ -187,6 +186,8 @@ def format_reactionpattern(rp, for_observable=False):
     return delimiter.join([format_complexpattern(cp) for cp in rp.complex_patterns])
 
 def format_complexpattern(cp):
+    if cp is None:
+        return '0'
     ret = '.'.join([format_monomerpattern(mp) for mp in cp.monomer_patterns])
     if cp.compartment is not None:
         ret = '@%s:%s' % (cp.compartment.name, ret)
@@ -195,8 +196,6 @@ def format_complexpattern(cp):
     return ret
 
 def format_monomerpattern(mp):
-    if isinstance(mp, KappaDot):
-        return '0'
     # sort sites in the same order given in the original Monomer
     site_conditions = sorted(mp.site_conditions.items(),
                              key=lambda x: mp.monomer.sites.index(x[0]))

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -312,6 +312,9 @@ class KappaPrinter(StrPrinter):
     def _print_Pi(self, expr):
         return '[pi]'
 
+    def _print_Exp1(self, expr):
+        return '[E]'
+
     def _print_Function(self, expr):
         """ Adapted from sympy/printing/str.py """
         if (expr.func in (sympy.log, sympy.exp, sympy.sin, sympy.cos,

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -145,6 +145,8 @@ def format_reactionpattern(rp):
 
 
 def format_complexpattern(cp):
+    if cp is None:
+        return '.'
     ret = ','.join(filter(None, [format_monomerpattern(mp)
                                  for mp in cp.monomer_patterns]))
     if cp.compartment is not None:
@@ -153,9 +155,6 @@ def format_complexpattern(cp):
 
 
 def format_monomerpattern(mp):
-    from pysb.kappa import KappaDot
-    if isinstance(mp, KappaDot):
-        return '.'
     # sort sites in the same order given in the original Monomer
     site_conditions = sorted(mp.site_conditions.items(),
                              key=lambda x: mp.monomer.sites.index(x[0]))

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -65,12 +65,8 @@ SimulationResult = namedtuple('SimulationResult',
 
 def run_simulation(model, time=10000, points=200, cleanup=True,
                    output_prefix=None, output_dir=None, flux_map=False,
-                   perturbation=None, seed=None, verbose=False,
-                   pre4syntax=False):
+                   perturbation=None, seed=None, verbose=False):
     """Runs the given model using KaSim and returns the parsed results.
-
-    By default, Kappa 4 syntax is used. To use Kappa 3, use the pre4syntax
-    argument.
 
     Parameters
     ----------
@@ -112,8 +108,6 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
         deterministic behaviour (e.g. for testing)
     verbose : boolean
         Whether to pass the output of KaSim through to stdout/stderr.
-    pre4syntax : boolean
-        True to use kappa version 3 syntax, False for kappa 4 or higher.
 
     Returns
     -------
@@ -134,7 +128,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
     the flux map graphically see :func:`run_static_analysis` (notes section).
     """
 
-    gen = KappaGenerator(model, pre4syntax=pre4syntax)
+    gen = KappaGenerator(model)
 
     if output_prefix is None:
         output_prefix = 'tmpKappa_%s_' % model.name
@@ -163,12 +157,8 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
         # If desired, add instructions to the kappa file to generate the
         # flux map:
         if flux_map:
-            if pre4syntax:
-                kappa_file.write('%%mod: [true] do $FLUX "%s" [true]\n' %
-                                 fm_filename)
-            else:
-                kappa_file.write('%%mod: [true] do $DIN "%s" [true];\n' %
-                                 fm_filename)
+            kappa_file.write('%%mod: [true] do $DIN "%s" [true];\n' %
+                             fm_filename)
 
         # If any perturbation language code has been passed in, add it to
         # the Kappa file:
@@ -220,11 +210,8 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
 
 def run_static_analysis(model, influence_map=False, contact_map=False,
                         cleanup=True, output_prefix=None, output_dir=None,
-                        verbose=False, pre4syntax=False):
+                        verbose=False):
     """Run static analysis (KaSa) on to get the contact and influence maps.
-
-    By default, Kappa 4 syntax is used. To use Kappa 3, use the pre4syntax
-    argument.
 
     If neither influence_map nor contact_map are set to True, then a ValueError
     is raised.
@@ -250,8 +237,6 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
         an Exception is thrown.
     verbose : boolean
         Whether to pass the output of KaSa through to stdout/stderr.
-    pre4syntax : boolean
-        True to use kappa version 3 syntax, False for kappa 4 or higher.
 
     Returns
     -------
@@ -284,7 +269,7 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
         raise ValueError('Either contact_map or influence_map (or both) must '
                          'be set to True in order to perform static analysis.')
 
-    gen = KappaGenerator(model, pre4syntax=pre4syntax, _warn_no_ic=False)
+    gen = KappaGenerator(model, _warn_no_ic=False)
 
     if output_prefix is None:
         output_prefix = 'tmpKappa_%s_' % model.name

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -465,9 +465,17 @@ class KappaDot(pysb.MonomerPattern):
 
        Rule('spawnB', A() + KappaDot() >> A() + B(), r)
 
+    KappaDot is ignored when using the BioNetGen interface (it is exported as
+    the null species `0`).
      """
     def __init__(self):
         dot_monomer = pysb.Monomer('__kappadot__', _export=False)
         super(KappaDot, self).__init__(dot_monomer,
                                        site_conditions={},
                                        compartment=None)
+
+    def __repr__(self):
+        return 'KappaDot()'
+
+    def __str__(self):
+        return repr(self)

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -445,37 +445,3 @@ def _parse_kasim_outfile(out_filename):
         raise Exception("problem parsing KaSim outfile: " + str(e))
 
     return recarr
-
-
-class KappaDot(pysb.MonomerPattern):
-    """
-    Represents a Null agent in Kappa 4; ignored in Kappa 3
-
-    Agent order is conserved in Kappa 4. This KappaDot will be needed in
-    situations like:
-
-    .. code-block:: none
-
-       // Agent A spawns a copy of agent B
-       A(),. -> A(),B() @ 'r'
-
-    This would be specified in PySB like:
-
-    .. code-block:: python
-
-       Rule('spawnB', A() + KappaDot() >> A() + B(), r)
-
-    KappaDot is ignored when using the BioNetGen interface (it is exported as
-    the null species `0`).
-     """
-    def __init__(self):
-        dot_monomer = pysb.Monomer('__kappadot__', _export=False)
-        super(KappaDot, self).__init__(dot_monomer,
-                                       site_conditions={},
-                                       compartment=None)
-
-    def __repr__(self):
-        return 'KappaDot()'
-
-    def __str__(self):
-        return repr(self)

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -58,6 +58,8 @@ _pysb_doctest_suppress_modelexistswarning = True
 
 def _complex_pattern_label(cp):
     """Return a string label for a ComplexPattern."""
+    if cp is None:
+        return ''
     mp_labels = [_monomer_pattern_label(mp) for mp in cp.monomer_patterns]
     return ''.join(mp_labels)
 

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -1,9 +1,9 @@
 from pysb.testing import *
 from pysb import *
 from pysb.bng import *
-from pysb.kappa import KappaDot
 import os
 import unittest
+from pysb.core import as_complex_pattern
 
 
 @with_model
@@ -17,19 +17,6 @@ def test_generate_network():
     Parameter('k', 1)
     Rule('degrade', A() >> None, k)
     ok_(generate_network(model))
-
-
-@with_model
-def test_ignore_kappa_dot():
-    Monomer('A', ['b'])
-    Monomer('B')
-    Parameter('k', 1)
-    Parameter('A_0', 1)
-    Initial(A(b=None), A_0)
-    Initial(A(b=1) % A(b=1), A_0)
-    Rule('synth', KappaDot() >> A(b=None), k)
-    Rule('degrade', A(b=1) % A(b=1) >> KappaDot() + A(b=None), k)
-    generate_network(model)
 
 
 @unittest.skipIf(os.name == 'nt', 'BNG Console does not work on Windows')
@@ -171,6 +158,16 @@ def test_unicode_strs():
     Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
     Monomer(u'B')
     Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
+    Initial(A(b=u'y'), Parameter(u'A_0', 100))
+    generate_equations(model)
+
+
+@with_model
+def test_none_in_rxn_pat():
+    Monomer(u'A', [u'b'], {u'b': [u'y', u'n']})
+    Monomer(u'B')
+    Rule(u'rule1', A(b=u'y') + None >> None + B(),
+         Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
     generate_equations(model)
 

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -1,6 +1,7 @@
 from pysb.testing import *
 from pysb import *
 from pysb.bng import *
+from pysb.kappa import KappaDot
 import os
 import unittest
 
@@ -16,6 +17,19 @@ def test_generate_network():
     Parameter('k', 1)
     Rule('degrade', A() >> None, k)
     ok_(generate_network(model))
+
+
+@with_model
+def test_ignore_kappa_dot():
+    Monomer('A', ['b'])
+    Monomer('B')
+    Parameter('k', 1)
+    Parameter('A_0', 1)
+    Initial(A(b=None), A_0)
+    Initial(A(b=1) % A(b=1), A_0)
+    Rule('synth', KappaDot() >> A(b=None), k)
+    Rule('degrade', A(b=1) % A(b=1) >> KappaDot() + A(b=None), k)
+    generate_network(model)
 
 
 @unittest.skipIf(os.name == 'nt', 'BNG Console does not work on Windows')

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -197,11 +197,10 @@ def test_influence_map_kasa():
 @with_model
 def test_unicode_strs():
     Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
-    Monomer(u'B')
-    Rule(u'rule1', A(b=u'y') + None >> None + B(),
+    Rule(u'rule1', A(b=u'y') >> A(b=u'n'),
          Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
-    Observable(u'B_', B())
+    Observable(u'A_y', A(b=u'y'))
     npts = 200
     kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
 

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -3,6 +3,7 @@ from pysb import *
 from pysb.kappa import *
 import networkx as nx
 import sympy
+from pysb.core import as_complex_pattern
 
 _KAPPA_SEED = 123456
 
@@ -197,12 +198,26 @@ def test_influence_map_kasa():
 def test_unicode_strs():
     Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
     Monomer(u'B')
-    Rule(u'rule1', A(b=u'y') + KappaDot() >> KappaDot() + B(),
+    Rule(u'rule1', A(b=u'y') + None >> None + B(),
          Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
     Observable(u'B_', B())
     npts = 200
     kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
+
+
+@with_model
+def test_none_in_rxn_pat():
+    Monomer('A')
+    Monomer('B')
+    Rule('rule1', A() + None >> None + B(), Parameter('k', 1))
+    Initial(A(), Parameter('A_0', 100))
+    Observable('B_', B())
+    npts = 200
+    kres = run_simulation(model, time=100, points=npts, seed=_KAPPA_SEED)
+
+    # check that rule1's reaction pattern parses with ComplexPatterns
+    as_complex_pattern(A()) + None >> None + as_complex_pattern(B())
 
 
 @with_model

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -35,6 +35,7 @@ def test_kappa_expressions():
     Expression('kf',1e-5/two)
     Expression('test_sqrt', -1 + sympy.sqrt(1 + two))
     Expression('test_pi', sympy.pi)
+    Expression('test_e', sympy.E)
     Expression('test_log', sympy.log(two))
     Expression('test_exp', sympy.exp(two))
     Expression('test_sin', sympy.sin(two))

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -2,6 +2,7 @@ from pysb.testing import *
 from pysb import *
 from pysb.kappa import *
 import networkx as nx
+import sympy
 
 _KAPPA_SEED = 123456
 
@@ -32,6 +33,18 @@ def test_kappa_expressions():
     Parameter('kr',0.1)
     Parameter('num_A',1000)
     Expression('kf',1e-5/two)
+    Expression('test_sqrt', -1 + sympy.sqrt(1 + two))
+    Expression('test_pi', sympy.pi)
+    Expression('test_log', sympy.log(two))
+    Expression('test_exp', sympy.exp(two))
+    Expression('test_sin', sympy.sin(two))
+    Expression('test_cos', sympy.cos(two))
+    Expression('test_tan', sympy.tan(two))
+    Expression('test_max', sympy.Max(two, kr, 2.0))
+    Expression('test_min', sympy.Min(two, kr, 2.0))
+    Expression('test_mod', sympy.Mod(10, two))
+    Expression('test_piecewise', sympy.Piecewise((0.0, two < 400.0),
+                                                 (1.0, True)))
     Initial(A(site=('u')),num_A)
     Rule('dimerize_fwd',
          A(site='u') + A(site='u') >> A(site=('u', 1)) % A(site=('u',1)), kf)
@@ -183,7 +196,8 @@ def test_influence_map_kasa():
 def test_unicode_strs():
     Monomer(u'A', [u'b'], {u'b':[u'y', u'n']})
     Monomer(u'B')
-    Rule(u'rule1', A(b=u'y') >> B(), Parameter(u'k', 1))
+    Rule(u'rule1', A(b=u'y') + KappaDot() >> KappaDot() + B(),
+         Parameter(u'k', 1))
     Initial(A(b=u'y'), Parameter(u'A_0', 100))
     Observable(u'B_', B())
     npts = 200


### PR DESCRIPTION
This PR introduces support for Kappa 4, which is enabled by default.
To use Kappa 3 syntax, use the `pre4syntax=False` argument to
`run_simulation` or `run_static_analysis`. Note that Kappa now
requires agents on the reactant side to correspond to agents on the
product side of a rule (i.e. order is preserved). The "dot" agent
is implemented in PySB as `KappaDot`, and is necessary in
[certain situations documented in the Kappa Manual](https://github.com/Kappa-Dev/KaSim/blob/master/CHANGES.md#agent-order-in-rules-must-be-maintained).

For example, the following Kappa rule:

    // Agent A spawns a copy of agent B
    A(),. -> A(),B() @ 'r'

would be implemented in PySB as:

    Rule('spawnB', A() + KappaDot() >> A() + B(), r)

This PR also improves Expression support for Kappa, implementing
`log`, `exp`, `min`, `max`, `sin`, `cos`, `tan`, `mod` and `sqrt`
functions, if expressions via sympy's `Piecewise`, and the `pi`
symbol.

Fixes: #333
Fixes: #288