### PR TITLE
networkx/pydot support for reading .dot files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 python:
 - '2.7'
-- '3.5'
+- '3.6'
 addons:
     apt:
         sources:
@@ -18,13 +18,10 @@ before_install:
 - chmod +x miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
-# Install conda 4.3.21 to avoid conda/weave issue (see #297 discussion)
-- conda install --yes conda==4.3.21
-- conda install --yes -c omnia python="$TRAVIS_PYTHON_VERSION"
-    numpy scipy matplotlib sympy networkx nose h5py pexpect pandas pygraphviz=1.3 theano
-    mock
+- conda install --yes -c conda-forge python="$TRAVIS_PYTHON_VERSION"
+    numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
+    pydot coveralls mock
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install weave; fi
-- pip install python-coveralls
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc
 - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,14 @@ install:
   - activate test-environment
 
   # Majority of dependencies can be installed with Anaconda
-  - conda install numpy scipy matplotlib sympy networkx nose h5py pandas theano
-    mkl=2017.0.3 mock
+  - conda install -c conda-forge "numpy>=1.14" scipy matplotlib sympy
+    networkx nose h5py pandas theano mkl pydot mock
 
   # Graphviz & PyGraphviz
   - appveyor DownloadFile "https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.zip" -FileName graphviz.zip
   - 7z x graphviz.zip -y > nul
   - set "PATH=%cd%\release\lib\release\dll;%PATH%"
   - if "%PYTHON_VERSION%"=="2.7" pip install https://www.dropbox.com/s/fixts2t9l082r2o/pygraphviz-1.3.1-cp27-none-win32.whl?dl=1
-  - if "%PYTHON_VERSION%"=="3.6" conda install pydot
 
   # BioNetGen
   - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ install:
   - appveyor DownloadFile "https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.zip" -FileName graphviz.zip
   - 7z x graphviz.zip -y > nul
   - set "PATH=%cd%\release\lib\release\dll;%PATH%"
-  - if "%PYTHON_VERSION%"=="2.7" pip install https://www.dropbox.com/s/fixts2t9l082r2o/pygraphviz-1.3.1-cp27-none-win32.whl?dl=1
 
   # BioNetGen
   - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.4
-      MINICONDA: C:\Miniconda3
+    - PYTHON_VERSION: 3.6
+      MINICONDA: C:\Miniconda36
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -33,7 +33,7 @@ install:
   - 7z x graphviz.zip -y > nul
   - set "PATH=%cd%\release\lib\release\dll;%PATH%"
   - if "%PYTHON_VERSION%"=="2.7" pip install https://www.dropbox.com/s/fixts2t9l082r2o/pygraphviz-1.3.1-cp27-none-win32.whl?dl=1
-  - if "%PYTHON_VERSION%"=="3.4" pip install https://www.dropbox.com/s/g51cnau5nlww9fc/pygraphviz-1.3.1-cp34-none-win32.whl?dl=1
+  - if "%PYTHON_VERSION%"=="3.6" conda install pydot
 
   # BioNetGen
   - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -215,7 +215,7 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     >>> numpy.set_printoptions(precision=4)
     >>> yfull = odesolve(model, linspace(0, 40, 10))
     >>> print(yfull['A_total'])            #doctest: +NORMALIZE_WHITESPACE
-    [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
+    [1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
     Obtain a view on a returned record array which uses an atomic data-type and
@@ -236,11 +236,11 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     (10, 6)
     >>> print(yarray.dtype)
     float64
-    >>> print(yarray[0:4, 1:3])
-    [[  0.0000e+00   0.0000e+00]
-     [  2.1672e-05   1.0093e-01]
-     [  1.6980e-05   1.4943e-01]
-     [  1.4502e-05   1.8209e-01]]
+    >>> print(yarray[0:4, 1:3])            #doctest: +NORMALIZE_WHITESPACE
+    [[0.0000e+00   0.0000e+00]
+     [2.1672e-05   1.0093e-01]
+     [1.6980e-05   1.4943e-01]
+     [1.4502e-05   1.8209e-01]]
 
     """
     integrator_options['integrator'] = integrator

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -23,6 +23,7 @@ import tempfile
 import shutil
 import warnings
 from collections import namedtuple
+from pysb.util import read_dot
 
 try:
     from future_builtins import zip
@@ -123,10 +124,14 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
     If flux_map is True, returns an instance of SimulationResult, a namedtuple
     with two members, `timecourse` and `flux_map`. The `timecourse` field
     contains the simulation ndarray, and the `flux_map` field is an instance of
-    a pygraphviz AGraph containing the flux map. The flux map can be rendered
-    as a pdf using the dot layout program as follows::
+    a networkx MultiGraph containing the flux map. The flux map can be rendered
+    as a PNG as follows (example requires pygraphviz)::
 
-        fluxmap.draw('fluxmap.pdf', prog='dot')
+        from networkx.drawing.nx_agraph import view_pygraphviz
+        view_pygraphviz(fluxmap)
+
+    For further information, see the networkx documenation:
+    https://networkx.github.io/documentation/latest/reference/drawing.html
     """
 
     gen = KappaGenerator(model)
@@ -184,19 +189,14 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
 
     if flux_map:
         try:
-            import pygraphviz
-            flux_graph = pygraphviz.AGraph(fm_filename)
+            flux_graph = read_dot(fm_filename)
         except ImportError:
             if cleanup:
-                raise RuntimeError(
-                        "Couldn't import pygraphviz, which is "
-                        "required to return the flux map as a "
-                        "pygraphviz AGraph object. Either install "
-                        "pygraphviz or set cleanup=False to retain "
-                        "dot files.")
+                raise
             else:
                 warnings.warn(
-                        "pygraphviz could not be imported so no AGraph "
+                        "neither pydot nor pygraphviz could be "
+                        "imported, so no MultiGraph "
                         "object returned (returning None); flux map "
                         "dot file available at %s" % fm_filename)
                 flux_graph = None
@@ -205,7 +205,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
         shutil.rmtree(base_directory)
 
     # If a flux map was generated, return both the simulation output and the
-    # flux map as a pygraphviz graph
+    # flux map as a networkx multigraph
     if flux_map:
         return SimulationResult(data, flux_graph)
     # If no flux map was requested, return only the simulation data
@@ -247,7 +247,7 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
     -------
     StaticAnalysisResult, a namedtuple with two fields, `contact_map` and
     `influence_map`, each containing the respective result as an instance
-    of a pygraphviz AGraph. If the either the contact_map or influence_map
+    of a networkx MultiGraph. If the either the contact_map or influence_map
     argument to the function is False, the corresponding entry in the
     StaticAnalysisResult returned by the function will be None.
     """
@@ -311,22 +311,17 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
 
     # Try to create the graphviz objects from the .dot files created
     try:
-        import pygraphviz
         # Convert the contact map to a Graph
-        cmap = pygraphviz.AGraph(cm_filename) if contact_map else None
-        imap = pygraphviz.AGraph(im_filename) if influence_map else None
+        cmap = read_dot(cm_filename) if contact_map else None
+        imap = read_dot(im_filename) if influence_map else None
     except ImportError:
         if cleanup:
-            raise RuntimeError(
-                    "Couldn't import pygraphviz, which is "
-                    "required to return the influence and contact maps "
-                    " as pygraphviz AGraph objects. Either install "
-                    "pygraphviz or set cleanup=False to retain "
-                    "dot files.")
+            raise
         else:
             warnings.warn(
-                    "pygraphviz could not be imported so no AGraph "
-                    "objects returned (returning None); "
+                    "neither pydot nor pygraphviz could be "
+                    "imported, so no MultiGraph "
+                    "object returned (returning None); "
                     "contact/influence maps available at %s" %
                     base_directory)
             cmap = None
@@ -352,11 +347,15 @@ def contact_map(model, **kwargs):
 
     Returns
     -------
-    pygraphviz AGraph object containing the contact map.
-    The contact map can be rendered as a pdf using the dot layout program
-    as follows::
+    networkx MultiGraph object containing the contact map.
+    The contact map can be rendered as a PNG using the dot as follows
+    (example requires pygraphviz)::
 
-        contact_map.draw('contact_map.pdf', prog='dot')
+        from networkx.drawing.nx_agraph import view_pygraphviz
+        view_pygraphviz(contact_map)
+
+    For further information, see the networkx documenation:
+    https://networkx.github.io/documentation/latest/reference/drawing.html
     """
 
     kasa_result = run_static_analysis(model, influence_map=False,
@@ -377,11 +376,15 @@ def influence_map(model, **kwargs):
 
     Returns
     -------
-    pygraphviz AGraph object containing the influence map.
-    The influence map can be rendered as a pdf using the dot layout program
-    as follows::
+    networkx MultiGraph object containing the influence map.
+    The influence map can be rendered as a PNG as follows (example requires
+    pygraphviz)::
 
-        influence_map.draw('influence_map.pdf', prog='dot')
+        from networkx.drawing.nx_agraph import view_pygraphviz
+        view_pygraphviz(influence_map)
+
+    For further information, see the networkx documenation:
+    https://networkx.github.io/documentation/latest/reference/drawing.html
     """
 
     kasa_result = run_static_analysis(model, influence_map=True,

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -124,14 +124,8 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
     If flux_map is True, returns an instance of SimulationResult, a namedtuple
     with two members, `timecourse` and `flux_map`. The `timecourse` field
     contains the simulation ndarray, and the `flux_map` field is an instance of
-    a networkx MultiGraph containing the flux map. The flux map can be rendered
-    as a PNG as follows (example requires pygraphviz)::
-
-        from networkx.drawing.nx_agraph import view_pygraphviz
-        view_pygraphviz(fluxmap)
-
-    For further information, see the networkx documenation:
-    https://networkx.github.io/documentation/latest/reference/drawing.html
+    a networkx MultiGraph containing the flux map. For details on viewing
+    the flux map graphically see :func:`run_static_analysis` (notes section).
     """
 
     gen = KappaGenerator(model)
@@ -195,7 +189,7 @@ def run_simulation(model, time=10000, points=200, cleanup=True,
                 raise
             else:
                 warnings.warn(
-                        "neither pydot nor pygraphviz could be "
+                        "The pydot library could not be "
                         "imported, so no MultiGraph "
                         "object returned (returning None); flux map "
                         "dot file available at %s" % fm_filename)
@@ -250,6 +244,23 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
     of a networkx MultiGraph. If the either the contact_map or influence_map
     argument to the function is False, the corresponding entry in the
     StaticAnalysisResult returned by the function will be None.
+
+    Notes
+    -----
+    To view a networkx file graphically, use `draw_network`::
+
+        import networkx as nx
+        nx.draw_networkx(g, with_labels=True)
+
+    You can use `graphviz_layout` to use graphviz for layout (requires pydot
+    library)::
+
+        import networkx as nx
+        pos = nx.drawing.nx_pydot.graphviz_layout(g, prog='dot')
+        nx.draw_networkx(g, pos, with_labels=True)
+
+    For further information, see the networkx documentation on visualization:
+    https://networkx.github.io/documentation/latest/reference/drawing.html
     """
 
     # Make sure the user has asked for an output!
@@ -319,7 +330,7 @@ def run_static_analysis(model, influence_map=False, contact_map=False,
             raise
         else:
             warnings.warn(
-                    "neither pydot nor pygraphviz could be "
+                    "The pydot library could not be "
                     "imported, so no MultiGraph "
                     "object returned (returning None); "
                     "contact/influence maps available at %s" %
@@ -347,17 +358,10 @@ def contact_map(model, **kwargs):
 
     Returns
     -------
-    networkx MultiGraph object containing the contact map.
-    The contact map can be rendered as a PNG using the dot as follows
-    (example requires pygraphviz)::
-
-        from networkx.drawing.nx_agraph import view_pygraphviz
-        view_pygraphviz(contact_map)
-
-    For further information, see the networkx documenation:
-    https://networkx.github.io/documentation/latest/reference/drawing.html
+    networkx MultiGraph object containing the contact map. For details on
+    viewing the contact map graphically see :func:`run_static_analysis` (notes
+    section).
     """
-
     kasa_result = run_static_analysis(model, influence_map=False,
                                     contact_map=True, **kwargs)
     return kasa_result.contact_map
@@ -376,15 +380,9 @@ def influence_map(model, **kwargs):
 
     Returns
     -------
-    networkx MultiGraph object containing the influence map.
-    The influence map can be rendered as a PNG as follows (example requires
-    pygraphviz)::
-
-        from networkx.drawing.nx_agraph import view_pygraphviz
-        view_pygraphviz(influence_map)
-
-    For further information, see the networkx documenation:
-    https://networkx.github.io/documentation/latest/reference/drawing.html
+    networkx MultiGraph object containing the influence map. For details on
+    viewing the influence map graphically see :func:`run_static_analysis`
+    (notes section).
     """
 
     kasa_result = run_static_analysis(model, influence_map=True,

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -630,35 +630,35 @@ class SimulationResult(object):
 
     >>> print(simulation_result.observables['Bax_c0']) \
         #doctest: +NORMALIZE_WHITESPACE
-    [  1.0000e+00   1.1744e-02   1.3791e-04   1.6196e-06   1.9020e-08
-       2.2337e-10   2.6232e-12   3.0806e-14   3.6178e-16   4.2492e-18]
+    [1.0000e+00   1.1744e-02   1.3791e-04   1.6196e-06   1.9020e-08
+     2.2337e-10   2.6232e-12   3.0806e-14   3.6178e-16   4.2492e-18]
 
     It is also possible to retrieve the value of all observables at a
     particular time point, e.g. the final concentrations:
 
     >>> print(simulation_result.observables[-1]) \
         #doctest: +SKIP
-    (  4.2492e-18,   1.6996e-16,  1.)
+    (4.2492e-18,   1.6996e-16,  1.)
 
     Expressions are read in the same way as observables:
 
     >>> print(simulation_result.expressions['NBD_signal']) \
         #doctest: +NORMALIZE_WHITESPACE
-    [ 0.   4.7847  4.9956  4.9999  5.   5.   5.   5.   5.   5. ]
+    [0.   4.7847  4.9956  4.9999  5.   5.   5.   5.   5.   5. ]
 
     The species trajectories can be accessed as a numpy ndarray:
 
-    >>> print(simulation_result.species)
-    [[  1.0000e+00   0.0000e+00   0.0000e+00]
-     [  1.1744e-02   5.2194e-02   9.3606e-01]
-     [  1.3791e-04   1.2259e-03   9.9864e-01]
-     [  1.6196e-06   2.1595e-05   9.9998e-01]
-     [  1.9020e-08   3.3814e-07   1.0000e+00]
-     [  2.2337e-10   4.9637e-09   1.0000e+00]
-     [  2.6232e-12   6.9951e-11   1.0000e+00]
-     [  3.0806e-14   9.5840e-13   1.0000e+00]
-     [  3.6178e-16   1.2863e-14   1.0000e+00]
-     [  4.2492e-18   1.6996e-16   1.0000e+00]]
+    >>> print(simulation_result.species) #doctest: +NORMALIZE_WHITESPACE
+    [[1.0000e+00   0.0000e+00   0.0000e+00]
+     [1.1744e-02   5.2194e-02   9.3606e-01]
+     [1.3791e-04   1.2259e-03   9.9864e-01]
+     [1.6196e-06   2.1595e-05   9.9998e-01]
+     [1.9020e-08   3.3814e-07   1.0000e+00]
+     [2.2337e-10   4.9637e-09   1.0000e+00]
+     [2.6232e-12   6.9951e-11   1.0000e+00]
+     [3.0806e-14   9.5840e-13   1.0000e+00]
+     [3.6178e-16   1.2863e-14   1.0000e+00]
+     [4.2492e-18   1.6996e-16   1.0000e+00]]
 
     Species, observables and expressions can be combined into a single numpy
     ndarray and accessed similarly. Here, the initial concentrations of all

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -89,7 +89,7 @@ class ScipyOdeSimulator(Simulator):
     >>> simulation_result = sim.run()
     >>> print(simulation_result.observables['A_total']) \
         #doctest: +NORMALIZE_WHITESPACE
-    [ 1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
+    [1.      0.899   0.8506  0.8179  0.793   0.7728  0.7557  0.7408  0.7277
     0.7158]
 
     For further information on retrieving trajectories (species,

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -73,14 +73,14 @@ class StochKitSimulator(Simulator):
     A_total trajectory for first run
 
     >>> print(simulation_result.observables[0]['A_total']) \
-        #doctest: +ELLIPSIS
-    [ 1.  0.  0.  0.  0.]
+        #doctest: +NORMALIZE_WHITESPACE
+    [1.  0.  0.  0.  0.]
 
     A_total trajectory for second run
 
     >>> print(simulation_result.observables[1]['A_total']) \
         #doctest: +SKIP
-    [ 1.  1.  1.  0.  0.]
+    [1.  1.  1.  0.  0.]
 
     For further information on retrieving trajectories (species,
     observables, expressions over time) from the ``simulation_result``

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -1,7 +1,7 @@
 from pysb.testing import *
 from pysb import *
 from pysb.kappa import *
-import pygraphviz as pgv
+import networkx as nx
 
 _KAPPA_SEED = 123456
 
@@ -70,7 +70,7 @@ def test_flux_map():
     ok_(simdata['time'][0] == 0)
     ok_(sorted(simdata['time'])[-1] == 10)
     fluxmap = res.flux_map
-    ok_(isinstance(fluxmap, pgv.AGraph))
+    ok_(isinstance(fluxmap, nx.MultiGraph))
 
 
 @with_model
@@ -106,7 +106,7 @@ def test_run_static_analysis_cmap():
          Parameter('k_A_binds_B', 1))
     Observable('AB', A(b=1) % B(b=1))
     res = run_static_analysis(model, contact_map=True, influence_map=False)
-    ok_(isinstance(res.contact_map, pgv.AGraph))
+    ok_(isinstance(res.contact_map, nx.MultiGraph))
     ok_(res.influence_map is None)
 
 
@@ -126,7 +126,7 @@ def test_run_static_analysis_imap():
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
     res = run_static_analysis(model, contact_map=False, influence_map=True)
-    ok_(isinstance(res.influence_map, pgv.AGraph))
+    ok_(isinstance(res.influence_map, nx.MultiGraph))
     ok_(res.contact_map is None)
 
 
@@ -146,8 +146,8 @@ def test_run_static_analysis_both():
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
     res = run_static_analysis(model, contact_map=True, influence_map=True)
-    ok_(isinstance(res.influence_map, pgv.AGraph))
-    ok_(isinstance(res.contact_map, pgv.AGraph))
+    ok_(isinstance(res.influence_map, nx.MultiGraph))
+    ok_(isinstance(res.contact_map, nx.MultiGraph))
 
 
 @with_model
@@ -158,7 +158,7 @@ def test_contact_map():
          Parameter('k_A_binds_B', 1))
     Observable('AB', A(b=1) % B(b=1))
     res = contact_map(model, cleanup=True)
-    ok_(isinstance(res, pgv.AGraph))
+    ok_(isinstance(res, nx.MultiGraph))
 
 
 @with_model
@@ -176,7 +176,7 @@ def test_influence_map_kasa():
          B(active='y') + C(active='n') >> B(active='y') + C(active='y'),
          Parameter('k_B_activates_C', 1))
     res = influence_map(model, cleanup=True)
-    ok_(isinstance(res, pgv.AGraph))
+    ok_(isinstance(res, nx.MultiGraph))
 
 
 @with_model

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -54,11 +54,14 @@ as a "modifier" (enzyme or catalyst).
 from __future__ import print_function
 import pysb
 import pysb.bng
-import sympy
 import re
 import sys
 import os
-import pygraphviz
+try:
+    import pygraphviz
+except ImportError:
+    pygraphviz = None
+
 
 def run(model):
     """
@@ -74,6 +77,9 @@ def run(model):
     string
         The dot format output.
     """
+    if pygraphviz is None:
+        raise ImportError('pygraphviz library is required to run this '
+                          'function')
 
     pysb.bng.generate_equations(model)
 

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -27,7 +27,10 @@ from __future__ import print_function
 import sys
 import os
 import re
-import pygraphviz
+try:
+    import pygraphviz
+except ImportError:
+    pygraphviz = None
 import pysb.bng
 
 # Alias basestring under Python 3 for forwards compatibility
@@ -56,6 +59,9 @@ def run(model):
 
 
 def render_species_as_dot(species_list, graph_name=""):
+    if pygraphviz is None:
+        raise ImportError('pygraphviz library is required to run this '
+                          'function')
     graph = pygraphviz.AGraph(name="%s species" % graph_name, rankdir="LR",
                               fontname='Arial')
     graph.edge_attr.update(fontname='Arial', fontsize=8)

--- a/pysb/tools/species_graph.py
+++ b/pysb/tools/species_graph.py
@@ -30,11 +30,14 @@ need to manually reopen it every time you rerun the tool.
 from __future__ import print_function
 import pysb
 import pysb.bng
-import sympy
 import re
 import sys
 import os
-import pygraphviz
+try:
+    import pygraphviz
+except ImportError:
+    pygraphviz = None
+
 
 def run(model):
     """
@@ -50,6 +53,9 @@ def run(model):
     string
         The dot format output.
     """
+    if pygraphviz is None:
+        raise ImportError('pygraphviz library is required to run this '
+                          'function')
 
     pysb.bng.generate_equations(model)
 

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -103,39 +103,26 @@ def load_params(fname):
     return parmsff
 
 
-def read_dot(filename, use=None):
-    """ Read a graphviz dot file using pydot or pygraphviz
+def read_dot(filename):
+    """ Read a graphviz dot file using pydot
 
     Parameters
     ----------
     filename: str
         A DOT (graphviz) filename
-    use: str, optional
-        Networkx backend to use for loading dot files, either 'pydot',
-        'pygraphviz', or None (which tries pydot, then pygraphviz)
 
     Returns
     -------
     MultiGraph
         A networkx MultiGraph file
     """
-    if use is None or use == 'pydot':
-        try:
-            import pydot
-            pydot_graph = pydot.graph_from_dot_file(filename)[0]
-            return _from_pydot(pydot_graph)
-        except ImportError:
-            if use == 'pydot':
-                raise
-
     try:
-        return read_dot_pygraphviz(filename)
+        import pydot
+        pydot_graph = pydot.graph_from_dot_file(filename)[0]
+        return _from_pydot(pydot_graph)
     except ImportError:
-        if use == 'pygraphviz':
-            raise
-        else:
-            raise ImportError('Either the pydot or pygraphviz library is '
-                              'required to read .dot files')
+        raise ImportError('Importing graphviz files requires the pydot '
+                          'library')
 
 
 def _from_pydot(P):

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -4,8 +4,14 @@ import pysb.core
 import inspect
 import numpy
 import io
+import networkx as nx
+from networkx.drawing.nx_agraph import read_dot as read_dot_pygraphviz
+try:
+    basestring
+except NameError:
+    basestring = str
 
-__all__ = ['alias_model_components', 'rules_using_parameter']
+__all__ = ['alias_model_components', 'rules_using_parameter', 'read_dot']
 
 
 def alias_model_components(model=None):
@@ -95,3 +101,134 @@ def load_params(fname):
     for i in temparr:
         parmsff[i[0]] = i[1]
     return parmsff
+
+
+def read_dot(filename, use=None):
+    """ Read a graphviz dot file using pydot or pygraphviz
+
+    Parameters
+    ----------
+    filename: str
+        A DOT (graphviz) filename
+    use: str, optional
+        Networkx backend to use for loading dot files, either 'pydot',
+        'pygraphviz', or None (which tries pydot, then pygraphviz)
+
+    Returns
+    -------
+    MultiGraph
+        A networkx MultiGraph file
+    """
+    if use is None or use == 'pydot':
+        try:
+            import pydot
+            pydot_graph = pydot.graph_from_dot_file(filename)[0]
+            return _from_pydot(pydot_graph)
+        except ImportError:
+            if use == 'pydot':
+                raise
+
+    try:
+        return read_dot_pygraphviz(filename)
+    except ImportError:
+        if use == 'pygraphviz':
+            raise
+        else:
+            raise ImportError('Either the pydot or pygraphviz library is '
+                              'required to read .dot files')
+
+
+def _from_pydot(P):
+    """Return a NetworkX graph from a Pydot graph.
+
+    Using this patched version until networkx issue is resolved, which fixes
+    .dot file support using PyDot:
+    https://github.com/networkx/networkx/issues/2832
+
+    Parameters
+    ----------
+
+    P : Pydot graph
+      A graph created with Pydot
+
+    Returns
+    -------
+    G : NetworkX multigraph
+        A MultiGraph or MultiDiGraph.
+
+    Examples
+    --------
+    >>> K5 = nx.complete_graph(5)
+    >>> A = nx.nx_pydot.to_pydot(K5)
+    >>> G = nx.nx_pydot.from_pydot(A) # return MultiGraph
+
+    # make a Graph instead of MultiGraph
+    >>> G = nx.Graph(nx.nx_pydot.from_pydot(A))
+
+    """
+    if P.get_strict(None):  # pydot bug: get_strict() shouldn't take argument
+        multiedges = False
+    else:
+        multiedges = True
+
+    if P.get_type() == 'graph':  # undirected
+        if multiedges:
+            N = nx.MultiGraph()
+        else:
+            N = nx.Graph()
+    else:
+        if multiedges:
+            N = nx.MultiDiGraph()
+        else:
+            N = nx.DiGraph()
+
+    # assign defaults
+    name = P.get_name().strip('"')
+    if name != '':
+        N.name = name
+
+    # add nodes, attributes to N.node_attr
+    for p in P.get_node_list():
+        n = p.get_name().strip('"')
+        if n in ('node', 'graph', 'edge'):
+            continue
+        N.add_node(n, **{k: v.strip('"')
+                         for k, v in p.get_attributes().items()})
+
+    # add edges
+    for e in P.get_edge_list():
+        u = e.get_source()
+        v = e.get_destination()
+        attr = {k: v.strip('"') for k, v in e.get_attributes().items()}
+        s = []
+        d = []
+
+        if isinstance(u, basestring):
+            s.append(u.strip('"'))
+        else:
+            for unodes in u['nodes']:
+                s.append(unodes.strip('"'))
+
+        if isinstance(v, basestring):
+            d.append(v.strip('"'))
+        else:
+            for vnodes in v['nodes']:
+                d.append(vnodes.strip('"'))
+
+        for source_node in s:
+            for destination_node in d:
+                N.add_edge(source_node, destination_node, **attr)
+
+    # add default attributes for graph, nodes, edges
+    pattr = {k: v.strip('"') for k, v in P.get_attributes().items()}
+    if pattr:
+        N.graph['graph'] = pattr
+    try:
+        N.graph['node'] = P.get_node_defaults()[0]
+    except:  # IndexError,TypeError:
+        pass  # N.graph['node']={}
+    try:
+        N.graph['edge'] = P.get_edge_defaults()[0]
+    except:  # IndexError,TypeError:
+        pass  # N.graph['edge']={}
+    return N


### PR DESCRIPTION
* pygraphviz support is now optional (tests complete without it):
pydot is now an alternative for reading .dot (graphviz) files. 
pygraphviz support on Windows on recent versions of Python is
patchy at best - pydot supports more platforms and is easier to
install.
* When dot file reading is required (kappa interface), the results are
now returned in the (more flexible and maintained) networkx format.
The dot file itself can be read using pydot or pygraphviz (both are
tried by default) - see new pysb.util.read_dot() function. Networkx
can export back to pygraphviz if required, as updated docs show.
* Move Python 3 continuous integration on both travis and 
appveyor to Python 3.6, to standardise across platforms
* Update doctests to numpy 1.14 standard (no leading whitespace
inside bracket when printing arrays)