### PR TITLE
Fix Kappa 4 multiple agent synthesis

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -892,7 +892,6 @@ class ComplexPattern(object):
         return ret
 
 
-
 class ReactionPattern(object):
 
     """
@@ -922,7 +921,15 @@ class ReactionPattern(object):
             return ReactionPattern(self.complex_patterns + [ComplexPattern([other], None)])
         elif isinstance(other, ComplexPattern):
             return ReactionPattern(self.complex_patterns + [other])
-        elif other == None:
+        elif other is None:
+            self.complex_patterns.append(None)
+            return self
+        else:
+            return NotImplemented
+
+    def __radd__(self, other):
+        if other is None:
+            self.complex_patterns = [None] + self.complex_patterns
             return self
         else:
             return NotImplemented

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -231,3 +231,19 @@ def test_kappa_error():
     assert_raises(KasimInterfaceError, run_simulation, model, time=10,
                   perturbation="'A_binds_B' A(b),B(b) -> A(b!1),B(b) @ "
                                "'k_A_binds_B'")
+
+
+@with_model
+def test_kappa_two_ghost_agents():
+    Monomer('A')
+    Monomer('M')
+    Parameter('k', 3.0)
+    Rule('synthesize_A_and_B', M() + None + None >> M() + A() + A(), k)
+    Initial(M(), Parameter('M_0', 1000))
+    Observable('A_', A())
+
+    # check the ReactionPattern.__radd__ version
+    rp = None + (None + A())
+    assert len(rp.complex_patterns) == 3
+
+    run_simulation(model, time=100, points=100, seed=_KAPPA_SEED)


### PR DESCRIPTION
In Kappa 4, a Ghost agent (placeholder 'dot') must be used to make
the two sides of a reaction rule match. For example, the following
two agent synthesis rule:

    Rule('synthesize_A_and_B', M() + None + None >> M() + A() + B(), k)

This was previously failing (one None was silently dropped). This
has been fixed by modifying ReactionPattern.__add__ and implementing
__radd__. The only caveat is with multiple leading Nones, which will
need to be in parentheses to avoid a TypeError from adding two Nones:

    None + (None + M())

This should also be avoidable by reordering the agents to put the
Nones last, as in the original example.

Fixes: #338