### PR TITLE
Use more anaconda binaries on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ dist: trusty
 python:
 - '2.7'
 - '3.6'
-addons:
-    apt:
-        sources:
-            - avsm
-        packages:
-            - ocaml-nox
-            - opam
-            - aspcud
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     -O miniconda.sh
@@ -24,29 +16,8 @@ before_install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install weave; fi
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc
-- wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz"
-    -O bionetgen.tar.gz
-- tar xzf bionetgen.tar.gz
-- export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
-# First install ocamlfind via opam (needed to build KaSim/KaSa)
-- opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-- opam install -y conf-which base-bytes
-- opam install -y ocamlbuild yojson result
-# Install KaSim/KaSa
-- git clone https://github.com/Kappa-Dev/KaSim.git
-- cd KaSim
-# KaSim version 4.0
-- git checkout v4.0rc1
-- make all
-- export KAPPAPATH=`pwd`
-- cd ../
-# Install StochKit
-- wget https://github.com/StochSS/StochKit/archive/master.zip -O StochKit.zip
-- unzip -q -d $HOME StochKit.zip
-- export STOCHKITPATH=$HOME/StochKit-master
-- cd $STOCHKITPATH
-- ./install.sh >/dev/null 2>&1
-- cd $TRAVIS_BUILD_DIR
+# Install BioNetGen, Kappa, StochKit and Atomizer
+- conda install --yes -c alubbock kappa stochkit bionetgen atomizer
 install:
   python setup.py build --build-lib=build/lib
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - '2.7'
 - '3.6'
 before_install:
-- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+- wget http://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh
     -O miniconda.sh
 - chmod +x miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,18 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
+      MINICONDA: C:\Miniconda-x64
     - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda36
+      MINICONDA: C:\Miniconda36-x64
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
 install:
+  # https://stackoverflow.com/questions/13596407/errors-while-building-installing-c-module-for-python-2-7
+  - if "%PYTHON_VERSION%"=="2.7" (copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsamd64.bat")
+  - if "%PYTHON_VERSION%"=="2.7" (copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat")
+
   # Issues have been encountered with installing numpy and scipy on
   # AppVeyor e.g.
   # http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
@@ -27,27 +31,9 @@ install:
   # Majority of dependencies can be installed with Anaconda
   - conda install -c conda-forge "numpy>=1.14" scipy matplotlib sympy
     networkx nose h5py pandas theano mkl pydot mock cython
+  - if "%PYTHON_VERSION%"=="2.7" (conda install -c conda-forge weave)
 
-  # Graphviz & PyGraphviz
-  - appveyor DownloadFile "https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.zip" -FileName graphviz.zip
-  - 7z x graphviz.zip -y > nul
-  - set "PATH=%cd%\release\lib\release\dll;%PATH%"
-
-  # BioNetGen
-  - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip
-  - 7z x BioNetGen.zip -y > nul
-  - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
-  - set "ATOMIZERPATH=%BNGPATH%\bin"
-
-  # KaSim and KaSa
-  - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4.0rc1/Kappapp.and.CLI.for.Windows.zip" -FileName Kappa.zip
-  - 7z x Kappa.zip -y > nul
-  - set "KAPPAPATH=%cd%\KappaBin\bin"
-
-  # StochKit
-  - appveyor DownloadFile "https://downloads.sourceforge.net/project/stochkit/StochKit2/StochKit2.0.10/StochKit2.0.10_WINDOWS_LITE.zip" -FileName stochkit.zip
-  - 7z x stochkit.zip -y > nul
-  - set "STOCHKITPATH=%cd%\StochKit2.0.10_WINDOWS_LITE"
+  - conda install -c alubbock graphviz bionetgen atomizer kappa stochkit-lite
 
   # Build PySB
   - python setup.py build --build-lib=build/lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ install:
   - appveyor DownloadFile "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable2_Windows.zip" -FileName BioNetGen.zip
   - 7z x BioNetGen.zip -y > nul
   - set "BNGPATH=%cd%\BioNetGen-2.2.6-stable"
+  - set "ATOMIZERPATH=%BNGPATH%\bin"
 
   # KaSim and KaSa
   - appveyor DownloadFile "https://github.com/Kappa-Dev/KaSim/releases/download/v4.0rc1/Kappapp.and.CLI.for.Windows.zip" -FileName Kappa.zip

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -84,8 +84,7 @@ def sbml_translator(input_file,
         BNGL output filename
     """
     logger = get_logger(__name__, log_level=verbose)
-    sbmltrans_bin = os.path.join(os.path.dirname(pf.get_path('bng')),
-                                 'bin/sbmlTranslator')
+    sbmltrans_bin = pf.get_path('atomizer')
     sbmltrans_args = [sbmltrans_bin, '-i', input_file]
     if output_file is None:
         output_file = os.path.splitext(input_file)[0] + '.bngl'

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -84,7 +84,11 @@ def sbml_translator(input_file,
         BNGL output filename
     """
     logger = get_logger(__name__, log_level=verbose)
-    sbmltrans_bin = pf.get_path('atomizer')
+    bng_path = os.path.realpath(pf.get_path('bng'))
+    sbmltrans_bin = os.path.join(
+        os.path.dirname(bng_path),
+        'sbmlTranslator' if bng_path.endswith('.bat') else 'bin/sbmlTranslator'
+    )
     sbmltrans_args = [sbmltrans_bin, '-i', input_file]
     if output_file is None:
         output_file = os.path.splitext(input_file)[0] + '.bngl'

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -222,8 +222,8 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     integer indexing (note that the view's data buffer is shared with the
     original array so there is no extra memory cost):
 
-    >>> print(yfull.shape)
-    (10,)
+    >>> yfull.shape == (10, )
+    True
     >>> print(yfull.dtype)                 #doctest: +NORMALIZE_WHITESPACE
     [('__s0', '<f8'), ('__s1', '<f8'), ('__s2', '<f8'), ('A_total', '<f8'),
     ('B_total', '<f8'), ('C_total', '<f8')]
@@ -232,8 +232,8 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
       ...
     IndexError: too many indices...
     >>> yarray = yfull.view(float).reshape(len(yfull), -1)
-    >>> print(yarray.shape)
-    (10, 6)
+    >>> yarray.shape == (10, 6)
+    True
     >>> print(yarray.dtype)
     float64
     >>> print(yarray[0:4, 1:3])            #doctest: +NORMALIZE_WHITESPACE

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -55,6 +55,7 @@ _path_config = {
             'posix': 'ssa',
             'nt': 'ssa.exe'
         },
+        'batch_file': 'ssa.bat',
         'env_var': 'STOCHKITPATH',
         'search_paths': {
             'posix': ('/usr/local/share/StochKit', ),
@@ -67,22 +68,13 @@ _path_config = {
             'posix': 'tau_leaping',
             'nt': 'tau_leaping.exe'
         },
+        'batch_file': 'tau_leaping.bat',
         'env_var': 'STOCHKITPATH',
         'search_paths': {
             'posix': ('/usr/local/share/StochKit',),
             'nt': ('c:/Program Files/StochKit',)
         }
-    },
-    'atomizer': {
-        'name': 'Atomizer',
-        'executable': 'sbmlTranslator',
-        'batch_file': 'sbmlTranslator.bat',
-        'env_var': 'ATOMIZERPATH',
-        'search_paths': {
-            'posix': ('/usr/local/share/BioNetGen/bin',),
-            'nt': ('c:/Program Files/BioNetGen/bin',)
-        }
-    },
+    }
 }
 _path_cache = {}
 

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -73,6 +73,16 @@ _path_config = {
             'nt': ('c:/Program Files/StochKit',)
         }
     },
+    'atomizer': {
+        'name': 'Atomizer',
+        'executable': 'sbmlTranslator',
+        'batch_file': 'sbmlTranslator.bat',
+        'env_var': 'ATOMIZERPATH',
+        'search_paths': {
+            'posix': ('/usr/local/share/BioNetGen/bin',),
+            'nt': ('c:/Program Files/BioNetGen/bin',)
+        }
+    },
 }
 _path_cache = {}
 

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -13,9 +13,9 @@ try:
 except ImportError:
     theano = None
 try:
-    import cython
+    import Cython
 except ImportError:
-    cython = None
+    Cython = None
 from sympy.printing.lambdarepr import lambdarepr
 import distutils
 import pysb.bng
@@ -198,13 +198,13 @@ class ScipyOdeSimulator(Simulator):
             ydot = np.zeros(len(self.model.species))
 
             if self._compiler == 'cython':
-                if not cython:
+                if not Cython:
                     raise ImportError('Cython library is not installed')
                 code_eqs = CYTHON_DECL + code_eqs
 
                 def rhs(t, y, p):
                     # note that the evaluated code sets ydot as a side effect
-                    cython.inline(code_eqs, quiet=True)
+                    Cython.inline(code_eqs, quiet=True)
 
                     return ydot
 
@@ -319,7 +319,7 @@ class ScipyOdeSimulator(Simulator):
                     jac_eqs = CYTHON_DECL + jac_eqs
 
                     def jacobian(t, y, p):
-                        cython.inline(jac_eqs, quiet=True)
+                        Cython.inline(jac_eqs, quiet=True)
                         return jac
 
                     with _set_cflags_no_warnings(self._logger):
@@ -405,12 +405,12 @@ class ScipyOdeSimulator(Simulator):
     def _test_cython(cls):
         if not hasattr(cls, '_use_cython'):
             cls._use_cython = False
-            if cython is None:
+            if Cython is None:
                 return
             try:
-                cython.inline('x = 1', force=True, quiet=True)
+                Cython.inline('x = 1', force=True, quiet=True)
                 cls._use_cython = True
-            except cython.Compiler.Errors.CompileError:
+            except Cython.Compiler.Errors.CompileError:
                 pass
 
     @classmethod

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -45,13 +45,23 @@ def bngl_import_compare_simulations(bng_file, force=False,
                               rtol=1e-8)
 
 
+def _bng_validate_directory():
+    """ Location of BNG's validation models directory"""
+    bng_exec = os.path.realpath(pf.get_path('bng'))
+    if bng_exec.endswith('.bat'):
+        conda_prefix = os.environ.get('CONDA_PREFIX')
+        if conda_prefix:
+            return os.path.join(conda_prefix, 'share\\bionetgen\\Validate')
+
+    return os.path.join(os.path.dirname(bng_exec), 'Validate')
+
+
 def _bngl_location(filename):
     """
     Gets the location of one of BioNetGen's validation model files in BNG's
     Validate directory.
     """
-    bng_dir = os.path.dirname(os.path.realpath(pf.get_path('bng')))
-    bngl_file = os.path.join(bng_dir, 'Validate', filename + '.bngl')
+    bngl_file = os.path.join(_bng_validate_directory(), filename + '.bngl')
     return bngl_file
 
 
@@ -60,9 +70,8 @@ def _sbml_location(filename):
     Gets the location of one of BioNetGen's validation SBML files in BNG's
     Validate/INPUT_FILES directory.
     """
-    bng_dir = os.path.dirname(os.path.realpath(pf.get_path('bng')))
-    sbml_file = os.path.join(bng_dir, 'Validate/INPUT_FILES', filename +
-                             '.xml')
+    sbml_file = os.path.join(
+        _bng_validate_directory(), 'INPUT_FILES', filename + '.xml')
     return sbml_file
 
 

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -50,7 +50,7 @@ def _bngl_location(filename):
     Gets the location of one of BioNetGen's validation model files in BNG's
     Validate directory.
     """
-    bng_dir = os.path.dirname(pf.get_path('bng'))
+    bng_dir = os.path.dirname(os.path.realpath(pf.get_path('bng')))
     bngl_file = os.path.join(bng_dir, 'Validate', filename + '.bngl')
     return bngl_file
 
@@ -60,7 +60,7 @@ def _sbml_location(filename):
     Gets the location of one of BioNetGen's validation SBML files in BNG's
     Validate/INPUT_FILES directory.
     """
-    bng_dir = os.path.dirname(pf.get_path('bng'))
+    bng_dir = os.path.dirname(os.path.realpath(pf.get_path('bng')))
     sbml_file = os.path.join(bng_dir, 'Validate/INPUT_FILES', filename +
                              '.xml')
     return sbml_file

--- a/pysb/tools/sensitivity_analysis.py
+++ b/pysb/tools/sensitivity_analysis.py
@@ -111,8 +111,7 @@ class InitialsSensitivity(object):
       [ 0.      0.      0.      0.    ]
       [ 5.0243  5.0243  0.      0.    ]
       [-4.5381 -4.5381  0.      0.    ]]
-    >>> sens.create_boxplot_and_heatplot() #doctest: +ELLIPSIS
-    <matplotlib.figure.Figure object ...>
+    >>> sens.create_boxplot_and_heatplot() #doctest: +SKIP
     """
 
     def __init__(self, solver, values_to_sample, objective_function,


### PR DESCRIPTION
* Use pre-built binaries for bionetgen (+ nfsim and atomizer), kappa and stochkit. This reduces build time and hopefully improves reproducibility.
* Use 64 bit builds on appveyor (test on 64 bit across platforms)
* Fix Cython exception triggering by capitalizing the "Cython" import
* Ensure weave is tested on Python 2.7
* Fix integrator doctests on Python 2.7 Win64 (calling numpy `.shape` shows integers as longs, with "L" suffix)