### PR TITLE
Deprecate <> operator for reversible rules

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -500,7 +500,7 @@ class MonomerPattern(object):
     def __ne__(self, other):
         warnings.warn("'<>' for reversible rules will be removed in a future "
                       "version of PySB. Use '|' instead.",
-                      PendingDeprecationWarning,
+                      DeprecationWarning,
                       stacklevel=2)
         return self.__or__(other)
 
@@ -869,7 +869,7 @@ class ComplexPattern(object):
     def __ne__(self, other):
         warnings.warn("'<>' for reversible rules will be removed in a future "
                       "version of PySB. Use '|' instead.",
-                      PendingDeprecationWarning,
+                      DeprecationWarning,
                       stacklevel=2)
         return self.__or__(other)
 
@@ -947,7 +947,7 @@ class ReactionPattern(object):
     def __ne__(self, other):
         warnings.warn("'<>' for reversible rules will be removed in a future "
                       "version of PySB. Use '|' instead.",
-                      PendingDeprecationWarning,
+                      DeprecationWarning,
                       stacklevel=2)
         return self.__or__(other)
 


### PR DESCRIPTION
PySB v1.6.0 was just released, with the <> reversible rule operator
issuing a PendingDeprecationWarning. This commit changes that to a
DeprecationWarning, which should be included in the next release.