### PR TITLE
Fix kappa generator using certain expressions

### DIFF
--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -43,10 +43,7 @@ class KappaGenerator(object):
         for p in self.model.parameters:
             self.__content += "%%var: '%s' %e\n" % (p.name, p.value)
         for e in self.model.expressions:
-            sym_names = [x.name for x in e.expr.atoms(sympy.Symbol)]
             str_expr = str(expression_to_muparser(e))
-            for n in sym_names:
-                str_expr = str_expr.replace(n,"'%s'"%n)
             self.__content += "%%var: '%s' %s\n" % (e.name, str_expr)
         self.__content += "\n"
 
@@ -273,6 +270,9 @@ class KappaPrinter(StrPrinter):
             return self._print(expr.args[0])
         return "[min] {} {}".format(
             self._print(expr.args[0]), self._print(sympy.Min(*expr.args[1:])))
+
+    def _print_Parameter(self, expr):
+        return "'{}'".format(expr.name)
 
 
 def expression_to_muparser(expression):

--- a/pysb/tests/test_kappa.py
+++ b/pysb/tests/test_kappa.py
@@ -247,3 +247,17 @@ def test_kappa_two_ghost_agents():
     assert len(rp.complex_patterns) == 3
 
     run_simulation(model, time=100, points=100, seed=_KAPPA_SEED)
+
+
+@with_model
+def test_kappa_parameter_name_overlap():
+    Parameter('avogadro', 6.022e23)
+    Parameter('cell_volume', 2.25e-12)
+    Parameter('cell_volume_fraction', 0.001)
+    Expression('stochastic', avogadro * cell_volume * cell_volume_fraction)
+
+    Monomer('A', ['b'])
+    Initial(A(b=None), Parameter('A_0', 100))
+    Rule('deg_A', A(b=None) >> None, stochastic)
+    Observable('A_', A())
+    run_simulation(model, time=100, points=100, seed=_KAPPA_SEED)


### PR DESCRIPTION
The kappa generator was incorrectly substituting parameter names in
expressions if one parameter was a substring of the other. This PR
uses the sympy printer instead of string replacement.

Fixes: #345 