### PR TITLE
Forbid defining a state as None

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -362,7 +362,7 @@ class MonomerPattern(object):
         invalid_sites = []
         for (site, state) in site_conditions.items():
             # pass through to next iteration if state type is ok
-            if state == None:
+            if state is None and site not in monomer.site_states:
                 continue
             elif isinstance(state, int):
                 continue
@@ -384,13 +384,13 @@ class MonomerPattern(object):
                 continue
             invalid_sites.append(site)
         if invalid_sites:
-            raise Exception("Invalid state value for sites: " +
-                            '; '.join(['%s=%s' % (s,str(site_conditions[s]))
+            raise ValueError("Invalid state value for sites: " +
+                             '; '.join(['%s=%s' % (s, str(site_conditions[s]))
                                        for s in invalid_sites]))
 
         # ensure compartment is a Compartment
         if compartment and not isinstance(compartment, Compartment):
-            raise Exception("compartment is not a Compartment object")
+            raise ValueError("compartment is not a Compartment object")
 
         self.monomer = monomer
         self.site_conditions = site_conditions

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -307,7 +307,6 @@ class SpeciesPatternMatcher(object):
     >>> A = Monomer('A', ['a'], {'a': ['u', 'p']}, _export=False)
     >>> model.add_component(A)
     >>> species = [                                                     \
-            A(a=None),                                                  \
             A(a='u'),                                                   \
             A(a=1) % A(a=1),                                            \
             A(a=('u', 1)) % A(a=('u', 1)),                              \
@@ -316,7 +315,7 @@ class SpeciesPatternMatcher(object):
     >>> model.species = [as_complex_pattern(sp) for sp in species]
     >>> spm2 = SpeciesPatternMatcher(model)
     >>> spm2.match(A()) # doctest:+NORMALIZE_WHITESPACE
-    [A(a=None), A(a='u'), A(a=1) % A(a=1), A(a=('u', 1)) % A(a=('u', 1)),
+    [A(a='u'), A(a=1) % A(a=1), A(a=('u', 1)) % A(a=('u', 1)),
      A(a=('p', 1)) % A(a=('p', 1))]
     >>> spm2.match(A(a='u'))
     [A(a='u')]

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -1,7 +1,7 @@
 from pysb.testing import *
 from pysb.core import *
 from functools import partial
-import itertools
+from nose.tools import assert_raises
 
 
 @with_model
@@ -333,3 +333,9 @@ def test_dangling_bond():
 @with_model
 def test_expression_type():
     assert_raises(ValueError, Expression, 'A', 1)
+
+
+@with_model
+def test_call_site_as_none():
+    Monomer('A', ['a'], {'a': ['x', 'y']})
+    assert_raises(ValueError, A, a=None)


### PR DESCRIPTION
A state, as opposed to a bond, should not be able to be defined as
None. Doing so causes an error in BNG: "reaction list cannot be read
because of errors". This commit adds a check for this condition
and a unit test.