### PR TITLE
Expressions must be created from sympy.Expr

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1354,6 +1354,9 @@ class Expression(Component, sympy.Symbol):
 
     def __init__(self, name, expr, _export=True):
         Component.__init__(self, name, _export)
+        if not isinstance(expr, sympy.Expr):
+            raise ValueError('An Expression can only be created from a '
+                             'sympy.Expr object')
         self.expr = expr
 
     def expand_expr(self, expand_observables=False):

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -214,7 +214,10 @@ class BnglBuilder(Builder):
             except KeyError:
                 return self.model.expressions[rate_law_name]
         elif rl.get('type') == 'Function':
-            return self.model.expressions[rl.get('name')]
+            try:
+                return self.model.expressions[rl.get('name')]
+            except KeyError:
+                return self.model.parameters[rl.get('name')]
         else:
             self._warn_or_except('Rate law %s has unknown type %s' %
                                  (rl.get('id'), rl.get('type')))
@@ -312,7 +315,10 @@ class BnglBuilder(Builder):
                                                           expr_text,
                                                           ex.message))
             expr_namespace[expr_name] = expr_val
-            self.expression(expr_name, expr_val)
+            if isinstance(expr_val, (float, int)):
+                self.parameter(expr_name, expr_val)
+            else:
+                self.expression(expr_name, expr_val)
 
     def _parse_bng_xml(self):
         self.model.name = self._x.get(_ns('id'))

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree
 import re
 from sympy.parsing.sympy_parser import parse_expr
 import warnings
+import numbers
 
 
 def _ns(tag_string):
@@ -315,7 +316,7 @@ class BnglBuilder(Builder):
                                                           expr_text,
                                                           ex.message))
             expr_namespace[expr_name] = expr_val
-            if isinstance(expr_val, (float, int)):
+            if isinstance(expr_val, numbers.Number):
                 self.parameter(expr_name, expr_val)
             else:
                 self.expression(expr_name, expr_val)

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -328,3 +328,8 @@ def test_dangling_bond():
     Monomer('A', ['a'])
     Parameter('kf', 1.0)
     assert_raises(DanglingBondError, as_reaction_pattern, A(a=1) % A(a=None))
+
+
+@with_model
+def test_expression_type():
+    assert_raises(ValueError, Expression, 'A', 1)


### PR DESCRIPTION
The BNGL and SBML importers were creating Expressions from ints and
floats, which are better represented as Parameters. This PR
performs this conversion within the importers where applicable.

Fixes: #349