### PR TITLE
Enforce synthesis products to be concrete

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1200,6 +1200,15 @@ class Rule(Component):
         self.move_connected = move_connected
         # TODO: ensure all numbered sites are referenced exactly twice within each of reactants and products
 
+        # Check synthesis products are concrete
+        if self.is_synth():
+            rp = self.reactant_pattern if self.is_reversible else \
+                self.product_pattern
+            for cp in rp.complex_patterns:
+                if not cp.is_concrete():
+                    raise ValueError('Product {} of synthesis rule {} is not '
+                                     'concrete'.format(cp, self.name))
+
     def is_synth(self):
         """Return a bool indicating whether this is a synthesis rule."""
         return len(self.reactant_pattern.complex_patterns) == 0 or \

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -333,3 +333,14 @@ def test_dangling_bond():
 @with_model
 def test_expression_type():
     assert_raises(ValueError, Expression, 'A', 1)
+
+
+@with_model
+def test_synth_requires_concrete():
+    Monomer('A', ['s'], {'s': ['a', 'b']})
+    Parameter('kA', 1.0)
+
+    # These synthesis products are not concrete (site "s" not specified),
+    # so they should raise a ValueError
+    assert_raises(ValueError, Rule, 'r1', None >> A(), kA)
+    assert_raises(ValueError, Rule, 'r2', A() | None, kA, kA)


### PR DESCRIPTION
This PR introduces a check at rule instantiation that every
product is concrete for synthesis rules.