### PR TITLE
Allow state=None in rule patterns

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -362,7 +362,7 @@ class MonomerPattern(object):
         invalid_sites = []
         for (site, state) in site_conditions.items():
             # pass through to next iteration if state type is ok
-            if state is None and site not in monomer.site_states:
+            if state is None:
                 continue
             elif isinstance(state, int):
                 continue

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -306,6 +306,7 @@ def test_concreteness():
     assert (A(s=('x', 1)) % A(s=('x', 1))).is_concrete()
     assert (A(s='x')).is_concrete()
     assert not A().is_concrete()
+    assert not A(s=None).is_concrete()
     assert not A(s=('x', ANY)).is_concrete()
     assert not A(s=WILD).is_concrete()
 
@@ -336,11 +337,6 @@ def test_expression_type():
 
 
 @with_model
-def test_call_site_as_none():
-    Monomer('A', ['a'], {'a': ['x', 'y']})
-    assert_raises(ValueError, A, a=None)
-
-@with_model
 def test_synth_requires_concrete():
     Monomer('A', ['s'], {'s': ['a', 'b']})
     Parameter('kA', 1.0)
@@ -349,3 +345,12 @@ def test_synth_requires_concrete():
     # so they should raise a ValueError
     assert_raises(ValueError, Rule, 'r1', None >> A(), kA)
     assert_raises(ValueError, Rule, 'r2', A() | None, kA, kA)
+
+
+@with_model
+def test_rulepattern_match_none_against_state():
+    Monomer('A', ['phospho'], {'phospho': ['u', 'p']})
+
+    # A(phospho=None) should match unbound A regardless of phospho state,
+    # so this should be a valid rule pattern
+    A(phospho=None) + A(phospho=None) >> A(phospho=1) % A(phospho=1)


### PR DESCRIPTION
None should be allowed in MonomerPatterns, to allow for models like
the following:

    Monomer('A', ['phospho'], {'phospho': ['u', 'p']})
    A(phospho=None) + A(phospho=None) >> A(phospho=1) % A(phospho=1)

#348 missed the mark somewhat... my intention was to disallow undefined
states in *species*, not in *patterns*. Such patterns are already detected 
as un-concrete, so they are forbidden in initials.

Thanks to @bgyori for spotting and reporting this.