### PR TITLE
Tests for PySB exporters

### DIFF
--- a/pysb/export/__init__.py
+++ b/pysb/export/__init__.py
@@ -133,6 +133,19 @@ formats = {
         'stochkit': 'StochKitExporter'
         }
 
+
+class ExportError(Exception):
+    pass
+
+
+class ExpressionsNotSupported(ExportError, NotImplementedError):
+    """ Expressions are not supported by this exporter """
+
+
+class CompartmentsNotSupported(ExportError, NotImplementedError):
+    """ Compartments are not supported by this exporter """
+
+
 def export(model, format, docstring=None):
     """Top-level function for exporting a model to a given format.
 

--- a/pysb/export/mathematica.py
+++ b/pysb/export/mathematica.py
@@ -108,8 +108,9 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from math import floor, log
-from pysb.export import Exporter
+from pysb.export import Exporter, ExpressionsNotSupported, \
+    CompartmentsNotSupported
+
 
 class MathematicaExporter(Exporter):
     """A class for returning the ODEs for a given PySB model for use in
@@ -128,6 +129,10 @@ class MathematicaExporter(Exporter):
         string
             String containing the Mathematica code for the model's ODEs.
         """
+        if self.model.expressions:
+            raise ExpressionsNotSupported()
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
 
         output = StringIO()
         pysb.bng.generate_equations(self.model)

--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -171,7 +171,9 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from pysb.export import Exporter, pad
+from pysb.export import Exporter, pad, ExpressionsNotSupported, \
+    CompartmentsNotSupported
+
 
 class MatlabExporter(Exporter):
     """A class for returning the ODEs for a given PySB model for use in
@@ -190,6 +192,11 @@ class MatlabExporter(Exporter):
             String containing the MATLAB code for an implementation of the
             model's ODEs.
         """
+        if self.model.expressions:
+            raise ExpressionsNotSupported()
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
+
         output = StringIO()
         pysb.bng.generate_equations(self.model)
 

--- a/pysb/export/potterswheel.py
+++ b/pysb/export/potterswheel.py
@@ -69,7 +69,9 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from pysb.export import Exporter
+from pysb.export import Exporter, ExpressionsNotSupported, \
+    CompartmentsNotSupported
+
 
 class PottersWheelExporter(Exporter):
     """A class for returning the PottersWheel equivalent for a given PySB model.
@@ -87,6 +89,10 @@ class PottersWheelExporter(Exporter):
         string
             String containing the PottersWheel code for the ODEs.
         """
+        if self.model.expressions:
+            raise ExpressionsNotSupported()
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
 
         output = StringIO()
         pysb.bng.generate_equations(self.model)

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -70,8 +70,8 @@ An example usage pattern for the standalone Robertson model, once generated::
 import pysb
 import pysb.bng
 import sympy
-import textwrap
-from pysb.export import Exporter, pad
+from pysb.export import Exporter, pad, ExpressionsNotSupported, \
+    CompartmentsNotSupported
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -92,6 +92,10 @@ class PythonExporter(Exporter):
         string
             String containing the standalone Python code.
         """
+        if self.model.expressions:
+            raise ExpressionsNotSupported()
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
 
         output = StringIO()
         pysb.bng.generate_equations(self.model)

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -9,8 +9,8 @@ for :py:mod:`pysb.export`.
 
 import pysb
 import pysb.bng
-from pysb.export import Exporter
-import sympy
+from pysb.export import Exporter, ExpressionsNotSupported, \
+    CompartmentsNotSupported
 from sympy.printing.mathml import MathMLPrinter
 import itertools
 import textwrap
@@ -83,6 +83,7 @@ def get_species_annotation(meta_id, cp):
     output += get_annotation_postamble()
     return indent(output, 16)
 
+
 class SbmlExporter(Exporter):
     """A class for returning the SBML for a given PySB model.
 
@@ -98,6 +99,10 @@ class SbmlExporter(Exporter):
         string
             String containing the SBML output.
         """
+        if self.model.expressions:
+            raise ExpressionsNotSupported()
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
 
         output = StringIO()
         pysb.bng.generate_equations(self.model)

--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -7,7 +7,7 @@ library with permission from author Brian Drawert.
 For information on how to use the model exporters, see the documentation
 for :py:mod:`pysb.export`.
 """
-from pysb.export import Exporter
+from pysb.export import Exporter, CompartmentsNotSupported
 from pysb.core import as_complex_pattern, Expression, Parameter
 from pysb.bng import generate_equations
 import numpy as np
@@ -122,6 +122,9 @@ class StochKitExporter(Exporter):
         string
             The model in StochKit2 XML format
         """
+        if self.model.compartments:
+            raise CompartmentsNotSupported()
+
         generate_equations(self.model)
         document = etree.Element("Model")
 

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -3,7 +3,7 @@ import sympy
 import warnings
 from sympy.printing import StrPrinter
 from sympy.core import S
-
+from pysb.export import CompartmentsNotSupported
 # Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
@@ -14,6 +14,8 @@ class KappaGenerator(object):
 
     # Dialect can be either 'complx' or 'kasim' (default)
     def __init__(self, model, dialect='kasim', _warn_no_ic=True):
+        if model.compartments:
+            raise CompartmentsNotSupported()
         self.model = model
         self.__content = None
         self.dialect = dialect

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -1,0 +1,36 @@
+# -*- coding:utf-8; -*-
+"""
+Test example models export without error using the available exporters
+
+Based on code submitted in a PR by @keszybz in pysb/pysb#113
+"""
+from pysb.tests.test_examples import get_example_models, expected_exceptions
+from pysb import export
+
+
+def test_export():
+    for model in get_example_models():
+        for format in export.formats:
+            fn = lambda: check_convert(model, format)
+            fn.description = "Check export: {} → {}".format(
+                model.name, format)
+            yield fn
+
+
+def check_convert(model, format):
+    """ Test exporters run without error """
+    try:
+        export.export(model, format)
+    except export.ExpressionsNotSupported:
+        pass
+    except export.CompartmentsNotSupported:
+        pass
+    except Exception as e:
+        # Some example models are deliberately incomplete, so here we
+        # will treat any of these "expected" exceptions as a success.
+        model_base_name = model.name.rsplit('.', 1)[1]
+        exception_class = expected_exceptions.get(model_base_name)
+        if exception_class and isinstance(e, exception_class):
+            pass
+        else:
+            raise


### PR DESCRIPTION
This PR tests all PySB example models against all the available
exporters. It's heavily based on @keszybz's approach in #113.

I've also implemented explicit ExpressionsNotSupported and
CompartmentsNotSupported exceptions for the exporters which
don't support those features.

Fixes: #154
Fixes: #73