### PR TITLE
Add fixed species support

### DIFF
--- a/doc/examples/robertson_standalone.py
+++ b/doc/examples/robertson_standalone.py
@@ -8,7 +8,6 @@ Analysis: An Introduction, J. Walsh, ed., Academic Press, 1966, pp. 178-182.
 # exported from PySB model 'robertson'
 
 import numpy
-import weave
 import scipy.integrate
 import collections
 import itertools
@@ -18,8 +17,11 @@ import distutils.errors
 _use_inline = False
 # try to inline a C statement to see if inline is functional
 try:
+    import weave
     weave.inline('int i;', force=1)
     _use_inline = True
+except ImportError:
+    pass
 except distutils.errors.CompileError:
     pass
 
@@ -41,7 +43,7 @@ class Model(object):
         self.sim_param_values = numpy.empty(6)
         self.parameters = [None] * 6
         self.observables = [None] * 3
-        self.initial_conditions = [None] * 3
+        self.initials = [None] * 3
     
         self.parameters[0] = Parameter('k1', 0.040000000000000001)
         self.parameters[1] = Parameter('k2', 30000000)
@@ -54,18 +56,18 @@ class Model(object):
         self.observables[1] = Observable('B_total', [1], [1])
         self.observables[2] = Observable('C_total', [2], [1])
 
-        self.initial_conditions[0] = Initial(3, 0)
-        self.initial_conditions[1] = Initial(4, 1)
-        self.initial_conditions[2] = Initial(5, 2)
+        self.initials[0] = Initial(3, 0)
+        self.initials[1] = Initial(4, 1)
+        self.initials[2] = Initial(5, 2)
 
     if _use_inline:
         
         def ode_rhs(self, t, y, p):
             ydot = self.ydot
             weave.inline(r'''
-                ydot[0] = -p[0]*y[0] + p[2]*y[1]*y[2];
-                ydot[1] = p[0]*y[0] - p[1]*pow(y[1], 2) - p[2]*y[1]*y[2];
-                ydot[2] = p[1]*pow(y[1], 2);
+                ydot[0] = y[1]*y[2]*p[2] + (y[0]*p[0])*(-1);
+                ydot[1] = y[0]*p[0] + (pow(y[1], 2)*p[1])*(-1) + (y[1]*y[2]*p[2])*(-1);
+                ydot[2] = pow(y[1], 2)*p[1];
                 ''', ['ydot', 't', 'y', 'p'])
             return ydot
         
@@ -73,9 +75,9 @@ class Model(object):
         
         def ode_rhs(self, t, y, p):
             ydot = self.ydot
-            ydot[0] = -p[0]*y[0] + p[2]*y[1]*y[2]
-            ydot[1] = p[0]*y[0] - p[1]*pow(y[1], 2) - p[2]*y[1]*y[2]
-            ydot[2] = p[1]*pow(y[1], 2)
+            ydot[0] = y[1]*y[2]*p[2] + (y[0]*p[0])*(-1)
+            ydot[1] = y[0]*p[0] + (pow(y[1], 2)*p[1])*(-1) + (y[1]*y[2]*p[2])*(-1)
+            ydot[2] = pow(y[1], 2)*p[1]
             return ydot
         
     
@@ -90,14 +92,14 @@ class Model(object):
             # create parameter vector from the values in the model
             self.sim_param_values[:] = [p.value for p in self.parameters]
         self.y0.fill(0)
-        for ic in self.initial_conditions:
+        for ic in self.initials:
             self.y0[ic.species_index] = self.sim_param_values[ic.param_index]
         if self.y is None or len(tspan) != len(self.y):
             self.y = numpy.empty((len(tspan), len(self.y0)))
             if len(self.observables):
                 self.yobs = numpy.ndarray(len(tspan),
-                                zip((obs.name for obs in self.observables),
-                                    itertools.repeat(float)))
+                                list(zip((obs.name for obs in self.observables),
+                                    itertools.repeat(float))))
             else:
                 self.yobs = numpy.ndarray((len(tspan), 0))
             self.yobs_view = self.yobs.view(float).reshape(len(self.yobs),

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -452,8 +452,8 @@ one shown (output shown below the ``'>>>'``` prompts)::
       {'obsC8': <pysb.core.Observable object at 0x104b2c4d0>,
        'obsBid': <pysb.core.Observable object at 0x104b2c5d0>,
        'obstBid': <pysb.core.Observable object at 0x104b2c6d0>}
-   >>> m.model.initial_conditions
-      [(C8(b=None), Parameter(name='C8_0', value=1000)), (Bid(b=None, S=u), Parameter(name='Bid_0', value=10000))]
+   >>> m.model.initials
+      [Initial(C8(b=None), C8_0), Initial(Bid(b=None, S='u'), Bid_0)]
    >>> m.model.rules
       {'C8_Bid_bind': Rule(name='C8_Bid_bind', reactants=C8(b=None) +
       Bid(b=None, S=None), products=C8(b=1) % Bid(b=1, S=None),

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -96,8 +96,10 @@ class BngBaseInterface(object):
         """
         if not self.model.rules:
             raise NoRulesError()
-        if not self.model.initial_conditions and not any(r.is_synth() for r
-                                                         in self.model.rules):
+        if (
+            not self.model.initials
+            and not any(r.is_synth() for r in self.model.rules)
+        ):
             raise NoInitialConditionsError()
 
     @classmethod

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -778,7 +778,7 @@ def _parse_species(model, line):
     monomer_patterns = []
     for ms in monomer_strings:
         monomer_name, site_strings, monomer_compartment_name = \
-            re.match(r'(\w+)\(([^)]*)\)(?:@(\w+))?', ms).groups()
+            re.match(r'\$?(\w+)\(([^)]*)\)(?:@(\w+))?', ms).groups()
         site_conditions = {}
         if len(site_strings):
             for ss in site_strings.split(','):

--- a/pysb/builder.py
+++ b/pysb/builder.py
@@ -172,9 +172,11 @@ class Builder(object):
         self.model.add_component(e)
         return e
 
-    def initial(self, *args):
+    def initial(self, *args, **kwargs):
         """Adds an initial condition to the Builder's model instance."""
-        self.model.initial(*args)
+        i = Initial(*args, _export=False, **kwargs)
+        self.model.add_initial(i)
+        return i
 
     def __getitem__(self, index):
         """Returns the component with the given string index

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -9,6 +9,7 @@ import weakref
 import copy
 import itertools
 import sympy
+import numpy as np
 import scipy.sparse
 import networkx as nx
 
@@ -23,9 +24,9 @@ except NameError:
     basestring = str
     long = int
 
-def Initial(*args):
+def Initial(*args, **kwargs):
     """Declare an initial condition (see Model.initial)."""
-    return SelfExporter.default_model.initial(*args)
+    return SelfExporter.default_model.initial(*args, **kwargs)
 
 def MatchOnce(pattern):
     """Make a ComplexPattern match-once."""
@@ -1490,6 +1491,7 @@ class Model(object):
         self.observables = ComponentSet()
         self.expressions = ComponentSet()
         self.initial_conditions = []
+        self.initial_conditions_fixed = []
         self.annotations = []
         self._odes = OdeView(self)
         self.reset_equations()
@@ -1506,6 +1508,7 @@ class Model(object):
                 self.add_component(component)
                 component._do_export()
             self.initial_conditions = model_copy.initial_conditions
+            self.initial_conditions_fixed = model_copy.initial_conditions_fixed
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1664,6 +1667,8 @@ class Model(object):
                     sm[r, i] -= 1
                 for p in reaction['products']:
                     sm[p, i] += 1
+            fixed = np.array(self.initial_conditions_fixed).nonzero()[0]
+            sm[fixed, :] = 0
             self._stoichiometry_matrix = sm.tocsr()
         return self._stoichiometry_matrix
 
@@ -1739,7 +1744,7 @@ class Model(object):
             raise InvalidInitialConditionError("MatchOnce not allowed here")
         return complex_pattern
 
-    def initial(self, pattern, value):
+    def initial(self, pattern, value, fixed=False):
         """
         Add an initial condition.
 
@@ -1752,11 +1757,14 @@ class Model(object):
             A concrete pattern defining the species to initialize.
         value : Parameter
             Amount of the species the model will start with.
+        fixed : bool
+            Whether or not the species should be held fixed (never consumed).
 
         """
         complex_pattern = self._validate_initial_condition_pattern(pattern)
         validate_const_expr(value, "initial condition value")
         self.initial_conditions.append( (complex_pattern, value) )
+        self.initial_conditions_fixed.append(fixed)
 
     def update_initial_condition_pattern(self, before_pattern, after_pattern):
         """
@@ -1805,7 +1813,9 @@ class Model(object):
         # We retain the old parameter object:
         p = self.initial_conditions[ic_index][1]
         del self.initial_conditions[ic_index]
+        fixed = self.initial_conditions_fixed.pop(ic_index)
         self.initial_conditions.append( (after_pattern, p) )
+        self.initial_conditions_fixed.append(fixed)
 
     def get_species_index(self, complex_pattern):
         """

--- a/pysb/examples/cupsoda/run_michment_cupsoda.py
+++ b/pysb/examples/cupsoda/run_michment_cupsoda.py
@@ -9,14 +9,18 @@ def run():
     # factors to multiply the values of the initial conditions
     multipliers = np.linspace(0.8, 1.2, 11)
     # 2D array of initial concentrations
-    initial_concentrations = [multipliers*ic[1].value for ic in model.initial_conditions]
+    initial_concentrations = [
+        multipliers * ic.value.value for ic in model.initials
+    ]
     # Cartesian product of initial concentrations
     cartesian_product = itertools.product(*initial_concentrations)
     # the Cartesian product object must be cast to a list, then to a numpy array
     # and transposed to give a (n_species x n_vals) matrix of initial concentrations
     initials_matrix = np.array(list(cartesian_product)).T
     # we can now construct the initials dictionary
-    initials = { ic[0] : initials_matrix[i] for i,ic in enumerate(model.initial_conditions) }
+    initials = {
+        ic.pattern: initials_matrix[i] for i, ic in enumerate(model.initials)
+    }
     # simulation time span and output points
     tspan = np.linspace(0, 50, 501)
     # run_cupsoda returns a 3D array of species and observables trajectories

--- a/pysb/examples/cupsoda/run_tyson_oscillator_cupsoda.py
+++ b/pysb/examples/cupsoda/run_tyson_oscillator_cupsoda.py
@@ -23,10 +23,10 @@ def run():
     # Initial concentrations
     initials = np.zeros((n_sims, len(model.species)))
     for i in range(len(initials)):
-        for ic in model.initial_conditions:
+        for ic in model.initials:
             for j in range(len(initials[i])):
-                if str(ic[0]) == str(model.species[j]):
-                    initials[i][j] = ic[1].value
+                if str(ic.pattern) == str(model.species[j]):
+                    initials[i][j] = ic.value.value
                     break
 
     x = sim.run(initials=initials, param_values=param_values)

--- a/pysb/examples/explicit.py
+++ b/pysb/examples/explicit.py
@@ -24,8 +24,8 @@ L_0 = Parameter('L_0', 1e2)
 R_0 = Parameter('R_0', 1e4)
 model.add_component(L_0)
 model.add_component(R_0)
-model.initial(L(r=None), L_0)
-model.initial(R(l=None), R_0)
+model.add_initial(Initial(L(r=None), L_0))
+model.add_initial(Initial(R(l=None), R_0))
 
 if __name__ == '__main__':
     print(__doc__, "\n", model)

--- a/pysb/examples/fixed_initial.py
+++ b/pysb/examples/fixed_initial.py
@@ -1,0 +1,38 @@
+"""Example of using an initial condition with a fixed amount.
+
+With the amount of free F fixed, most of the free A will be able to bind and
+form the A-F complex before equilibrium is reached. If free F were not fixed,
+its lower initial amount would severely restrict how much complex could form.
+See run_fixed_initial.py for a demonstration of this behavior.
+
+"""
+
+from __future__ import print_function
+from pysb import *
+
+Model()
+
+Monomer('A', ['b'])
+Monomer('F', ['b'])
+
+Parameter('kf', 1.0)
+Parameter('kr', 1.0)
+Parameter('A_0', 100)
+Parameter('F_0', 20)
+
+Rule('A_bind_F', A(b=None) + F(b=None) | A(b=1) % F(b=1), kf, kr)
+
+Initial(A(b=None), A_0)
+Initial(F(b=None), F_0, fixed=True)
+
+Observable('A_free', A(b=None))
+Observable('F_free', F(b=None))
+Observable('AF_complex', A(b=1) % F(b=1))
+
+
+if __name__ == '__main__':
+    print(__doc__, "\n", model)
+    print("""
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid.""")

--- a/pysb/examples/run_fixed_initial.py
+++ b/pysb/examples/run_fixed_initial.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Demonstrate the effect of fixed initial conditions."""
+
+import copy
+import numpy as np
+import matplotlib.pyplot as plt
+from pysb.simulator import ScipyOdeSimulator
+
+from pysb.examples.fixed_initial import model
+
+n_obs = len(model.observables)
+tspan = np.linspace(0, 0.5)
+
+plt.figure(figsize=(8,4))
+
+# Simulate the model as written, with free F fixed.
+sim = ScipyOdeSimulator(model, tspan)
+res = sim.run()
+obs = res.observables.view(float).reshape(-1, n_obs)
+plt.subplot(121)
+plt.plot(res.tout[0], obs)
+plt.ylabel('Amount')
+plt.xlabel('Time')
+plt.legend([x.name for x in model.observables], frameon=False)
+plt.title('Free F fixed')
+
+# Make a copy of the model and unfix the initial condition for free F.
+model2 = copy.deepcopy(model)
+model2.reset_equations()
+model2.initials[1].fixed = False
+sim2 = ScipyOdeSimulator(model2, tspan)
+res2 = sim2.run()
+obs2 = res2.observables.view(float).reshape(-1, n_obs)
+plt.subplot(122)
+plt.plot(res2.tout[0], obs2)
+plt.xlabel('Time')
+plt.legend([x.name for x in model.observables], frameon=False)
+plt.title('Free F can be consumed')
+
+plt.show()

--- a/pysb/examples/run_michment.py
+++ b/pysb/examples/run_michment.py
@@ -6,12 +6,12 @@ import itertools
 
 # Construct initials dict
 mult = np.linspace(0.8, 1.2, 11)
-matrix = [mult*ic[1].value for ic in model.initial_conditions]
+matrix = [mult*ic.value.value for ic in model.initials]
 initials = {}
-for i,ic in enumerate(model.initial_conditions):
-    initials[ic[0]] = []
+for i, ic in enumerate(model.initials):
+    initials[ic.pattern] = []
     for tup in itertools.product(*matrix): # Cartesian product
-        initials[ic[0]].append(tup[i])
+        initials[ic.pattern].append(tup[i])
 
 tspan = np.linspace(0, 50, 501)
 sim = ScipyOdeSimulator(model, tspan, verbose=False)

--- a/pysb/export/mathematica.py
+++ b/pysb/export/mathematica.py
@@ -200,9 +200,9 @@ class MathematicaExporter(Exporter):
 
         ## INITIAL CONDITIONS
         ic_values = ['0'] * len(self.model.odes)
-        for i, ic in enumerate(self.model.initial_conditions):
-            ic_values[self.model.get_species_index(ic[0])] = \
-                                        ic[1].name.replace('_', '')
+        for i, ic in enumerate(self.model.initials):
+            idx = self.model.get_species_index(ic.pattern)
+            ic_values[idx] = ic.value.name.replace('_', '')
 
         init_conds_str = 'initconds = {\n'
         init_conds_str += ',\n'.join(['s%s[0] == %s' % (i, val)

--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -231,8 +231,8 @@ class MatlabExporter(Exporter):
                              len(self.model.species)
         initial_values_str += ('\n'+' '*12).join(
                 ['initial_values(%d) = self.parameters.%s; %% %s' %
-                 (i+1, _fix_underscores(ic[1].name), ic[0])
-                 for i, ic in enumerate(self.model.initial_conditions)])
+                 (i+1, _fix_underscores(ic.value.name), ic.pattern)
+                 for i, ic in enumerate(self.model.initials)])
 
         # -- Build observables declaration --
         observables_str = 'self.observables = struct( ...\n'+' '*16

--- a/pysb/export/potterswheel.py
+++ b/pysb/export/potterswheel.py
@@ -100,8 +100,8 @@ class PottersWheelExporter(Exporter):
         model_name = self.model.name.replace('.', '_')
 
         ic_values = [0] * len(self.model.odes)
-        for cp, ic_param in self.model.initial_conditions:
-            ic_values[self.model.get_species_index(cp)] = ic_param.value
+        for ic in self.model.initials:
+            ic_values[self.model.get_species_index(ic.pattern)] = ic.value.value
 
         # list of "dynamic variables"
         pw_x = ["m = pwAddX(m, 's%d', %e);" % (i, ic_values[i])

--- a/pysb/export/pysb_flat.py
+++ b/pysb/export/pysb_flat.py
@@ -74,8 +74,8 @@ class PysbFlatExporter(Exporter):
         write_cset(self.model.observables)
         write_cset(self.model.expressions_dynamic())
         write_cset(self.model.rules)
-        for pattern, value in self.model.initial_conditions:
-            output.write("Initial(%s, %s)\n" % (repr(pattern), value.name))
+        for ic in self.model.initials:
+            output.write("%s\n" % ic)
         output.write("\n")
         write_cset(self.model.annotations)
 

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -169,6 +169,7 @@ class SbmlExporter(Exporter):
 
         # Initial values/assignments
         initial_concs = [0.0] * len(self.model.species)
+        fixed_species_idx = set()
         for ic in self.model.initials:
             sp_idx = self.model.get_species_index(ic.pattern)
             if isinstance(ic.value, pysb.Expression):
@@ -180,6 +181,8 @@ class SbmlExporter(Exporter):
                 initial_concs[sp_idx] = None
             else:
                 initial_concs[sp_idx] = ic.value.value
+                if ic.fixed:
+                    fixed_species_idx.add(sp_idx)
 
         # Species
         for i, s in enumerate(self.model.species):
@@ -204,7 +207,7 @@ class SbmlExporter(Exporter):
                 compartment_name = 'default'
             _check(sp.setCompartment(compartment_name))
             _check(sp.setName(str(s).replace('% ', '._br_')))
-            _check(sp.setBoundaryCondition(False))
+            _check(sp.setBoundaryCondition(i in fixed_species_idx))
             _check(sp.setConstant(False))
             _check(sp.setHasOnlySubstanceUnits(True))
             if initial_concs[i] is not None:

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -6,7 +6,6 @@ for :py:mod:`pysb.export`.
 """
 import pysb
 import pysb.bng
-from sympy import sympify
 from pysb.export import Exporter
 from sympy.printing.mathml import MathMLPrinter
 from xml.dom.minidom import Document
@@ -170,17 +169,17 @@ class SbmlExporter(Exporter):
 
         # Initial values/assignments
         initial_concs = [0.0] * len(self.model.species)
-        for cp, param in self.model.initial_conditions:
-            sp_idx = self.model.get_species_index(cp)
-            if isinstance(param, pysb.Expression):
+        for ic in self.model.initials:
+            sp_idx = self.model.get_species_index(ic.pattern)
+            if isinstance(ic.value, pysb.Expression):
                 ia = smodel.createInitialAssignment()
                 _check(ia)
                 _check(ia.setSymbol('__s{}'.format(sp_idx)))
-                init_mathml = self._sympy_to_sbmlast(sympify(param.name))
+                init_mathml = self._sympy_to_sbmlast(ic.value)
                 _check(ia.setMath(init_mathml))
                 initial_concs[sp_idx] = None
             else:
-                initial_concs[sp_idx] = param.value
+                initial_concs[sp_idx] = ic.value.value
 
         # Species
         for i, s in enumerate(self.model.species):

--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -159,19 +159,19 @@ class StochKitExporter(Exporter):
             subs = dict((p, param_values[i]) for i, p in
                         enumerate(self.model.parameters))
 
-            for cp, value_obj in self.model.initial_conditions:
-                cp = as_complex_pattern(cp)
+            for ic in self.model.initials:
+                cp = as_complex_pattern(ic.pattern)
                 si = self.model.get_species_index(cp)
                 if si is None:
                     raise IndexError("Species not found in model: %s" %
                                      repr(cp))
-                if isinstance(value_obj, (int, float)):
-                    value = value_obj
-                elif value_obj in self.model.parameters:
-                    pi = self.model.parameters.index(value_obj)
+                if isinstance(ic.value, (int, float)):
+                    value = ic.value
+                elif ic.value in self.model.parameters:
+                    pi = self.model.parameters.index(ic.value)
                     value = param_values[pi]
-                elif value_obj in self.model.expressions:
-                    value = value_obj.expand_expr().evalf(subs=subs)
+                elif ic.value in self.model.expressions:
+                    value = ic.value.expand_expr().evalf(subs=subs)
                 else:
                     raise ValueError(
                         "Unexpected initial condition value type")

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -136,6 +136,8 @@ class BngGenerator(object):
             warn_caller("Model does not contain any initial conditions")
             return
         species_codes = [format_complexpattern(cp) for cp, param in self.model.initial_conditions]
+        fixed = ['$' if f else '' for f in self.model.initial_conditions_fixed]
+        species_codes = [f + c for f, c in zip(fixed, species_codes)]
         for cp in self._additional_initials:
             if not any([cp.is_equivalent_to(i) for i, _ in
                         self.model.initial_conditions]):

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -136,10 +136,9 @@ class BngGenerator(object):
             warn_caller("Model does not contain any initial conditions")
             return
         species_codes = [
-            format_complexpattern(ic.pattern) for ic in self.model.initials
+            format_complexpattern(ic.pattern, ic.fixed)
+            for ic in self.model.initials
         ]
-        fixed = ['$' if ic.fixed else '' for ic in self.model.initials]
-        species_codes = [f + c for f, c in zip(fixed, species_codes)]
         for cp in self._additional_initials:
             if not any([
                 cp.is_equivalent_to(ic.pattern) for ic in self.model.initials
@@ -190,10 +189,12 @@ def format_reactionpattern(rp, for_observable=False):
         delimiter = ' '
     return delimiter.join([format_complexpattern(cp) for cp in rp.complex_patterns])
 
-def format_complexpattern(cp):
+def format_complexpattern(cp, fixed=False):
     if cp is None:
         return '0'
     ret = '.'.join([format_monomerpattern(mp) for mp in cp.monomer_patterns])
+    if fixed:
+        ret = '$' + ret
     if cp.compartment is not None:
         ret = '@%s:%s' % (cp.compartment.name, ret)
     if cp.match_once:

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -132,21 +132,24 @@ class BngGenerator(object):
         self.__content += "end functions\n\n"
 
     def generate_species(self):
-        if not self.model.initial_conditions:
+        if not self.model.initials:
             warn_caller("Model does not contain any initial conditions")
             return
-        species_codes = [format_complexpattern(cp) for cp, param in self.model.initial_conditions]
-        fixed = ['$' if f else '' for f in self.model.initial_conditions_fixed]
+        species_codes = [
+            format_complexpattern(ic.pattern) for ic in self.model.initials
+        ]
+        fixed = ['$' if ic.fixed else '' for ic in self.model.initials]
         species_codes = [f + c for f, c in zip(fixed, species_codes)]
         for cp in self._additional_initials:
-            if not any([cp.is_equivalent_to(i) for i, _ in
-                        self.model.initial_conditions]):
+            if not any([
+                cp.is_equivalent_to(ic.pattern) for ic in self.model.initials
+            ]):
                 species_codes.append(format_complexpattern(cp))
         max_length = max(len(code) for code in species_codes)
         self.__content += "begin species\n"
         for i, code in enumerate(species_codes):
-            if i < len(self.model.initial_conditions):
-                param = self.model.initial_conditions[i][1].name
+            if i < len(self.model.initials):
+                param = self.model.initials[i].value.name
             else:
                 param = '0'
             self.__content += ("  %-" + str(max_length) + "s   %s\n") % (code,

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -115,7 +115,7 @@ class KappaGenerator(object):
     def generate_species(self):
         if self._warn_no_ic and not self.model.initial_conditions:
             warnings.warn("Warning: No initial conditions.")
-        if any(self.model.initial_conditions_fixed):
+        if any(ic.fixed for ic in self.model.initials):
             raise KappaException(
                 "Kappa generator does not support fixed-amount species"
             )

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -113,18 +113,19 @@ class KappaGenerator(object):
         self.__content += "\n"
 
     def generate_species(self):
-        if self._warn_no_ic and not self.model.initial_conditions:
+        if self._warn_no_ic and not self.model.initials:
             warnings.warn("Warning: No initial conditions.")
         if any(ic.fixed for ic in self.model.initials):
             raise KappaException(
                 "Kappa generator does not support fixed-amount species"
             )
 
-        species_codes = [self.format_complexpattern(cp)
-                         for cp, param in self.model.initial_conditions]
+        species_codes = [
+            self.format_complexpattern(ic.pattern) for ic in self.model.initials
+        ]
         #max_length = max(len(code) for code in species_codes)
         for i, code in enumerate(species_codes):
-            param = self.model.initial_conditions[i][1]
+            param = self.model.initials[i].value
             #self.__content += ("%%init:  %-" + str(max_length) + \
             #                  "s   %s\n") % (code, param.name)
             if (self.dialect == 'kasim'):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -115,6 +115,10 @@ class KappaGenerator(object):
     def generate_species(self):
         if self._warn_no_ic and not self.model.initial_conditions:
             warnings.warn("Warning: No initial conditions.")
+        if any(self.model.initial_conditions_fixed):
+            raise KappaException(
+                "Kappa generator does not support fixed-amount species"
+            )
 
         species_codes = [self.format_complexpattern(cp)
                          for cp, param in self.model.initial_conditions]

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -186,11 +186,6 @@ class BnglBuilder(Builder):
 
     def _parse_initials(self):
         for i in self._x.iterfind(_ns('{0}ListOfSpecies/{0}Species')):
-            if i.get('Fixed') is not None and i.get('Fixed') == "1":
-                self._warn_or_except('Species %s is fixed, but will be '
-                                     'treated as an ordinary species in '
-                                     'PySB.' % i.get('name'))
-
             value_param = i.get('concentration')
             try:
                 value = float(value_param)
@@ -210,7 +205,9 @@ class BnglBuilder(Builder):
                         'concentration')]
             mon_pats = self._parse_species(i)
             species_cpt = self.model.compartments.get(i.get('compartment'))
-            self.initial(ComplexPattern(mon_pats, species_cpt), value_param)
+            cp = ComplexPattern(mon_pats, species_cpt)
+            fixed = i.get('Fixed') == "1"
+            self.initial(cp, value_param, fixed)
 
     def _parse_compartments(self):
         for c in self._x.iterfind(_ns('{0}ListOfCompartments/{0}compartment')):

--- a/pysb/integrate.py
+++ b/pysb/integrate.py
@@ -123,9 +123,8 @@ class Solver(object):
         y0 : vector-like, optional
             Values to use for the initial condition of all species. Ordering is
             determined by the order of model.species. If not specified, initial
-            conditions will be taken from model.initial_conditions (with
-            initial condition parameter values taken from `param_values` if
-            specified).
+            conditions will be taken from model.initials (with initial condition
+            parameter values taken from `param_values` if specified).
         """
         self._yobs_view = None
         self._yexpr_view = None
@@ -157,8 +156,8 @@ def odesolve(model, tspan, param_values=None, y0=None, integrator='vode',
     y0 : vector-like, optional
         Values to use for the initial condition of all species. Ordering is
         determined by the order of model.species. If not specified, initial
-        conditions will be taken from model.initial_conditions (with initial
-        condition parameter values taken from `param_values` if specified).
+        conditions will be taken from model.initials (with initial condition
+        parameter values taken from `param_values` if specified).
     integrator : string, optional
         Name of the integrator to use, taken from the list of integrators known
         to :py:class:`scipy.integrate.ode`.

--- a/pysb/jacobian.py
+++ b/pysb/jacobian.py
@@ -114,11 +114,10 @@ class JacobianGenerator(object):
         self.emit("INITIAL")
         self.indent()
         vars_unseen = set(['s%d' % i for i in range(len(self.model.species))])
-        for (pattern, param) in self.model.initial_conditions:
-            sname = 's%d' % self.model.get_species_index(pattern)
+        for ic in self.model.initials:
+            sname = 's%d' % self.model.get_species_index(ic.pattern)
             vars_unseen.remove(sname)
-            #self.emit("M.%s = M.%s;" % (sname, param.name))
-            self.emit("M.%s = %g;" % (sname, param.value))
+            self.emit("M.%s = %g;" % (sname, ic.value.value))
         for sname in sorted(vars_unseen):
             self.emit("M.%s = 0;" % sname)
         self.outdent()

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -54,9 +54,8 @@ class Simulator(object):
     initials : vector-like or dict, optional
         Values to use for the initial condition of all species. Ordering is
         determined by the order of model.species. If not specified, initial
-        conditions will be taken from model.initial_conditions (with
-        initial condition parameter values taken from `param_values` if
-        specified).
+        conditions will be taken from model.initials (with initial condition
+        parameter values taken from `param_values` if specified).
     param_values : vector-like or dict, optional
         Values to use for every parameter in the model. Ordering is
         determined by the order of model.parameters.
@@ -189,8 +188,8 @@ class Simulator(object):
 
     @property
     def initials_dict(self):
-        initials_dict = {cp: [param.value] for cp, param in
-                         self.model.initial_conditions}
+        initials_dict = {ic.pattern: [ic.value.value]
+                         for ic in self.model.initials}
         # Apply any base initial overrides
         initials_dict = self._update_initials_dict(initials_dict,
                                                    self._initials)
@@ -264,8 +263,8 @@ class Simulator(object):
                     for pv in self.param_values]
                 if len(subs) == 1 and n_sims_actual > 1:
                     subs = list(itertools.repeat(subs[0], n_sims_actual))
-            y0 = self._update_y0(y0, self._model.initial_conditions, subs,
-                                 n_sims_params)
+            ic_tuples = [(ic.pattern, ic.value) for ic in self._model.initials]
+            y0 = self._update_y0(y0, ic_tuples, subs, n_sims_params)
 
         # Any remaining unset initials should be set to zero
         y0 = np.nan_to_num(y0)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -58,9 +58,8 @@ class ScipyOdeSimulator(Simulator):
     initials : vector-like or dict, optional
         Values to use for the initial condition of all species. Ordering is
         determined by the order of model.species. If not specified, initial
-        conditions will be taken from model.initial_conditions (with
-        initial condition parameter values taken from `param_values` if
-        specified).
+        conditions will be taken from model.initials (with initial condition
+        parameter values taken from `param_values` if specified).
     param_values : vector-like or dict, optional
         Values to use for every parameter in the model. Ordering is
         determined by the order of model.parameters.

--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -37,9 +37,8 @@ class StochKitSimulator(Simulator):
     initials : vector-like or dict, optional
         Values to use for the initial condition of all species. Ordering is
         determined by the order of model.species. If not specified, initial
-        conditions will be taken from model.initial_conditions (with
-        initial condition parameter values taken from `param_values` if
-        specified).
+        conditions will be taken from model.initials (with initial condition
+        parameter values taken from `param_values` if specified).
     param_values : vector-like or dict, optional
         Values to use for every parameter in the model. Ordering is
         determined by the order of model.parameters.

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -67,8 +67,8 @@ def test_compartment_species_equivalence():
     Initial(Q(x=None) ** C, p)
     Initial(R(y=None) ** C, p)
     generate_equations(model)
-    for i, (cp, param) in enumerate(model.initial_conditions):
-        ok_(cp.is_equivalent_to(model.species[i]))
+    for i, ic in enumerate(model.initials):
+        ok_(ic.pattern.is_equivalent_to(model.species[i]))
     ok_(model.species[2].is_equivalent_to(Q(x=1) ** C % R(y=1) ** C))
 
 

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -207,6 +207,17 @@ def test_bng_error():
     )
 
 
+@with_model
+def test_fixed_species():
+    Monomer('A', ['a'])
+    Monomer('B', ['b'])
+    Initial(A(a=1) % B(b=1), Parameter('AB_0', 1), fixed=True)
+    Rule('rule1', A(a=1) % B(b=1) >> A(a=None) + B(b=None), Parameter('k', 1))
+    generate_equations(model)
+    num_non_zeros = model.stoichiometry_matrix[0].getnnz()
+    assert num_non_zeros == 0
+
+
 def _bng_print(expr):
     return BngPrinter(order='none').doprint(expr)
 

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -16,13 +16,26 @@ except ImportError:
 from nose.plugins.skip import SkipTest
 
 
+# Pairs of model, format that are expected to be incompatible.
+skip_combinations = {
+    ('fixed_initial', 'kappa'),
+}
+
+
 def test_export():
     for model in get_example_models():
         for format in export.formats:
+            if (base_name(model), format) in skip_combinations:
+                continue
             fn = lambda: check_convert(model, format)
             fn.description = "Check export: {} → {}".format(
                 model.name, format)
             yield fn
+
+
+def base_name(model):
+    # This needs to handle names with zero or more dots.
+    return model.name.split('.')[-1]
 
 
 def check_convert(model, format):
@@ -37,8 +50,7 @@ def check_convert(model, format):
     except Exception as e:
         # Some example models are deliberately incomplete, so here we
         # will treat any of these "expected" exceptions as a success.
-        model_base_name = model.name.rsplit('.', 1)[1]
-        exception_class = expected_exceptions.get(model_base_name)
+        exception_class = expected_exceptions.get(base_name(model))
         if not exception_class or not isinstance(e, exception_class):
             raise
 

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -77,15 +77,7 @@ def _sbml_location(filename):
 
 def test_bngl_import_expected_passes_with_force():
     for filename in ('Haugh2b',
-                     'continue',
-                     'gene_expr',
-                     'gene_expr_func',
                      'Motivating_example',
-                     'Motivating_example_cBNGL',
-                     'test_synthesis_cBNGL_simple',
-                     'test_synthesis_complex',
-                     'test_synthesis_complex_source_cBNGL',
-                     'test_synthesis_simple'
                      ):
         full_filename = _bngl_location(filename)
         with warnings.catch_warnings():
@@ -95,20 +87,29 @@ def test_bngl_import_expected_passes_with_force():
 
 def test_bngl_import_expected_passes():
     for filename in ('CaOscillate_Func',
+                     'continue',
                      'deleteMolecules',
                      'egfr_net',
                      'empty_compartments_block',
+                     'gene_expr',
+                     'gene_expr_func',
                      'gene_expr_simple',
                      'isomerization',
                      'michment',
+                     'Motivating_example_cBNGL',
                      'motor',
                      'simple_system',
                      'test_compartment_XML',
                      'test_setconc',
+                     'test_synthesis_cBNGL_simple',
+                     'test_synthesis_complex',
                      'test_synthesis_complex_0_cBNGL',
+                     'test_synthesis_complex_source_cBNGL',
+                     'test_synthesis_simple',
                      'toy-jim',
                      'univ_synth',
-                     'visualize'):
+                     'visualize',
+                     ):
         full_filename = _bngl_location(filename)
         yield (bngl_import_compare_simulations, full_filename)
 

--- a/pysb/tests/test_simulator_cupsoda.py
+++ b/pysb/tests/test_simulator_cupsoda.py
@@ -18,10 +18,10 @@ class TestCupSODASimulatorSingle(object):
                                                            'max_steps': 20000})
         len_model_species = len(model.species)
         y0 = np.zeros((self.n_sims, len_model_species))
-        for ic in model.initial_conditions:
+        for ic in model.initials:
             for j in range(len_model_species):
-                if str(ic[0]) == str(model.species[j]):
-                    y0[:, j] = ic[1].value
+                if str(ic.pattern) == str(model.species[j]):
+                    y0[:, j] = ic.value.value
                     break
         self.y0 = y0
 

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -75,9 +75,10 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
     def test_y0_as_list(self):
         """Test y0 with list of initial conditions"""
         # Test the initials getter method before anything is changed
-        assert np.allclose(self.sim.initials[0][0:2],
-                           [ic[1].value for ic in
-                            self.model.initial_conditions])
+        assert np.allclose(
+            self.sim.initials[0][0:2],
+            [ic.value.value for ic in self.model.initials]
+        )
 
         initials = [10, 20, 0]
         simres = self.sim.run(initials=initials)

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -84,7 +84,7 @@ def run(model):
     pysb.bng.generate_equations(model)
 
     graph = pygraphviz.AGraph(directed=True, rankdir="LR")
-    ic_species = [cp for cp, parameter in model.initial_conditions]
+    ic_species = [ic.pattern for ic in model.initials]
     for i, cp in enumerate(model.species):
         species_node = 's%d' % i
         slabel = re.sub(r'% ', r'%\\l', str(cp))

--- a/pysb/tools/sensitivity_analysis.py
+++ b/pysb/tools/sensitivity_analysis.py
@@ -147,7 +147,7 @@ class InitialsSensitivity(object):
     def _ic_params_of_interest(self):
         if self._ic_params_of_interest_cache is None:
             self._ic_params_of_interest_cache = list(
-                (i[1].name for i in self._model.initial_conditions))
+                (i.value.name for i in self._model.initials))
             self._ic_params_of_interest_cache = \
                 sorted(self._ic_params_of_interest_cache)
 
@@ -271,12 +271,12 @@ class InitialsSensitivity(object):
     def _create_index_of_species(self):
         """ create dictionary of initial conditions by index """
         index_of_init_condition = {}
-        for ic_sp, ic_param in self._model.initial_conditions:
+        for ic in self._model.initials:
             for sp_idx, sp in enumerate(self._model.species):
-                if ic_sp.is_equivalent_to(sp):
-                    self._original_initial_conditions[sp_idx] = ic_param.value
-                    if ic_param.name in self._ic_params_of_interest:
-                        index_of_init_condition[ic_param.name] = sp_idx
+                if ic.pattern.is_equivalent_to(sp):
+                    self._original_initial_conditions[sp_idx] = ic.value.value
+                    if ic.value.name in self._ic_params_of_interest:
+                        index_of_init_condition[ic.value.name] = sp_idx
         index_of_species_of_interest = collections.OrderedDict(
             sorted(index_of_init_condition.items()))
         return index_of_species_of_interest

--- a/pysb/tools/species_graph.py
+++ b/pysb/tools/species_graph.py
@@ -60,7 +60,7 @@ def run(model):
     pysb.bng.generate_equations(model)
 
     graph = pygraphviz.AGraph(directed=True, rankdir="LR")
-    ic_species = [cp for cp, parameter in model.initial_conditions]
+    ic_species = [ic.pattern for ic in model.initials]
     for i, cp in enumerate(model.species):
         species_node = 's%d' % i
         slabel = re.sub(r'% ', r'%\\l', str(cp))


### PR DESCRIPTION
This adds a `fixed` boolean kwarg to `Initial` for declaring that a species should not be consumed or produced by any reactions. This maps to a leading `$` on a species entry in BNG. If there's a Kappa equivalent I would be happy to add that too, but right now the KappaGenerator raises an exception.

The implementation adds a new list of booleans to `Model`, `initial_conditions_fixed`, rather than modify the current `initial_conditions` tuple structure. I'm not totally happy with this, though, and am open to alternatives. The effect of a fixed species is simply that its row in the stoichiometric matrix is set to zero.