### PR TITLE
LibSBML model exporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
     pydot coveralls mock cython
 - if [[ $PYVER == 2.7 ]]; then pip install weave; fi
 - conda install --yes -c SBMLTeam python-libsbml
+- pip install libroadrunner
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc
 # Install BioNetGen, Kappa, StochKit and Atomizer

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
     pydot coveralls mock cython
 - if [[ $PYVER == 2.7 ]]; then pip install weave; fi
+- conda install --yes -c SBMLTeam python-libsbml
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc
 # Install BioNetGen, Kappa, StochKit and Atomizer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,8 @@ install:
     networkx nose h5py pandas theano mkl pydot mock cython
   - if "%PYTHON_VERSION%"=="2.7" (conda install -c conda-forge weave)
 
+  - conda install -c SBMLTeam python-libsbml
+
   - conda install -c alubbock graphviz bionetgen atomizer kappa stochkit-lite
 
   # Build PySB

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1615,9 +1615,19 @@ class Model(object):
         # intersect with original parameter list to retain ordering
         return self.parameters & cset
 
+    def parameters_expressions(self):
+        cset = ComponentSet()
+        for expr in self.expressions:
+            for sym in expr.expand_expr().free_symbols:
+                if sym in self.parameters:
+                    cset.add(sym)
+        # intersect with original parameter list to retain ordering
+        return self.parameters & cset
+
     def parameters_unused(self):
         """Return a ComponentSet of unused parameters."""
-        cset_used = self.parameters_rules() | self.parameters_initial_conditions() | self.parameters_compartments()
+        cset_used = (self.parameters_rules() | self.parameters_initial_conditions() |
+                     self.parameters_compartments() | self.parameters_expressions())
         return self.parameters - cset_used
 
 #     def expressions_constant(self):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1616,6 +1616,7 @@ class Model(object):
         return self.parameters & cset
 
     def parameters_expressions(self):
+        """Return a ComponentSet of expression parameters."""
         cset = ComponentSet()
         for expr in self.expressions:
             for sym in expr.expand_expr().free_symbols:

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1616,7 +1616,7 @@ class Model(object):
         return self.parameters & cset
 
     def parameters_expressions(self):
-        """Return a ComponentSet of expression parameters."""
+        """Return a ComponentSet of the parameters used in expressions."""
         cset = ComponentSet()
         for expr in self.expressions:
             for sym in expr.expand_expr().free_symbols:

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -1,34 +1,18 @@
 """
-Module containing a class for exporting a PySB model to SBML.
+Module containing a class for exporting a PySB model to SBML using libSBML
 
 For information on how to use the model exporters, see the documentation
 for :py:mod:`pysb.export`.
 """
-
-# FIXME this should use libsbml if available
-
 import pysb
 import pysb.bng
-from pysb.export import Exporter, ExpressionsNotSupported, \
-    CompartmentsNotSupported
+from pysb.export import Exporter
 from sympy.printing.mathml import MathMLPrinter
-import itertools
-import textwrap
 try:
-    from cStringIO import StringIO
+    import libsbml
 except ImportError:
-    from io import StringIO
+    libsbml = None
 
-def indent(text, n=0):
-    """Re-indent a multi-line string, stripping leading newlines and trailing
-    spaces."""
-    text = text.lstrip('\n')
-    text = textwrap.dedent(text)
-    lines = text.split('\n')
-    lines = [' '*n + l for l in lines]
-    text = '\n'.join(lines)
-    text = text.rstrip(' ')
-    return text
 
 class MathMLContentPrinter(MathMLPrinter):
     """Prints an expression to MathML without presentation markup."""
@@ -37,51 +21,47 @@ class MathMLContentPrinter(MathMLPrinter):
         ci.appendChild(self.dom.createTextNode(sym.name))
         return ci
 
+
 def print_mathml(expr, **settings):
     return MathMLContentPrinter(settings).doprint(expr)
 
-def format_single_annotation(annotation):
-    return '''<rdf:li rdf:resource="%s" />''' % annotation.object
 
-def get_annotation_preamble(meta_id):
-    return indent('''
-      <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-              <rdf:Description rdf:about="#%s">
-      ''' % meta_id)
-
-def get_annotation_postamble():
-    return indent('''
-              </rdf:Description>
-          </rdf:RDF>
-      </annotation>
-      ''')
-
-def get_species_annotation(meta_id, cp):
-    output = get_annotation_preamble(meta_id)
-    model = cp.monomer_patterns[0].monomer.model()
-    if len(cp.monomer_patterns) == 1:
-        # single monomer
-        all_annotations = model.get_annotations(cp.monomer_patterns[0].monomer)
-        groups = itertools.groupby(all_annotations, lambda a: a.predicate)
-        for predicate, annotations in groups:
-            qualifier = 'bqbiol:%s' % predicate
-            output += indent('<%s>\n    <rdf:Bag>\n' % qualifier, 12)
-            for a in annotations:
-                output += indent(format_single_annotation(a) + '\n', 20)
-            output += indent('    </rdf:Bag>\n</%s>\n' % qualifier, 12)
+def _check(value):
+    """If 'value' is None, prints an error message constructed using
+    'message' and then exits with status code 1.  If 'value' is an integer,
+    it assumes it is a libSBML return status code.  If the code value is
+    LIBSBML_OPERATION_SUCCESS, returns without further action; if it is not,
+    prints an error message constructed using 'message' along with text from
+    libSBML explaining the meaning of the code, and exits with status code 1.
+    """
+    if value is None:
+        raise ValueError('LibSBML returned a null value')
+    elif type(value) is int:
+        if value == libsbml.LIBSBML_OPERATION_SUCCESS:
+            return
+        else:
+            err_msg = 'Error encountered converting to SBML. ' \
+                      + 'LibSBML returned error code ' + str(value) + ': "' \
+                      + libsbml.OperationReturnValue_toString(value).strip() + '"'
+            raise ValueError(err_msg)
     else:
-        # complex
-        monomers = set(mp.monomer for mp in cp.monomer_patterns)
-        annotations = [a for m in monomers for a in model.get_annotations(m)
-                       if a.predicate in ('is', 'hasPart')]
-        qualifier = 'bqbiol:hasPart'
-        output += indent('<%s>\n    <rdf:Bag>\n' % qualifier, 12)
-        for a in annotations:
-            output += indent(format_single_annotation(a) + '\n', 20)
-        output += indent('    </rdf:Bag>\n</%s>\n' % qualifier, 12)
-    output += get_annotation_postamble()
-    return indent(output, 16)
+        return
+
+
+def _mathml_expr_call(expr, as_ast=False):
+    mathstr = '<apply><ci>{}</ci>'.format(expr.name)
+    for sym in expr.expand_expr(expand_observables=True).free_symbols:
+        if isinstance(sym, pysb.Expression):
+            continue
+        mathstr += '<ci>{}</ci>'.format(sym.name if isinstance(sym, pysb.Parameter) else sym)
+    mathstr += '</apply>'
+    if not as_ast:
+        return mathstr
+    mathstr = "<?xml version='1.0' encoding='UTF-8'?>" \
+          "<math xmlns='http://www.w3.org/1998/Math/MathML'>{}</math>".format(mathstr)
+    rate_mathml = libsbml.readMathMLFromString(mathstr)
+    _check(rate_mathml)
+    return rate_mathml
 
 
 class SbmlExporter(Exporter):
@@ -90,28 +70,65 @@ class SbmlExporter(Exporter):
     Inherits from :py:class:`pysb.export.Exporter`, which implements
     basic functionality for all exporters.
     """
+    def __init__(self, *args, **kwargs):
+        super(SbmlExporter, self).__init__(*args, **kwargs)
+        if not libsbml:
+            raise ImportError('The SbmlExporter requires the libsbml python package')
 
-    def export(self):
-        """Export the SBML for the PySB model associated with the exporter.
+    def _sympy_to_sbmlast(self, sympy_expr, wrap_lambda=False):
+        """
+        Convert a sympy expression to the AST format used by libsbml
+
+        wrap_lambda indicates whether the expression should be converted into a mathml lambda function
+        """
+        mathml = print_mathml(sympy_expr)
+
+        if wrap_lambda:
+            # For function definitions
+            args = ''
+            for sym in sympy_expr.free_symbols:
+                if isinstance(sym, pysb.Expression):
+                    continue
+                args += '<bvar><ci> {} </ci></bvar>'.format(sym.name if isinstance(sym, pysb.Parameter) else sym)
+            mathml = '<lambda>{}{}</lambda>'.format(args, mathml)
+        else:
+            # For rates expressions with <apply> wrapper, but not within the function definitions block
+            for expr in self.model.expressions:
+                mathml = mathml.replace('<ci>{}</ci>'.format(expr.name), _mathml_expr_call(expr))
+
+        mathml = "<?xml version='1.0' encoding='UTF-8'?>" \
+                 "<math xmlns='http://www.w3.org/1998/Math/MathML'>{}</math>".format(
+            mathml,
+        )
+        rate_mathml = libsbml.readMathMLFromString(mathml)
+        _check(rate_mathml)
+        return rate_mathml
+
+    def convert(self, level=(3, 2)):
+        """
+        Convert the PySB model to a libSBML document
+
+        Requires the libsbml python package
+
+        Parameters
+        ----------
+        level: (int, int)
+            The SBML level and version to use. The default is SBML level 3, version 2. Conversion
+            to other levels/versions may not be possible or may lose fidelity.
 
         Returns
         -------
-        string
-            String containing the SBML output.
+        libsbml.SBMLDocument
+            A libSBML document converted form the PySB model
         """
-        if self.model.expressions:
-            raise ExpressionsNotSupported()
-        if self.model.compartments:
-            raise CompartmentsNotSupported()
+        doc = libsbml.SBMLDocument(3, 2)
+        smodel = doc.createModel()
+        _check(smodel)
+        _check(smodel.setName(self.model.name))
 
-        output = StringIO()
         pysb.bng.generate_equations(self.model)
 
-        output.write(
-            """<?xml version="1.0" encoding="UTF-8"?>
-    <sbml xmlns="http://www.sbml.org/sbml/level2" level="2" version="1">
-        <model name="%s">""" % self.model.name)
-
+        # Docstring
         if self.docstring:
             notes_str = """
             <notes>
@@ -119,55 +136,145 @@ class SbmlExporter(Exporter):
                     <p>%s</p>
                 </body>
             </notes>""" % self.docstring.replace("\n", "<br />\n"+" "*20)
-            output.write(notes_str)
+            _check(smodel.setNotes(notes_str))
 
-        output.write("""
-            <listOfCompartments>
-                <compartment id="default" name="default" spatialDimensions="3" size="1"/>
-            </listOfCompartments>
-    """)
+        # Compartments
+        if self.model.compartments:
+            for cpt in self.model.compartments:
+                c = smodel.createCompartment()
+                _check(c)
+                _check(c.setId(cpt.name))
+                _check(c.setSpatialDimensions(cpt.dimension))
+                _check(c.setSize(cpt.size.value))
+                _check(c.setConstant(True))
+        else:
+            c = smodel.createCompartment()
+            _check(c)
+            _check(c.setId('default'))
+            _check(c.setSpatialDimensions(3))
+            _check(c.setSize(1))
+            _check(c.setConstant(True))
 
-        # complexpattern, initial value
-        ics = [[s, 0] for s in self.model.species]
-        for cp, ic_param in self.model.initial_conditions:
-            ics[self.model.get_species_index(cp)][1] = ic_param.value
-        output.write("        <listOfSpecies>\n")
-        for i, (cp, value) in enumerate(ics):
-            id = '__s%d' % i
-            metaid = 'metaid_%d' % i
-            name = str(cp).replace('% ', '._br_')  # CellDesigner does something weird with % in names
-            output.write('            <species id="%s" metaid="%s" name="%s" compartment="default" initialAmount="%.17g">\n'
-                         % (id, metaid, name, value));
-            output.write(get_species_annotation(metaid, cp))
-            output.write('            </species>\n')
-        output.write("        </listOfSpecies>\n")
+        # Expressions
+        for expr in self.model.expressions:
+            f = smodel.createFunctionDefinition()
+            _check(f)
+            _check(f.setId(expr.name))
+            _check(f.setMath(self._sympy_to_sbmlast(expr.expand_expr(expand_observables=True), wrap_lambda=True)))
 
-        output.write("        <listOfParameters>\n")
-        for i, param in enumerate(self.model.parameters_rules()):
-            output.write('            <parameter id="%s" metaid="metaid_%s" name="%s" value="%.17g"/>\n'
-                         % (param.name, param.name, param.name, param.value));
-        output.write("        </listOfParameters>\n")
+        # Initial values/assignments
+        initial_concs = [0.0] * len(self.model.species)
+        for cp, param in self.model.initial_conditions:
+            sp_idx = self.model.get_species_index(cp)
+            if isinstance(param, pysb.Expression):
+                ia = smodel.createInitialAssignment()
+                _check(ia)
+                _check(ia.setSymbol('__s{}'.format(sp_idx)))
+                _check(ia.setMath(_mathml_expr_call(param, as_ast=True)))
+                initial_concs[sp_idx] = None
+            else:
+                initial_concs[sp_idx] = param.value
 
-        output.write("        <listOfReactions>\n")
+        # Species
+        for i, s in enumerate(self.model.species):
+            sp = smodel.createSpecies()
+            _check(sp)
+            _check(sp.setId('__s{}'.format(i)))
+            if self.model.compartments:
+                # Try to determine compartment, which must be unique for the species
+                mon_cpt = set(mp.compartment for mp in s.monomer_patterns if mp.compartment is not None)
+                if len(mon_cpt) == 0 and s.compartment:
+                    compartment_name = s.compartment_name
+                elif len(mon_cpt) == 1:
+                    mon_cpt = mon_cpt.pop()
+                    if s.compartment is not None and mon_cpt != s.compartment:
+                        raise ValueError('Species {} has different monomer and species compartments, '
+                                         'which is not supported in SBML'.format(s))
+                    compartment_name = mon_cpt.name
+                else:
+                    raise ValueError('Species {} has more than one different monomer compartment, '
+                                     'which is not supported in SBML'.format(s))
+            else:
+                compartment_name = 'default'
+            _check(sp.setCompartment(compartment_name))
+            _check(sp.setName(str(s).replace('% ', '._br_')))
+            _check(sp.setBoundaryCondition(False))
+            _check(sp.setConstant(False))
+            _check(sp.setHasOnlySubstanceUnits(True))
+            if initial_concs[i] is not None:
+                _check(sp.setInitialAmount(initial_concs[i]))
+
+        # Parameters
+        for i, param in enumerate(self.model.parameters):
+            if param in self.model.parameters_initial_conditions():
+                continue
+            p = smodel.createParameter()
+            _check(p)
+            _check(p.setId(param.name))
+            _check(p.setName(param.name))
+            _check(p.setValue(param.value))
+            _check(p.setConstant(True))
+
+        # Reactions
         for i, reaction in enumerate(self.model.reactions_bidirectional):
-            reversible = str(reaction['reversible']).lower()
-            output.write('            <reaction id="r%d" metaid="metaid_r%d" name="r%d" reversible="%s">\n'
-                         % (i, i, i, reversible));
-            output.write('                <listOfReactants>\n');
-            for species in reaction['reactants']:
-                output.write('                    <speciesReference species="__s%d"/>\n' % species)
-            output.write('                </listOfReactants>\n');
-            output.write('                <listOfProducts>\n');
-            for species in reaction['products']:
-                output.write('                    <speciesReference species="__s%d"/>\n' % species)
-            output.write('                </listOfProducts>\n');
-            mathml = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
-                + print_mathml(reaction['rate']) + '</math>'
-            output.write('                <kineticLaw>' + mathml + '</kineticLaw>\n');
-            output.write('            </reaction>\n');
-        output.write("        </listOfReactions>\n")
+            rxn = smodel.createReaction()
+            _check(rxn)
+            _check(rxn.setId('r{}'.format(i)))
+            _check(rxn.setName('r{}'.format(i)))
+            _check(rxn.setReversible(reaction['reversible']))
 
-        output.write("    </model>\n</sbml>\n")
-        return output.getvalue()
+            for sp in reaction['reactants']:
+                reac = rxn.createReactant()
+                _check(reac)
+                _check(reac.setSpecies('__s{}'.format(sp)))
+                _check(reac.setConstant(True))
 
+            for sp in reaction['products']:
+                prd = rxn.createProduct()
+                _check(prd)
+                _check(prd.setSpecies('__s{}'.format(sp)))
+                _check(prd.setConstant(True))
 
+            for symbol in reaction['rate'].free_symbols:
+                if isinstance(symbol, pysb.Expression):
+                    expr = symbol.expand_expr(expand_observables=True)
+                    for sym in expr.free_symbols:
+                        if not isinstance(sym, (pysb.Parameter, pysb.Expression)):
+                            # Species reference, needs to be specified as modifier
+                            modifier = rxn.createModifier()
+                            _check(modifier)
+                            _check(modifier.setSpecies(str(sym)))
+
+            rate = rxn.createKineticLaw()
+            _check(rate)
+            rate_mathml = self._sympy_to_sbmlast(reaction['rate'])
+            _check(rate.setMath(rate_mathml))
+
+        # Apply any requested level/version conversion
+        if level != (3, 2):
+            prop = libsbml.ConversionProperties(libsbml.SBMLNamespaces(*level))
+            prop.addOption('strict', False)
+            prop.addOption('setLevelAndVersion', True)
+            prop.addOption('ignorePackages', True)
+            _check(doc.convert(prop))
+
+        return doc
+
+    def export(self, level=(3, 2)):
+        """
+        Export the SBML for the PySB model associated with the exporter
+
+        Requires libsbml package.
+
+        Parameters
+        ----------
+        level: (int, int)
+            The SBML level and version to use. The default is SBML level 3, version 2. Conversion
+            to other levels/versions may not be possible or may lose fidelity.
+
+        Returns
+        -------
+        string
+            String containing the SBML output.
+        """
+        return libsbml.writeSBMLToString(self.convert(level=level))

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -13,6 +13,7 @@ try:
     import roadrunner
 except ImportError:
     roadrunner = None
+from nose.plugins.skip import SkipTest
 
 
 def test_export():
@@ -50,7 +51,7 @@ def check_convert(model, format):
         elif format == 'sbml':
             # Skip the simulation comparison if roadrunner not available
             if roadrunner is None:
-                return
+                raise SkipTest("SBML Simulation test skipped (requires roadrunner)")
 
             roadrunner.Logger.setLevel(roadrunner.Logger.LOG_ERROR)
             # Simulate SBML using roadrunner

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def main():
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
                          'pandas', 'theano', 'h5py', 'mock', 'cython',
-                         'libsbml'],
+                         'libsbml', 'roadrunner'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],
           classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ def main():
           install_requires=['numpy', 'scipy', 'sympy', 'networkx'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas', 'theano', 'h5py', 'mock', 'cython'],
+                         'pandas', 'theano', 'h5py', 'mock', 'cython',
+                         'libsbml'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],
           classifiers=[


### PR DESCRIPTION
This replaces the original SBML exporter with a libsbml-based one.
New features include compartment and expression support, and
conversion between SBML levels/versions (L3V2 by default).

Fixes: #269 