### PR TITLE
Additonal function support when exporting to BNG

### DIFF
--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -288,6 +288,12 @@ class BngPrinter(StrPrinter):
     def _print_Exp1(self, expr):
         return '_e'
 
+    def _print_floor(self, expr):
+        return 'rint({} - 0.5)'.format(self._print(expr.args[0]))
+
+    def _print_ceiling(self, expr):
+        return '(rint({} + 1) - 1)'.format(self._print(expr.args[0]))
+
     def __make_lower(self, expr):
         """ Print a function with its name in lower case """
         return '{}({})'.format(

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -272,6 +272,12 @@ class BngPrinter(StrPrinter):
         return super(BngPrinter, self)._print_Pow(expr, rational)\
             .replace('**', '^')
 
+    def _print_And(self, expr):
+        return super(BngPrinter, self)._print_And(expr).replace('&', '&&')
+
+    def _print_Or(self, expr):
+        return super(BngPrinter, self)._print_Or(expr).replace('|', '||')
+
     def _print_log(self, expr):
         # BNG doesn't accept "log", only "ln".
         return 'ln' + "(%s)" % self.stringify(expr.args, ", ")

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -282,6 +282,24 @@ class BngPrinter(StrPrinter):
         # BNG doesn't accept "log", only "ln".
         return 'ln' + "(%s)" % self.stringify(expr.args, ", ")
 
+    def _print_Pi(self, expr):
+        return '_pi'
+
+    def _print_Exp1(self, expr):
+        return '_e'
+
+    def __make_lower(self, expr):
+        """ Print a function with its name in lower case """
+        return '{}({})'.format(
+            self._print(expr.func).lower(),
+            self._print(expr.args[0] if len(expr.args) == 1 else
+                        ', '.join([self._print(a) for a in expr.args]))
+        )
+
+    _print_Abs = __make_lower
+    _print_Min = __make_lower
+    _print_Max = __make_lower
+
 
 def expression_to_muparser(expression):
     """Render the Expression as a muparser-compatible string."""

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -206,7 +206,41 @@ def test_bng_error():
     )
 
 
+def _bng_print(expr):
+    return BngPrinter(order='none').doprint(expr)
+
+
 def test_bng_printer():
-    sympy.symbols('x y')
-    assert BngPrinter(order='none').doprint(sympy.sympify('x & y')) == 'x && y'
-    assert BngPrinter(order='none').doprint(sympy.sympify('x | y')) == 'x || y'
+    # Constants
+    assert _bng_print(sympy.pi) == '_pi'
+    assert _bng_print(sympy.E) == '_e'
+
+    x, y = sympy.symbols('x y')
+
+    # Binary functions
+    assert _bng_print(sympy.sympify('x & y')) == 'x && y'
+    assert _bng_print(sympy.sympify('x | y')) == 'x || y'
+
+    # Trig functions
+    assert _bng_print(sympy.sin(x)) == 'sin(x)'
+    assert _bng_print(sympy.cos(x)) == 'cos(x)'
+    assert _bng_print(sympy.tan(x)) == 'tan(x)'
+    assert _bng_print(sympy.asin(x)) == 'asin(x)'
+    assert _bng_print(sympy.acos(x)) == 'acos(x)'
+    assert _bng_print(sympy.atan(x)) == 'atan(x)'
+    assert _bng_print(sympy.sinh(x)) == 'sinh(x)'
+    assert _bng_print(sympy.cosh(x)) == 'cosh(x)'
+    assert _bng_print(sympy.tanh(x)) == 'tanh(x)'
+    assert _bng_print(sympy.asinh(x)) == 'asinh(x)'
+    assert _bng_print(sympy.acosh(x)) == 'acosh(x)'
+    assert _bng_print(sympy.atanh(x)) == 'atanh(x)'
+
+    # Logs and powers
+    assert _bng_print(sympy.log(x)) == 'ln(x)'
+    assert _bng_print(sympy.exp(x)) == 'exp(x)'
+    assert _bng_print(sympy.sqrt(x)) == 'sqrt(x)'
+
+    # Others
+    assert _bng_print(sympy.Abs(x)) == 'abs(x)'
+    assert _bng_print(sympy.Min(x, y)) == 'min(x, y)'
+    assert _bng_print(sympy.Max(x, y)) == 'max(x, y)'

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -4,6 +4,8 @@ from pysb.bng import *
 import os
 import unittest
 from nose.tools import assert_raises_regexp
+from pysb.generator.bng import BngPrinter
+import sympy
 
 
 @with_model
@@ -202,3 +204,9 @@ def test_bng_error():
         generate_equations,
         model
     )
+
+
+def test_bng_printer():
+    sympy.symbols('x y')
+    assert BngPrinter(order='none').doprint(sympy.sympify('x & y')) == 'x && y'
+    assert BngPrinter(order='none').doprint(sympy.sympify('x | y')) == 'x || y'


### PR DESCRIPTION
Support for exporting `e` and `pi` constants, and `&`, `|`, `Abs`, `Min`, `Max`, `Ceiling`, `Floor` functions to BioNetGen.