### PR TITLE
Default module name when __name__ not set

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -179,10 +179,7 @@ class Component(object):
         # We assume we're dealing with Component subclasses here
         frame = inspect.currentframe().f_back
         while frame is not None:
-            try:
-                mod_name = frame.f_globals['__name__']
-            except KeyError:
-                mod_name = '__unnamed__'
+            mod_name = frame.f_globals.get('__name__', '__unnamed__')
             if mod_name in ['IPython.core.interactiveshell', '__main__']:
                 break
             if mod_name not in ['pysb.core', 'pysb.macros'] and not \

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -179,7 +179,10 @@ class Component(object):
         # We assume we're dealing with Component subclasses here
         frame = inspect.currentframe().f_back
         while frame is not None:
-            mod_name = frame.f_globals['__name__']
+            try:
+                mod_name = frame.f_globals['__name__']
+            except KeyError:
+                mod_name = '__unnamed__'
             if mod_name in ['IPython.core.interactiveshell', '__main__']:
                 break
             if mod_name not in ['pysb.core', 'pysb.macros'] and not \


### PR DESCRIPTION
The module/function name is captured by PySB when Components
are defined, but in some interpreters the `__name__` attribute
is not set for interactive sessions. To avoid an error, this
introduces a default value of `__unnamed__`.