### PR TITLE
Fix StochKit export on Python 3 with lxml installed

### DIFF
--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -304,7 +304,7 @@ class StochKitExporter(Exporter):
         document.append(reacs)
 
         if pretty_print:
-            return etree.tostring(document, pretty_print=True)
+            return etree.tostring(document, pretty_print=True).decode('utf8')
         else:
             # Hack to print pretty xml without pretty-print
             # (requires the lxml module).


### PR DESCRIPTION
This previously failed because `lxml` outputs `bytes`, which
needs conversion into a UTF-8 `str` on Python 3.

Thanks to @ortega2247 for the report.