### PR TITLE
Fix Simulator initials_dict when set by array

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -161,8 +161,7 @@ class Simulator(object):
             else:
                 return 1
 
-    @staticmethod
-    def _update_initials_dict(initials_dict, initials_source):
+    def _update_initials_dict(self, initials_dict, initials_source):
         if isinstance(initials_source, collections.Mapping):
             # Can't just use .update() as we need to test
             # equality with .is_equivalent_to()
@@ -176,7 +175,14 @@ class Simulator(object):
                 if not found:
                     initials_dict[cp] = val
         elif initials_source is not None:
-            for cp_idx, cp in enumerate(initials_dict.keys()):
+            # Update from array-like structure, which we can only do if we
+            # have the species available (e.g. not in network-free simulations)
+            if not self.model.species:
+                raise ValueError(
+                    'Cannot update initials from an array-like source without '
+                    'model species. ')
+            initials_dict = {}
+            for cp_idx, cp in enumerate(self.model.species):
                 initials_dict[cp] = [initials_source[n][cp_idx] for n in
                                      range(len(initials_source))]
         return initials_dict

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -197,6 +197,24 @@ class TestScipySimulatorSequential(TestScipySimulatorBase):
         # Check that the single-run initials were removed after the run
         assert np.allclose(self.sim.initials, orig_initials)
 
+    def test_sequential_initials_dict_then_list(self):
+        A, B = self.model.monomers
+
+        base_sim = ScipyOdeSimulator(
+            self.model,
+            initials={A(a=None): 10, B(b=None): 20})
+
+        assert np.allclose(base_sim.initials, [10, 20, 0])
+        assert len(base_sim.initials_dict) == 2
+
+        # Now set initials using a list, which should overwrite the dict
+        base_sim.initials = [30, 40, 50]
+
+        assert np.allclose(base_sim.initials, [30, 40, 50])
+        assert np.allclose(
+            sorted([x[0] for x in base_sim.initials_dict.values()]),
+            base_sim.initials)
+
     def test_sequential_param_values(self):
         orig_param_values = self.sim.param_values
         new_param_values = {'kbindAB': 0}


### PR DESCRIPTION
The `Simulator` class method `initials_dict` returns initial conditions
as a dictionary, mostly for use by network-free simulators like NFsim.
When initial conditions are set by an array or a list, species which
were not explicitly set using `Initial()` in the model are ignored.

This only affects users of the `BngSimulator`, which uses this
method, or anyone who called this method directly after setting
initials with an array or list.

This PR fixes the issue by returning a dictionary with values from the
array. This requires a species list for the model, so a `ValueError`
is raised where this is not available/`generate_equations` hasn't been
called yet.

Fixes: #376