### PR TITLE
Fix BNGSimulator when tspan doesn't start at 0

### DIFF
--- a/pysb/tests/test_simulator_bng.py
+++ b/pysb/tests/test_simulator_bng.py
@@ -62,6 +62,16 @@ class TestBngSimulator(object):
     def test_bng_pla(self):
         self.sim.run(n_runs=5, method='pla', seed=_BNG_SEED)
 
+    def test_tout_matches_tspan(self):
+        # Linearly spaced, starting from 0
+        assert all(self.sim.run(tspan=[0, 10, 20]).tout[0] == [0, 10, 20])
+        # Non-linearly spaced, starting from 0
+        assert all(self.sim.run(tspan=[0, 10, 30]).tout[0] == [0, 10, 30])
+        # Linearly spaced, starting higher than 0
+        assert all(self.sim.run(tspan=[10, 20, 30]).tout[0] == [10, 20, 30])
+        # Linearly spaced, starting higher than 0
+        assert all(self.sim.run(tspan=[5, 20, 30]).tout[0] == [5, 20, 30])
+
     def tearDown(self):
         self.model = None
         self.time = None


### PR DESCRIPTION
BNG simulations require the t_start argument, even when supplying 
sample_times. This was causing t=0 to get added to the simulation 
even when using tspan starting after 0. Trajectories would also be 
wrong in this case, since initials would be assumed to start at t=0 
rather than the start value of tspan.

Fixes: #378