### PR TITLE
Tab completion of components in IPython, Notebook

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1969,6 +1969,9 @@ class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
     def __setstate__(self, state):
         self.__dict__ = state
 
+    def __dir__(self):
+        return self.keys()
+
     def get(self, key, default=None):
         if isinstance(key, (int, long)):
             raise ValueError("get is undefined for integer arguments, use []"


### PR DESCRIPTION
Implement `ComponentSet.__dir__()`, which enables tab completion of
component names at an IPython prompt and in Jupyter Notebook.