### PR TITLE
Validate init kwargs to ScipyOdeSimulator

### DIFF
--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -147,11 +147,16 @@ class ScipyOdeSimulator(Simulator):
                                                 verbose=verbose,
                                                 **kwargs)
         # We'll need to know if we're using the Jacobian when we get to run()
-        self._use_analytic_jacobian = kwargs.get('use_analytic_jacobian',
+        self._use_analytic_jacobian = kwargs.pop('use_analytic_jacobian',
                                                  False)
-        self.cleanup = kwargs.get('cleanup', True)
-        integrator = kwargs.get('integrator', 'vode')
-        compiler_mode = kwargs.get('compiler', None)
+        self.cleanup = kwargs.pop('cleanup', True)
+        integrator = kwargs.pop('integrator', 'vode')
+        compiler_mode = kwargs.pop('compiler', None)
+        integrator_options = kwargs.pop('integrator_options', {})
+        if kwargs:
+            raise ValueError('Unknown keyword argument(s): {}'.format(
+                ', '.join(kwargs.keys())
+            ))
         # Generate the equations for the model
         pysb.bng.generate_equations(self._model, self.cleanup, self.verbose)
 
@@ -339,7 +344,7 @@ class ScipyOdeSimulator(Simulator):
             options.update(
                 self.default_integrator_options[integrator])  # default options
 
-        options.update(kwargs.get('integrator_options', {}))  # overwrite
+        options.update(integrator_options)  # overwrite
         # defaults
         self.opts = options
 

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -55,6 +55,10 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
         simres = self.sim.run()
         assert simres._nsims == 1
 
+    @raises(ValueError)
+    def test_invalid_init_kwarg(self):
+        ScipyOdeSimulator(self.model, tspan=self.time, spam='eggs')
+
     def test_lsoda_solver_run(self):
         """Test lsoda."""
         solver_lsoda = ScipyOdeSimulator(self.model, tspan=self.time,


### PR DESCRIPTION
Previously, unrecognised kwargs would be silently ignored. Now a
ValueError is raised if they are not recognised.