### PR TITLE
Validate init kwargs to StochkitSimulator

### DIFF
--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -97,7 +97,11 @@ class StochKitSimulator(Simulator):
                                                 param_values=param_values,
                                                 verbose=verbose,
                                                 **kwargs)
-        self.cleanup = kwargs.get('cleanup', True)
+        self.cleanup = kwargs.pop('cleanup', True)
+        if kwargs:
+            raise ValueError('Unknown keyword argument(s): {}'.format(
+                ', '.join(kwargs.keys())
+            ))
         self._outdir = None
         generate_equations(self._model,
                            cleanup=self.cleanup,

--- a/pysb/tests/test_simulator_stochkit.py
+++ b/pysb/tests/test_simulator_stochkit.py
@@ -3,12 +3,18 @@ from pysb.simulator import StochKitSimulator
 from pysb.examples import robertson, earm_1_0, expression_observables
 import numpy as np
 from pysb.core import as_complex_pattern
+from nose.tools import raises
 
 _STOCHKIT_SEED = 123
 
 
 def test_stochkit_export():
     StochKitExporter(robertson.model).export()
+
+
+@raises(ValueError)
+def test_stochkit_invalid_init_kwarg():
+    StochKitSimulator(earm_1_0.model, tspan=range(100), spam='eggs')
 
 
 def test_stochkit_earm():


### PR DESCRIPTION
Previously, unrecognised kwargs would be silently ignored. Now a
ValueError is raised if they are not recognised.