### PR TITLE
Validate cupsoda init kwargs and integrator opts

### DIFF
--- a/pysb/simulator/cupsoda.py
+++ b/pysb/simulator/cupsoda.py
@@ -146,18 +146,38 @@ class CupSodaSimulator(Simulator):
             'n_blocks': None,  # number of GPU blocks
             'memory_usage': 'sharedconstant'}}  # see _memory_options dict
 
+    _integrator_options_allowed = {'max_steps', 'atol', 'rtol', 'n_blocks',
+                                   'memory_usage', 'vol'}
+
     def __init__(self, model, tspan=None, initials=None, param_values=None,
                  verbose=False, **kwargs):
         super(CupSodaSimulator, self).__init__(model, tspan=tspan,
                                                initials=initials,
                                                param_values=param_values,
                                                verbose=verbose, **kwargs)
-        self.gpu = kwargs.get('gpu', 0)
-        self._obs_species_only = kwargs.get('obs_species_only', True)
-        self._cleanup = kwargs.get('cleanup', True)
-        self._prefix = kwargs.get('prefix', self._model.name.replace('.', '_'))
-        self._base_dir = kwargs.get('base_dir', None)
-        self.integrator = kwargs.get('integrator', 'cupsoda')
+        self.gpu = kwargs.pop('gpu', 0)
+        self._obs_species_only = kwargs.pop('obs_species_only', True)
+        self._cleanup = kwargs.pop('cleanup', True)
+        self._prefix = kwargs.pop('prefix', self._model.name.replace('.', '_'))
+        self._base_dir = kwargs.pop('base_dir', None)
+        self.integrator = kwargs.pop('integrator', 'cupsoda')
+        integrator_options = kwargs.pop('integrator_options', {})
+
+        if kwargs:
+            raise ValueError('Unknown keyword argument(s): {}'.format(
+                ', '.join(kwargs.keys())
+            ))
+
+        unknown_integrator_options = set(integrator_options.keys()).difference(
+            self._integrator_options_allowed
+        )
+        if unknown_integrator_options:
+            raise ValueError(
+                'Unknown integrator_options: {}. Allowed options: {}'.format(
+                    ', '.join(unknown_integrator_options),
+                    ', '.join(self._integrator_options_allowed)
+                )
+            )
 
         # generate the equations for the model
         pysb.bng.generate_equations(self._model, self._cleanup, self.verbose)
@@ -171,7 +191,7 @@ class CupSodaSimulator(Simulator):
         else:
             raise SimulatorException(
                 "Integrator type '" + self.integrator + "' not recognized.")
-        options.update(kwargs.get('integrator_options', {}))  # overwrite
+        options.update(integrator_options)  # overwrite
 
         # defaults
         self.opts = options

--- a/pysb/tests/test_simulator_cupsoda.py
+++ b/pysb/tests/test_simulator_cupsoda.py
@@ -80,9 +80,9 @@ class TestCupSODASimulatorSingle(object):
 
     def test_verbose(self):
         solver = CupSodaSimulator(model, tspan=self.tspan, verbose=True,
-                                  vol=1e-5,
                                   integrator_options={'atol': 1e-12,
                                                       'rtol': 1e-12,
+                                                      'vol': 1e-5,
                                                       'max_steps': 20000})
         solver.run()
 

--- a/pysb/tests/test_simulator_cupsoda.py
+++ b/pysb/tests/test_simulator_cupsoda.py
@@ -88,3 +88,12 @@ class TestCupSODASimulatorSingle(object):
 
     def test_run_cupsoda_instance(self):
         run_cupsoda(model, tspan=self.tspan)
+
+    @raises(ValueError)
+    def test_invalid_init_kwarg(self):
+        CupSodaSimulator(model, tspan=self.tspan, spam='eggs')
+
+    @raises(ValueError)
+    def test_invalid_integrator_option(self):
+        CupSodaSimulator(model, tspan=self.tspan,
+                         integrator_options={'spam': 'eggs'})


### PR DESCRIPTION
Previously, unrecognised kwargs and integrator options were
silently ignored. Now a ValueError is raised if they are not
recognised.