### PR TITLE
BngSimulator: respect cleanup flag in `__init__`

### DIFF
--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -25,7 +25,7 @@ class BngSimulator(Simulator):
 
     def run(self, tspan=None, initials=None, param_values=None, n_runs=1,
             method='ssa', output_dir=None, output_file_basename=None,
-            cleanup=True, population_maps=None, **additional_args):
+            cleanup=None, population_maps=None, **additional_args):
         """
         Simulate a model using BioNetGen
 
@@ -67,8 +67,9 @@ class BngSimulator(Simulator):
             output directory, rather than the individual files.
         cleanup : bool, optional
             If True (default), delete the temporary files after the
-            simulation is
-            finished. If False, leave them in place. Useful for debugging.
+            simulation is finished. If False, leave them in place (Useful for
+            debugging). The default value, None, means to use the value
+            specified in :py:func:`__init__`.
         population_maps: list of PopulationMap
             List of :py:class:`PopulationMap` objects for hybrid
             particle/population modeling. Only used when method='nf'.
@@ -152,7 +153,8 @@ class BngSimulator(Simulator):
                               verbose=verbose_bool,
                               output_dir=output_dir,
                               output_prefix=output_file_basename,
-                              cleanup=cleanup,
+                              cleanup=self.cleanup if cleanup is None
+                              else cleanup,
                               model_additional_species=model_additional_species
                               ) as bngfile:
             if hpp_bngl:

--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -96,7 +96,7 @@ class BngSimulator(Simulator):
                                       )
 
         if cleanup is None:
-            clean = self.cleanup
+            cleanup = self.cleanup
 
         if method not in self._SIMULATOR_TYPES:
             raise ValueError("Method must be one of " +

--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -95,6 +95,9 @@ class BngSimulator(Simulator):
                                       _run_kwargs=locals()
                                       )
 
+        if cleanup is None:
+            clean = self.cleanup
+
         if method not in self._SIMULATOR_TYPES:
             raise ValueError("Method must be one of " +
                              str(self._SIMULATOR_TYPES))
@@ -153,8 +156,7 @@ class BngSimulator(Simulator):
                               verbose=verbose_bool,
                               output_dir=output_dir,
                               output_prefix=output_file_basename,
-                              cleanup=self.cleanup if cleanup is None
-                              else cleanup,
+                              cleanup=cleanup,
                               model_additional_species=model_additional_species
                               ) as bngfile:
             if hpp_bngl:


### PR DESCRIPTION
The cleanup flag in BngSimulator's `__init__()` was being ignored;
only the value specified to `run()` was used. The `__init__()`
cleanup flag is now treated as a default, which can be overridden
on a per simulation basis in `run()` if required.