### PR TITLE
fix serialization of Components that do not have a model weakref set

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -192,7 +192,7 @@ class Component(object):
     def __getstate__(self):
         # clear the weakref to parent model (restored in Model.__setstate__)
         state = self.__dict__.copy()
-        del state['model']
+        state.pop('model', None)
         # Force _export to False; we don't want the unpickling process to
         # trigger SelfExporter.export!
         state['_export'] = False


### PR DESCRIPTION
`__getstate__` should not error if `.model` is not set