### PR TITLE
Fix Python 3.7 libsbml install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
     pydot coveralls mock cython
 - if [[ $PYVER == 2.7 ]]; then pip install weave; fi
-- conda install --yes -c SBMLTeam python-libsbml
+- if [[ $PYVER == 3.7 ]]; then pip install python-libsbml; else conda install --yes -c SBMLTeam python-libsbml; fi
 - pip install libroadrunner
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc


### PR DESCRIPTION
Travis is failing due to the lack of anaconda binaries for python-libsbml on Python 3.7. I've added a temporary fix to install python-libsbml using pip, which compiles from source (slow). This can be switched back when/if the libsbml team releases an appropriate binary (I've requested one on the llibsbml-interoperability mailing list).