### PR TITLE
Use system PATH variable in pathfinder

### DIFF
--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -3,7 +3,7 @@ import sys
 import sysconfig
 
 # Set to False to not utilize the system PATH environment variable
-use_path = True
+use_path = 'PYSB_PATHFINDER_IGNORE_PATH' not in os.environ
 
 _path_config = {
     'bng': {
@@ -151,9 +151,8 @@ def get_path(prog_name):
 
     search_paths = path_conf['search_paths'][os.name]
     if use_path:
-        search_paths = list(search_paths) + [
-            path.strip('"') for path in
-            os.environ.get('PATH', '').split(os.pathsep)]
+        search_paths = list(search_paths) + os.environ.get('PATH', '').split(
+            os.pathsep)
 
     for search_path in search_paths:
         try:

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -2,6 +2,9 @@ import os
 import sys
 import sysconfig
 
+# Set to False to not utilize the system PATH environment variable
+use_path = True
+
 _path_config = {
     'bng': {
         'name': 'BioNetGen',
@@ -147,6 +150,11 @@ def get_path(prog_name):
                                      set_path.__name__))
 
     search_paths = path_conf['search_paths'][os.name]
+    if use_path:
+        search_paths = list(search_paths) + [
+            path.strip('"') for path in
+            os.environ.get('PATH', '').split(os.pathsep)]
+
     for search_path in search_paths:
         try:
             _path_cache[prog_name] = _validate_path(prog_name, search_path)


### PR DESCRIPTION
This PR allows PySB to search paths defined in the system PATH variable for external executables. Paths in PATH have the lowest order of precedence (below specific environment variables, anaconda environments, and pathfinder's system default paths), so existing installations shouldn't be impacted.