### PR TITLE
Fix path detection in Anaconda

### DIFF
--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -126,14 +126,13 @@ def get_path(prog_name):
                                 path_conf['name'],
                                 _get_executable(prog_name)))
 
-    # If this is anaconda, check the anaconda binary dir
-    if _is_anaconda():
-        try:
-            _path_cache[prog_name] = _validate_path(prog_name,
-                                                    _get_anaconda_bindir())
-            return _path_cache[prog_name]
-        except ValueError:
-            pass
+    # Check the Anaconda environment, if applicable, or BINDIR
+    try:
+        _path_cache[prog_name] = _validate_path(prog_name,
+                                                _get_anaconda_bindir())
+        return _path_cache[prog_name]
+    except ValueError:
+        pass
 
     # Check default paths for this operating system
     if os.name not in path_conf['search_paths'].keys():
@@ -186,10 +185,6 @@ def set_path(prog_name, full_path):
     _path_cache[prog_name] = _validate_path(prog_name, full_path)
 
 
-def _is_anaconda():
-    """ Identify if this is an anaconda environment """
-    return 'conda' in sys.version
-
 
 def _get_anaconda_bindir():
     """ Get the binary path from python build time (for anaconda) """
@@ -198,7 +193,7 @@ def _get_anaconda_bindir():
     if conda_env:
         return os.path.join(conda_env, 'Scripts' if os.name == 'nt' else 'bin')
 
-    # Otherwise, use the default anaconda bin directory
+    # Otherwise, try the default anaconda/python bin directory
     bindir = sysconfig.get_config_var('BINDIR')
     if os.name == 'nt':
         # bindir doesn't point to scripts directory on Windows
@@ -236,7 +231,7 @@ def _validate_path(prog_name, full_path):
     if not os.path.isfile(full_path):
         # On anaconda, check batch file on Windows, if applicable
         batch_file = _get_batch_file(prog_name)
-        if _is_anaconda() and os.name == 'nt' and batch_file:
+        if os.name == 'nt' and batch_file:
             try:
                 return _validate_path(prog_name,
                                       os.path.join(full_path, batch_file))


### PR DESCRIPTION
Path detection in Anaconda was broken when they released
Python 3.7.1, due to a change in the version string. This
update no longer checks for an Anaconda environment
explicity, it goes straight to validating the paths
("it's easier to ask for forgiveness than for permission")

Fixes: #393 