### PR TITLE
ScipyOdeSimulator multiprocessing capability

### DIFF
--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -29,6 +29,7 @@ import logging
 import itertools
 import contextlib
 import importlib
+import sys
 import multiprocessing as mp
 
 
@@ -552,6 +553,9 @@ class ScipyOdeSimulator(Simulator):
                         trajectories[n, i:, :] = 'nan'
         else:
             # Parallel
+            if sys.version_info < (3, 3):
+                raise ValueError('Parallel execution is only available with '
+                                 'Python >= 3.3')
             if self._compiler != 'cython':
                 raise ValueError('Parallel execution is only available with '
                                  'compiler=\'cython\' option')

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -506,7 +506,10 @@ class ScipyOdeSimulator(Simulator):
         param_values
             See parameter definitions in :class:`ScipyOdeSimulator`.
         num_processors : int
-            Number of CPU cores to use (default: 1)
+            Number of processes to use (default: 1). Set to a larger number
+            (e.g. the number of CPU cores available) for parallel execution of
+            simulations. This is only useful when simulating with more than one
+            set of initial conditions and/or parameters.
 
         Returns
         -------
@@ -685,6 +688,7 @@ def _lsoda_process(code_eqs, jac_eqs, num_species, num_odes, *args, **kwargs):
 
 def _integrator_process(code_eqs, jac_eqs, num_species, num_odes, initials,
                         tspan, param_values, integrator_name, **opts):
+    """ Single integrator process, for parallel execution """
     ydot = np.zeros(num_species)
 
     def rhs(t, y, p):
@@ -722,4 +726,3 @@ def _integrator_process(code_eqs, jac_eqs, num_species, num_odes, initials,
         trajectory[i:, :] = 'nan'
 
     return trajectory
-

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -29,8 +29,7 @@ import logging
 import itertools
 import contextlib
 import importlib
-import sys
-import multiprocessing as mp
+from concurrent.futures import ProcessPoolExecutor, Executor, Future
 
 
 class ScipyOdeSimulator(Simulator):
@@ -157,8 +156,7 @@ class ScipyOdeSimulator(Simulator):
         integrator = kwargs.pop('integrator', 'vode')
         compiler_mode = kwargs.pop('compiler', None)
         integrator_options = kwargs.pop('integrator_options', {})
-        cython_directives = kwargs.pop('cython_directives',
-                                       self.default_cython_directives)
+
         if kwargs:
             raise ValueError('Unknown keyword argument(s): {}'.format(
                 ', '.join(kwargs.keys())
@@ -185,14 +183,7 @@ class ScipyOdeSimulator(Simulator):
         else:
             self._compiler = compiler_mode
 
-        extra_compile_args = []
-        # Inhibit weave C compiler warnings unless log level <= EXTENDED_DEBUG.
-        # Note that since the output goes straight to stderr rather than via the
-        # logging system, the threshold must be lower than DEBUG or else the
-        # Nose logcapture plugin will cause the warnings to be shown and tests
-        # will fail due to unexpected output.
-        if not self._logger.isEnabledFor(EXTENDED_DEBUG):
-            extra_compile_args.append('-w')
+        self._compiler_directives = None
 
         # Use lambdarepr (Python code) with Cython, otherwise use C code
         eqn_repr = lambdarepr if self._compiler == 'cython' else sympy.ccode
@@ -209,22 +200,32 @@ class ScipyOdeSimulator(Simulator):
             ydot = np.zeros(len(self.model.species))
 
             if self._compiler == 'cython':
+                self._compiler_directives = kwargs.pop(
+                    'cython_directives', self.default_cython_directives
+                )
+
                 if not Cython:
                     raise ImportError('Cython library is not installed')
-                self._code_eqs = code_eqs
 
-                def rhs(t, y, p):
-                    # note that the evaluated code sets ydot as a side effect
-                    Cython.inline(
-                        code_eqs, quiet=True,
-                        cython_compiler_directives=cython_directives)
-
-                    return ydot
+                rhs = _get_rhs(self._compiler,
+                               code_eqs,
+                               ydot=ydot,
+                               compiler_directives=self._compiler_directives
+                               )
 
                 with _set_cflags_no_warnings(self._logger):
                     rhs(0.0, self.initials[0], self.param_values[0])
             else:
                 # Weave
+                self._compiler_directives = []
+                # Inhibit weave C compiler warnings unless log
+                # level <= EXTENDED_DEBUG. Note that since the output goes
+                # straight to stderr rather than via the logging system, the
+                # threshold must be lower than DEBUG or else the Nose
+                # logcapture plugin will cause the warnings to be shown and
+                # tests will fail due to unexpected output.
+                if not self._logger.isEnabledFor(EXTENDED_DEBUG):
+                    self._compiler_directives.append('-w')
                 if not weave_inline:
                     raise ImportError('Weave library is not installed')
                 for arr_name in ('ydot', 'y', 'p'):
@@ -232,16 +233,18 @@ class ScipyOdeSimulator(Simulator):
                     code_eqs = re.sub(r'\b%s\[(\d+)\]' % arr_name,
                                       '%s(\\1)' % macro, code_eqs)
 
-                def rhs(t, y, p):
-                    # note that the evaluated code sets ydot as a side effect
-                    weave_inline(code_eqs, ['ydot', 't', 'y', 'p'],
-                                 extra_compile_args=extra_compile_args)
-                    return ydot
+                    rhs = _get_rhs(self._compiler,
+                                   code_eqs,
+                                   ydot=ydot,
+                                   compiler_directives=self._compiler_directives
+                                   )
 
                 # Call rhs once just to trigger the weave C compilation step
                 # while asserting control over distutils logging.
                 with self._patch_distutils_logging:
                     rhs(0.0, self.initials[0], self.param_values[0])
+
+            self._code_eqs = code_eqs
 
         elif self._compiler in ('theano', 'python'):
             self._symbols = sympy.symbols(','.join('__s%d' % sp_id for sp_id in
@@ -263,8 +266,8 @@ class ScipyOdeSimulator(Simulator):
                 code_eqs_py = sympy.lambdify(self._symbols,
                                              sympy.flatten(ode_mat))
 
-            def rhs(t, y, p):
-                return code_eqs_py(*itertools.chain(y, p))
+            rhs = _get_rhs(self._compiler, code_eqs_py)
+            self._code_eqs = code_eqs_py
         else:
             raise ValueError('Unknown compiler_mode: %s' % self._compiler)
 
@@ -287,7 +290,7 @@ class ScipyOdeSimulator(Simulator):
                     on_unused_input='ignore'
                 )
 
-                def jacobian(t, y, p):
+                def jac_fn(t, y, p):
                     jacmat = np.asarray(jac_eqs_py(*itertools.chain(y, p)))
                     jacmat.shape = (len(self.model.odes),
                                     len(self.model.species))
@@ -321,32 +324,33 @@ class ScipyOdeSimulator(Simulator):
                         jac_eqs = re.sub(r'\b%s\[(\d+)\]' % arr_name,
                                          '%s(\\1)' % macro, jac_eqs)
 
-                    def jacobian(t, y, p):
-                        weave_inline(jac_eqs, ['jac', 't', 'y', 'p'],
-                                     extra_compile_args=extra_compile_args)
-                        return jac
+                    jac_fn = _get_rhs(
+                        self._compiler,
+                        jac_eqs,
+                        compiler_directives=self._compiler_directives,
+                        jac=jac
+                    )
 
                     # Manage distutils logging, as above for rhs.
                     with self._patch_distutils_logging:
-                        jacobian(0.0, self.initials[0], self.param_values[0])
+                        jac_fn(0.0, self.initials[0], self.param_values[0])
                 else:
-                    self._jac_eqs = jac_eqs
-
-                    def jacobian(t, y, p):
-                        Cython.inline(
-                            jac_eqs, quiet=True,
-                            cython_compiler_directives=cython_directives)
-                        return jac
+                    jac_fn = _get_rhs(
+                        self._compiler,
+                        jac_eqs,
+                        compiler_directives=self._compiler_directives,
+                        jac=jac
+                    )
 
                     with _set_cflags_no_warnings(self._logger):
-                        jacobian(0.0, self.initials[0], self.param_values[0])
+                        jac_fn(0.0, self.initials[0], self.param_values[0])
+                self._jac_eqs = jac_eqs
             else:
                 jac_eqs_py = sympy.lambdify(self._symbols, jac_matrix, "numpy")
 
-                def jacobian(t, y, p):
-                    return jac_eqs_py(*itertools.chain(y, p))
+                jac_fn = _get_rhs(self._compiler, jac_eqs_py)
 
-            jac_fn = jacobian
+                self._jac_eqs = jac_eqs_py
 
         # build integrator options list from our defaults and any kwargs
         # passed to this function
@@ -359,27 +363,8 @@ class ScipyOdeSimulator(Simulator):
         # defaults
         self.opts = options
 
-        # Integrator
-        if integrator == 'lsoda':
-            # lsoda is accessed via scipy.integrate.odeint which,
-            # as a function,
-            # requires that we pass its args at the point of call. Thus we need
-            # to stash stuff like the rhs and jacobian functions in self so we
-            # can pass them in later.
-            self.integrator = integrator
-            # lsoda's rhs and jacobian function arguments are in a different
-            # order to other integrators, so we define these shims that swizzle
-            # the argument order appropriately.
-            self.func = lambda t, y, p: rhs(y, t, p)
-            if jac_fn is None:
-                self.jac_fn = None
-            else:
-                self.jac_fn = lambda t, y, p: jac_fn(y, t, p)
-        else:
-            # The scipy.integrate.ode integrators on the other hand are object
-            # oriented and hold the functions and such internally. Once we set
-            # up the integrator object we only need to retain a reference to it
-            # and can forget about the other bits.
+        if integrator != 'lsoda':
+            # Only used to check the user has selected a valid integrator
             self.integrator = scipy.integrate.ode(rhs, jac=jac_fn)
             with warnings.catch_warnings():
                 warnings.filterwarnings('error', 'No integrator name match')
@@ -522,69 +507,31 @@ class ScipyOdeSimulator(Simulator):
         n_sims = len(self.param_values)
 
         num_species = len(self._model.species)
+        num_odes = len(self._model.odes)
+        results = []
         if num_processors == 1:
             self._logger.debug('Single processor (serial) mode')
-            # Serial
-            trajectories = np.ndarray((n_sims, len(self.tspan), num_species))
-            for n in range(n_sims):
-                self._logger.info('Running simulation %d of %d', n + 1, n_sims)
-                if self.integrator == 'lsoda':
-                    trajectories[n] = scipy.integrate.odeint(
-                        self.func,
-                        self.initials[n],
-                        self.tspan,
-                        Dfun=self.jac_fn,
-                        args=(self.param_values[n],),
-                        **self.opts)
-                else:
-                    self.integrator.set_initial_value(self.initials[n],
-                                                      self.tspan[0])
-                    # Set parameter vectors for RHS func and Jacobian
-                    self.integrator.set_f_params(self.param_values[n])
-                    if self._use_analytic_jacobian:
-                        self.integrator.set_jac_params(self.param_values[n])
-                    trajectories[n][0] = self.initials[n]
-                    i = 1
-                    while self.integrator.successful() and self.integrator.t < \
-                            self.tspan[-1]:
-                        self._logger.log(EXTENDED_DEBUG,
-                                         'Simulation %d/%d Integrating t=%g',
-                                         n + 1, n_sims, self.integrator.t)
-                        trajectories[n][i] = self.integrator.integrate(self.tspan[i])
-                        i += 1
-                    if self.integrator.t < self.tspan[-1]:
-                        trajectories[n, i:, :] = 'nan'
         else:
-            # Parallel
-            if sys.version_info < (3, 3):
-                raise ValueError('Parallel execution is only available with '
-                                 'Python >= 3.3')
-            if self._compiler != 'cython':
-                raise ValueError('Parallel execution is only available with '
-                                 'compiler=\'cython\' option')
-
             self._logger.debug('Multi-processor (parallel) mode using {} '
                                'processes'.format(num_processors))
-            num_odes = len(self._model.odes)
-            with mp.Pool(processes=num_processors) as pool:
-                if self.integrator == 'lsoda':
-                    results = [pool.apply_async(
-                        _lsoda_process,
-                        args=(self._code_eqs, self._jac_eqs, num_species,
-                              num_odes, self.initials[n], self.tspan),
-                        kwds=dict(args=(self.param_values[n],),
-                                  **self.opts)
-                    ) for n in range(n_sims)]
-                else:
-                    results = [pool.apply_async(
-                        _integrator_process,
-                        args=(self._code_eqs, self._jac_eqs, num_species,
-                              num_odes, self.initials[n], self.tspan,
-                              self.param_values[n],
-                              self._init_kwargs.get('integrator', 'vode')),
-                        kwds=self.opts
-                    ) for n in range(n_sims)]
-                trajectories = [r.get() for r in results]
+        with DummyExecutor() if num_processors == 1 else \
+                ProcessPoolExecutor(max_workers=num_processors) as executor:
+            for n in range(n_sims):
+                results.append(executor.submit(
+                    _integrator_process,
+                    self._code_eqs,
+                    self._jac_eqs,
+                    num_species,
+                    num_odes,
+                    self.initials[n],
+                    self.tspan,
+                    self.param_values[n],
+                    self._init_kwargs.get('integrator', 'vode'),
+                    compiler=self._compiler,
+                    integrator_opts=self.opts,
+                    compiler_directives=self._compiler_directives
+                ))
+            trajectories = [r.result() for r in results]
 
         tout = np.array([self.tspan] * n_sims)
         self._logger.info('All simulation(s) complete')
@@ -660,55 +607,58 @@ class _DistutilsProxyLoggerAdapter(logging.LoggerAdapter):
     fatal = logging.LoggerAdapter.critical
 
 
-def _lsoda_process(code_eqs, jac_eqs, num_species, num_odes, *args, **kwargs):
-    """ Single LSODA integration process, for parallel execution """
-    ydot = np.zeros(num_species)
+def _get_rhs(compiler, code_eqs, ydot=None, jac=None, compiler_directives=None):
+    if compiler == 'cython':
+        def rhs(t, y, p):
+            # note that the evaluated code sets ydot as a side effect
+            Cython.inline(code_eqs, quiet=True,
+                          cython_compiler_directives=compiler_directives)
 
-    def rhs(y, t, p):
-        # note that the evaluated code sets ydot as a side effect
-        Cython.inline(code_eqs, quiet=True)
+            return ydot if ydot is not None else jac
+    elif compiler == 'weave':
+        def rhs(t, y, p):
+            # note that the evaluated code sets ydot as a side effect
+            weave_inline(code_eqs, ['ydot' if ydot is not None else 'jac',
+                                    't', 'y', 'p'],
+                         extra_compile_args=compiler_directives)
+            return ydot if ydot is not None else jac
+    else:
+        def rhs(t, y, p):
+            return code_eqs(*itertools.chain(y, p))
 
-        return ydot
-
-    jac_fn = None
-    if jac_eqs:
-        jac = np.zeros((num_odes, num_species))
-
-        def jac_fn(y, t, p):
-            Cython.inline(jac_eqs, quiet=True)
-            return jac
-
-    return scipy.integrate.odeint(
-        rhs,
-        *args,
-        Dfun=jac_fn,
-        **kwargs
-    )
+    return rhs
 
 
 def _integrator_process(code_eqs, jac_eqs, num_species, num_odes, initials,
-                        tspan, param_values, integrator_name, **opts):
+                        tspan, param_values, integrator_name, compiler,
+                        integrator_opts, compiler_directives):
     """ Single integrator process, for parallel execution """
-    ydot = np.zeros(num_species)
-
-    def rhs(t, y, p):
-        # note that the evaluated code sets ydot as a side effect
-        Cython.inline(code_eqs, quiet=True)
-
-        return ydot
+    rhs = _get_rhs(compiler, code_eqs, ydot=np.zeros(num_species),
+                   compiler_directives=compiler_directives)
 
     jac_fn = None
     if jac_eqs:
-        jac = np.zeros((num_odes, num_species))
+        jac_eqs = _get_rhs(compiler, jac_eqs,
+                           jac=np.zeros((num_odes, num_species)),
+                           compiler_directives=compiler_directives)
 
-        def jac_fn(t, y, p):
-            Cython.inline(jac_eqs, quiet=True)
-            return jac
+    # LSODA
+    if integrator_name == 'lsoda':
+        return scipy.integrate.odeint(
+            rhs,
+            initials,
+            tspan,
+            args=(param_values, ),
+            Dfun=jac_fn,
+            tfirst=True,
+            **integrator_opts
+        )
 
+    # All other integrators
     integrator = scipy.integrate.ode(rhs, jac=jac_fn)
     with warnings.catch_warnings():
         warnings.filterwarnings('error', 'No integrator name match')
-        integrator.set_integrator(integrator_name, **opts)
+        integrator.set_integrator(integrator_name, **integrator_opts)
     integrator.set_initial_value(initials, tspan[0])
 
     # Set parameter vectors for RHS func and Jacobian
@@ -726,3 +676,17 @@ def _integrator_process(code_eqs, jac_eqs, num_species, num_odes, initials,
         trajectory[i:, :] = 'nan'
 
     return trajectory
+
+
+class DummyExecutor(Executor):
+    """ Execute tasks in serial (immediately on submission) """
+    def submit(self, fn, *args, **kwargs):
+        f = Future()
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as e:
+            f.set_exception(e)
+        else:
+            f.set_result(result)
+
+        return f

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -233,11 +233,11 @@ class ScipyOdeSimulator(Simulator):
                     code_eqs = re.sub(r'\b%s\[(\d+)\]' % arr_name,
                                       '%s(\\1)' % macro, code_eqs)
 
-                    rhs = _get_rhs(self._compiler,
-                                   code_eqs,
-                                   ydot=ydot,
-                                   compiler_directives=self._compiler_directives
-                                   )
+                rhs = _get_rhs(self._compiler,
+                               code_eqs,
+                               ydot=ydot,
+                               compiler_directives=self._compiler_directives
+                               )
 
                 # Call rhs once just to trigger the weave C compilation step
                 # while asserting control over distutils logging.
@@ -514,7 +514,7 @@ class ScipyOdeSimulator(Simulator):
         else:
             self._logger.debug('Multi-processor (parallel) mode using {} '
                                'processes'.format(num_processors))
-        with DummyExecutor() if num_processors == 1 else \
+        with SerialExecutor() if num_processors == 1 else \
                 ProcessPoolExecutor(max_workers=num_processors) as executor:
             for n in range(n_sims):
                 results.append(executor.submit(
@@ -678,7 +678,7 @@ def _integrator_process(code_eqs, jac_eqs, num_species, num_odes, initials,
     return trajectory
 
 
-class DummyExecutor(Executor):
+class SerialExecutor(Executor):
     """ Execute tasks in serial (immediately on submission) """
     def submit(self, fn, *args, **kwargs):
         f = Future()

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -356,12 +356,16 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
                         [90, 100, 110, 5, 6]]
         self.sim.run(initials=initials, param_values=param_values)
 
+    @unittest.skipIf(sys.version_info.major < 3,
+                     'Parallel execution requires Python >= 3.3')
     def test_parallel_vode(self):
         initials = [[10, 20, 30], [50, 60, 70]]
         base_res = self.sim.run(initials=initials)
         res = self.sim.run(initials=initials, num_processors=2)
         assert np.allclose(res.species, base_res.species)
 
+    @unittest.skipIf(sys.version_info.major < 3,
+                     'Parallel execution requires Python >= 3.3')
     def test_parallel_vode_jacobian(self):
         initials = [[10, 20, 30], [50, 60, 70]]
         sim = ScipyOdeSimulator(self.model, self.sim.tspan,
@@ -372,6 +376,8 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
         assert np.allclose(res.species, base_res.species)
 
 
+    @unittest.skipIf(sys.version_info.major < 3,
+                     'Parallel execution requires Python >= 3.3')
     def test_parallel_lsoda(self):
         initials = [[10, 20, 30], [50, 60, 70]]
         sim = ScipyOdeSimulator(self.model, self.sim.tspan,
@@ -381,6 +387,8 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
         res = sim.run(num_processors=2)
         assert np.allclose(res.species, base_res.species)
 
+    @unittest.skipIf(sys.version_info.major < 3,
+                     'Parallel execution requires Python >= 3.3')
     def test_parallel_lsoda_jacobian(self):
         initials = [[10, 20, 30], [50, 60, 70]]
         sim = ScipyOdeSimulator(self.model, self.sim.tspan,

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -356,6 +356,41 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
                         [90, 100, 110, 5, 6]]
         self.sim.run(initials=initials, param_values=param_values)
 
+    def test_parallel_vode(self):
+        initials = [[10, 20, 30], [50, 60, 70]]
+        base_res = self.sim.run(initials=initials)
+        res = self.sim.run(initials=initials, num_processors=2)
+        assert np.allclose(res.species, base_res.species)
+
+    def test_parallel_vode_jacobian(self):
+        initials = [[10, 20, 30], [50, 60, 70]]
+        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
+                                 initials=initials,
+                                 use_analytic_jacobian=True)
+        base_res = sim.run()
+        res = sim.run(num_processors=2)
+        assert np.allclose(res.species, base_res.species)
+
+
+    def test_parallel_lsoda(self):
+        initials = [[10, 20, 30], [50, 60, 70]]
+        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
+                                 initials=initials,
+                                 integrator='lsoda')
+        base_res = sim.run()
+        res = sim.run(num_processors=2)
+        assert np.allclose(res.species, base_res.species)
+
+    def test_parallel_lsoda_jacobian(self):
+        initials = [[10, 20, 30], [50, 60, 70]]
+        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
+                                 integrator='lsoda',
+                                 initials=initials,
+                                 use_analytic_jacobian=True)
+        base_res = sim.run()
+        res = sim.run(num_processors=2)
+        assert np.allclose(res.species, base_res.species)
+
 
 @with_model
 def test_integrate_with_expression():

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -358,45 +358,21 @@ class TestScipySimulatorMultiple(TestScipySimulatorBase):
 
     @unittest.skipIf(sys.version_info.major < 3,
                      'Parallel execution requires Python >= 3.3')
-    def test_parallel_vode(self):
-        initials = [[10, 20, 30], [50, 60, 70]]
-        base_res = self.sim.run(initials=initials)
-        res = self.sim.run(initials=initials, num_processors=2)
-        assert np.allclose(res.species, base_res.species)
+    def test_parallel(self):
+        for integrator in ('vode', 'lsoda'):
+            for use_analytic_jacobian in (True, False):
+                yield self._check_parallel, integrator, use_analytic_jacobian
 
-    @unittest.skipIf(sys.version_info.major < 3,
-                     'Parallel execution requires Python >= 3.3')
-    def test_parallel_vode_jacobian(self):
+    def _check_parallel(self, integrator, use_analytic_jacobian):
         initials = [[10, 20, 30], [50, 60, 70]]
-        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
-                                 initials=initials,
-                                 use_analytic_jacobian=True)
-        base_res = sim.run()
-        res = sim.run(num_processors=2)
-        assert np.allclose(res.species, base_res.species)
-
-
-    @unittest.skipIf(sys.version_info.major < 3,
-                     'Parallel execution requires Python >= 3.3')
-    def test_parallel_lsoda(self):
-        initials = [[10, 20, 30], [50, 60, 70]]
-        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
-                                 initials=initials,
-                                 integrator='lsoda')
-        base_res = sim.run()
-        res = sim.run(num_processors=2)
-        assert np.allclose(res.species, base_res.species)
-
-    @unittest.skipIf(sys.version_info.major < 3,
-                     'Parallel execution requires Python >= 3.3')
-    def test_parallel_lsoda_jacobian(self):
-        initials = [[10, 20, 30], [50, 60, 70]]
-        sim = ScipyOdeSimulator(self.model, self.sim.tspan,
-                                 integrator='lsoda',
-                                 initials=initials,
-                                 use_analytic_jacobian=True)
-        base_res = sim.run()
-        res = sim.run(num_processors=2)
+        sim = ScipyOdeSimulator(
+            self.model, self.sim.tspan,
+            initials=initials,
+            integrator=integrator,
+            use_analytic_jacobian=use_analytic_jacobian
+        )
+        base_res = sim.run(initials=initials)
+        res = sim.run(initials=initials, num_processors=2)
         assert np.allclose(res.species, base_res.species)
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,11 @@ def main():
                     'pysb.testing', 'pysb.tests'],
           scripts=['scripts/pysb_export'],
           # We should really specify some minimum versions here.
-          install_requires=['numpy', 'scipy', 'sympy', 'networkx'],
+          install_requires=['numpy', 'scipy>=1.1', 'sympy', 'networkx',
+                            'futures; python_version == "2.7"'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas', 'theano', 'h5py', 'mock', 'cython',
+                         'pandas', 'theano>=1.0.4', 'h5py', 'mock', 'cython',
                          'python-libsbml', 'libroadrunner'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],


### PR DESCRIPTION
This PR uses the multiprocessing module to add parallel simulation
capability to the ScipyOdeSimulator. This only works when using
Cython as a compiler.

Multiprocessing is picky about what can be pickled and sent to
child processes, so the Cython code is sent as text for use with
inline(). Since inline() is called in `__init__()` with the same code,
it utilises cython's cache, and therefore the ODEs only have to be
compiled once. The code is a little bit duplicative, since we can't
pass instance methods through to multiprocessing's processes,
thefore the `rhs()` and `jac_fn()` methods must be redefined in
each process. Requires (and checks for) Python >=3.3.