### PR TITLE
Fix distribution name for libroadrunner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def main():
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
                          'pandas', 'theano', 'h5py', 'mock', 'cython',
-                         'python-libsbml', 'roadrunner'],
+                         'python-libsbml', 'libroadrunner'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],
           classifiers=[


### PR DESCRIPTION
#367 added `roadrunner` to `tests_require`, but the correct distribution name is `libroadrunner`. There *is* a `roadrunner` but it's something else. Travis wouldn't catch this because there's an explicit `pip install` for it. This PR fixes the distribution name.