### PR TITLE
Cython compiler directives for faster simulations

### DIFF
--- a/benchmarks/simulator.py
+++ b/benchmarks/simulator.py
@@ -14,23 +14,34 @@ class Earm10ODESuite(object):
             [[p.value for p in self.model.parameters]], self.nsims, axis=0)
         integrator_options_common = {
             'model': self.model,
-            'tspan': np.linspace(0, 1000, 101),
-            'atol': 1e-6,
-            'rtol': 1e-6,
-            'mxsteps': 20000,
+            'tspan': np.linspace(0, 20000, 101),
             'param_values': self.parameter_set
         }
 
         self.sim_lsoda = ScipyOdeSimulator(
             integrator='lsoda',
+            compiler='cython',
+            integrator_options={'atol': 1e-6, 'rtol': 1e-6, 'mxstep': 20000},
             **integrator_options_common
         )
+        self.sim_lsoda_no_compiler_directives = ScipyOdeSimulator(
+            integrator='lsoda',
+            compiler='cython',
+            cython_directives={},
+            integrator_options={'atol': 1e-6, 'rtol': 1e-6, 'mxstep': 20000},
+            **integrator_options_common
+        )
+
         self.sim_cupsoda = CupSodaSimulator(
+            integrator_options={'atol': 1e-6, 'rtol': 1e-6, 'max_steps': 20000},
             **integrator_options_common
         )
 
     def time_scipy_lsoda(self):
         self.sim_lsoda.run()
+
+    def time_scipy_lsoda_no_compiler_directives(self):
+        self.sim_lsoda_no_compiler_directives.run()
 
     def time_cupsoda(self):
         self.sim_cupsoda.run()

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -31,10 +31,6 @@ import contextlib
 import importlib
 
 
-CYTHON_DECL = '#cython: boundscheck=False, wraparound=False, ' \
-              'nonecheck=False, initializedcheck=False\n'
-
-
 class ScipyOdeSimulator(Simulator):
     """
     Simulate a model using SciPy ODE integration
@@ -137,6 +133,13 @@ class ScipyOdeSimulator(Simulator):
         }
     }
 
+    default_cython_directives = {
+        'boundscheck': False,
+        'wraparound': False,
+        'nonecheck': False,
+        'initializedcheck': False
+    }
+
     def __init__(self, model, tspan=None, initials=None, param_values=None,
                  verbose=False, **kwargs):
 
@@ -153,6 +156,8 @@ class ScipyOdeSimulator(Simulator):
         integrator = kwargs.pop('integrator', 'vode')
         compiler_mode = kwargs.pop('compiler', None)
         integrator_options = kwargs.pop('integrator_options', {})
+        cython_directives = kwargs.pop('cython_directives',
+                                       self.default_cython_directives)
         if kwargs:
             raise ValueError('Unknown keyword argument(s): {}'.format(
                 ', '.join(kwargs.keys())
@@ -205,11 +210,12 @@ class ScipyOdeSimulator(Simulator):
             if self._compiler == 'cython':
                 if not Cython:
                     raise ImportError('Cython library is not installed')
-                code_eqs = CYTHON_DECL + code_eqs
 
                 def rhs(t, y, p):
                     # note that the evaluated code sets ydot as a side effect
-                    Cython.inline(code_eqs, quiet=True)
+                    Cython.inline(
+                        code_eqs, quiet=True,
+                        cython_compiler_directives=cython_directives)
 
                     return ydot
 
@@ -321,10 +327,10 @@ class ScipyOdeSimulator(Simulator):
                     with self._patch_distutils_logging:
                         jacobian(0.0, self.initials[0], self.param_values[0])
                 else:
-                    jac_eqs = CYTHON_DECL + jac_eqs
-
                     def jacobian(t, y, p):
-                        Cython.inline(jac_eqs, quiet=True)
+                        Cython.inline(
+                            jac_eqs, quiet=True,
+                            cython_compiler_directives=cython_directives)
                         return jac
 
                     with _set_cflags_no_warnings(self._logger):


### PR DESCRIPTION
I created a PR for Cython (https://github.com/cython/cython/pull/2595)
which added compiler directive support for cython.inline(), which
is now present in Cython>=0.92

This PR introduces user-configurable Cython compiler directives
within the ScipyOdeSimulator. By default, these directives disable
bounds, wrap around, "None", and initialized checks. Some initial
benchmarking on asv shows a speed improvement of about 5% on my
laptop (every little helps?)