### PR TITLE
Remove stochkit initial condition support for numeric ICs

### DIFF
--- a/pysb/export/stochkit.py
+++ b/pysb/export/stochkit.py
@@ -165,9 +165,7 @@ class StochKitExporter(Exporter):
                 if si is None:
                     raise IndexError("Species not found in model: %s" %
                                      repr(cp))
-                if isinstance(value_obj, (int, float)):
-                    value = value_obj
-                elif value_obj in self.model.parameters:
+                if value_obj in self.model.parameters:
                     pi = self.model.parameters.index(value_obj)
                     value = param_values[pi]
                 elif value_obj in self.model.expressions:


### PR DESCRIPTION
Raw numeric intial conditions, as opposed to those wrapped in a
parameter or constant expression, are not allowed in PySB.
This removes a superfluous check for this condition in the
StochKit exporter.