### PR TITLE
Small changes to 'BngSimulator.run' to support optional arguments to

### DIFF
--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -25,7 +25,8 @@ class BngSimulator(Simulator):
 
     def run(self, tspan=None, initials=None, param_values=None, n_runs=1,
             method='ssa', output_dir=None, output_file_basename=None,
-            cleanup=None, population_maps=None, **additional_args):
+            cleanup=None, population_maps=None, netgen_args={}, 
+            **additional_args):
         """
         Simulate a model using BioNetGen
 
@@ -177,7 +178,7 @@ class BngSimulator(Simulator):
             if method != 'nf':
                 # TODO: Write existing netfile if already generated
                 bngfile.action('generate_network', overwrite=True,
-                               verbose=extended_debug)
+                               verbose=extended_debug, **netgen_args)
             if output_file_basename is None:
                 prefix = 'pysb'
             else:


### PR DESCRIPTION
BNG's 'generate_network' method. Added a new optional argument,
'netgen_args', to the 'BngSimulator.run' call signature. This is a
dictionary that gets passed to 'bngfile.action' when the
'generate_network' command is called.