### PR TITLE
Duplicate sites support

### DIFF
--- a/pysb/__init__.py
+++ b/pysb/__init__.py
@@ -3,7 +3,7 @@ from pysb.annotation import Annotation
 
 __all__ = ['Observable', 'Initial', 'MatchOnce', 'Model', 'Monomer',
            'Parameter', 'Compartment', 'Rule', 'Expression', 'ANY', 'WILD',
-           'Annotation']
+           'Annotation', 'MultiSite']
 
 try:
     import reinteract         # fails if reinteract not installed

--- a/pysb/__init__.py
+++ b/pysb/__init__.py
@@ -3,7 +3,7 @@ from pysb.annotation import Annotation
 
 __all__ = ['Observable', 'Initial', 'MatchOnce', 'Model', 'Monomer',
            'Parameter', 'Compartment', 'Rule', 'Expression', 'ANY', 'WILD',
-           'Annotation', 'MultiSite']
+           'Annotation', 'MultiState']
 
 try:
     import reinteract         # fails if reinteract not installed

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -519,7 +519,8 @@ class BngFileInterface(BngBaseInterface):
             Value of parameter
 
         """
-        self.command_queue.write('\tsetParameter("%s", %g)\n' % (name, value))
+        self.command_queue.write('\tsetParameter("%s", %.17g)\n'
+                                 % (name, value))
 
     def set_concentration(self, cplx_pat, value):
         """
@@ -539,8 +540,8 @@ class BngFileInterface(BngBaseInterface):
             formatted_name = format_complexpattern(
                 pysb.core.as_complex_pattern(cplx_pat)
             )
-        self.command_queue.write('\tsetConcentration("%s", %g)\n' % (
-            formatted_name, value))
+        self.command_queue.write('\tsetConcentration("%s", %.17g)\n'
+                                 % (formatted_name, value))
 
 
 def generate_hybrid_model(model, population_maps, additional_species=None,

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -781,7 +781,7 @@ def _parse_species(model, line):
     for ms in monomer_strings:
         monomer_name, site_strings, monomer_compartment_name = \
             re.match(r'\$?(\w+)\(([^)]*)\)(?:@(\w+))?', ms).groups()
-        site_conditions = {}
+        site_conditions = collections.defaultdict(list)
         if len(site_strings):
             for ss in site_strings.split(','):
                 # FIXME this should probably be done with regular expressions
@@ -805,7 +805,10 @@ def _parse_species(model, line):
                     site_name, condition = ss.split('~')
                 else:
                     site_name, condition = ss, None
-                site_conditions[site_name] = condition
+                site_conditions[site_name].append(condition)
+
+        site_conditions = {k: v[0] if len(v) == 1 else tuple(v)
+                           for k, v in site_conditions.items()}
         monomer = model.monomers[monomer_name]
         monomer_compartment = model.compartments.get(monomer_compartment_name)
         # Compartment prefix notation in BNGL means "assign this compartment to

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -519,8 +519,7 @@ class BngFileInterface(BngBaseInterface):
             Value of parameter
 
         """
-        self.command_queue.write('\tsetParameter("%s", %.17g)\n'
-                                 % (name, value))
+        self.command_queue.write('\tsetParameter("%s", %g)\n' % (name, value))
 
     def set_concentration(self, cplx_pat, value):
         """
@@ -540,8 +539,8 @@ class BngFileInterface(BngBaseInterface):
             formatted_name = format_complexpattern(
                 pysb.core.as_complex_pattern(cplx_pat)
             )
-        self.command_queue.write('\tsetConcentration("%s", %.17g)\n'
-                                 % (formatted_name, value))
+        self.command_queue.write('\tsetConcentration("%s", %g)\n' % (
+            formatted_name, value))
 
 
 def generate_hybrid_model(model, population_maps, additional_species=None,

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -481,6 +481,7 @@ class MonomerPattern(object):
     * *tuple of (str, int)* : state with specified bond
     * *tuple of (str, WILD)* : state with wildcard bond
     * *tuple of (str, ANY)* : state with any bond
+    * MultiSite : duplicate sites
 
     If a site is not listed in site_conditions then the pattern will match any
     state for that site, i.e. \"don't write, don't care\".
@@ -806,7 +807,7 @@ class ComplexPattern(object):
             elif is_state_bond_tuple(state_or_bond):
                 state = state_or_bond[0]
                 bond_num = state_or_bond[1]
-            elif isinstance(state_or_bond, int):
+            elif isinstance(state_or_bond, (int, list)):
                 bond_num = state_or_bond
             elif state_or_bond is not ANY and state_or_bond is not None:
                 raise ValueError('Unrecognized state: {}'.format(
@@ -827,6 +828,9 @@ class ComplexPattern(object):
                 bond_edges[NO_BOND].append(mon_site_id)
             elif isinstance(bond_num, int):
                 bond_edges[bond_num].append(mon_site_id)
+            elif isinstance(bond_num, list):
+                for bond in bond_num:
+                    bond_edges[bond].append(mon_site_id)
 
         for mp in self.monomer_patterns:
             mon_node_id = next(node_count)

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 import pysb
-from pysb.core import MultiSite
+from pysb.core import MultiState
 import sympy
 from sympy.printing import StrPrinter
 
@@ -233,7 +233,7 @@ def format_site_condition(site, state):
         elif state[1] == pysb.ANY:
             state = (state[0], '+')
         state_code = '~%s!%s' % state
-    elif isinstance(state, MultiSite):
+    elif isinstance(state, MultiState):
         return ','.join(format_site_condition(site, s) for s in state)
     # one or more unspecified bonds
     elif state is pysb.ANY:

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -46,7 +46,7 @@ class BngGenerator(object):
         max_length = max(len(p.name) for p in
                          self.model.parameters | self.model.expressions)
         for p in self.model.parameters:
-            self.__content += (("  %-" + str(max_length) + "s   %.17g\n") %
+            self.__content += (("  %-" + str(max_length) + "s   %e\n") %
                                (p.name, p.value))
         for e in exprs:
             self.__content += (("  %-" + str(max_length) + "s   %s\n") %

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 import pysb
-from pysb.core import is_state_bond_tuple, MultiSite
+from pysb.core import MultiSite
 import sympy
 from sympy.printing import StrPrinter
 
@@ -11,8 +11,8 @@ try:
 except NameError:
     basestring = str
 
-class BngGenerator(object):
 
+class BngGenerator(object):
     def __init__(self, model, additional_initials=None, population_maps=None):
         self.model = model
         if additional_initials is None:
@@ -46,7 +46,7 @@ class BngGenerator(object):
         max_length = max(len(p.name) for p in
                          self.model.parameters | self.model.expressions)
         for p in self.model.parameters:
-            self.__content += (("  %-" + str(max_length) + "s   %e\n") %
+            self.__content += (("  %-" + str(max_length) + "s   %.17g\n") %
                                (p.name, p.value))
         for e in exprs:
             self.__content += (("  %-" + str(max_length) + "s   %s\n") %

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 import pysb
-from pysb.core import is_state_bond_tuple
+from pysb.core import is_state_bond_tuple, MultiSite
 import sympy
 from sympy.printing import StrPrinter
 
@@ -227,15 +227,14 @@ def format_site_condition(site, state):
         state_code = '~' + state
     # state AND single bond
     elif isinstance(state, tuple):
-        if is_state_bond_tuple(state):
-            # bond is wildcard (zero or more unspecified bonds)
-            if state[1] == pysb.WILD:
-                state = (state[0], '?')
-            elif state[1] == pysb.ANY:
-                state = (state[0], '+')
-            state_code = '~%s!%s' % state
-        else:
-            return ','.join(format_site_condition(site, s) for s in state)
+        # bond is wildcard (zero or more unspecified bonds)
+        if state[1] == pysb.WILD:
+            state = (state[0], '?')
+        elif state[1] == pysb.ANY:
+            state = (state[0], '+')
+        state_code = '~%s!%s' % state
+    elif isinstance(state, MultiSite):
+        return ','.join(format_site_condition(site, s) for s in state)
     # one or more unspecified bonds
     elif state is pysb.ANY:
         state_code = '!+'

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -1,6 +1,7 @@
 import inspect
 import warnings
 import pysb
+from pysb.core import is_state_bond_tuple
 import sympy
 from sympy.printing import StrPrinter
 
@@ -226,12 +227,15 @@ def format_site_condition(site, state):
         state_code = '~' + state
     # state AND single bond
     elif isinstance(state, tuple):
-        # bond is wildcard (zero or more unspecified bonds)
-        if state[1] == pysb.WILD:
-            state = (state[0], '?')
-        elif state[1] == pysb.ANY:
-            state = (state[0], '+')
-        state_code = '~%s!%s' % state
+        if is_state_bond_tuple(state):
+            # bond is wildcard (zero or more unspecified bonds)
+            if state[1] == pysb.WILD:
+                state = (state[0], '?')
+            elif state[1] == pysb.ANY:
+                state = (state[0], '+')
+            state_code = '~%s!%s' % state
+        else:
+            return ','.join(format_site_condition(site, s) for s in state)
     # one or more unspecified bonds
     elif state is pysb.ANY:
         state_code = '!+'
@@ -241,7 +245,8 @@ def format_site_condition(site, state):
     elif state is pysb.WILD:
         state_code = '!?'
     else:
-        raise Exception("BNG generator has encountered an unknown element in a rule pattern site condition.")
+        raise ValueError("BNG generator has encountered an unknown element in "
+                         "a rule pattern site condition.")
     return '%s%s' % (site, state_code)
 
 def warn_caller(message):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -196,10 +196,9 @@ class KappaGenerator(object):
         # If there is a bond number
         elif isinstance(state, int):
             state_code = '[%s]' % state
-        # If there is a lists of bonds to the site (not supported by Kappa)
-        elif isinstance(state, list):
-            raise KappaException("Kappa generator does not support multiple "
-                                 "bonds to a single site.")
+        # If there is a MultiBond, raise an Exception (not supported by Kappa)
+        elif isinstance(state, pysb.MultiSite):
+            raise KappaException("Kappa generator does not support MultiSites.")
         # Site with state
         elif isinstance(state, basestring):
             state_code = '{%s}[.]' % state

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -49,7 +49,7 @@ class KappaGenerator(object):
 
     def generate_parameters(self):
         for p in self.model.parameters:
-            self.__content += "%%var: '%s' %.17g\n" % (p.name, p.value)
+            self.__content += "%%var: '%s' %e\n" % (p.name, p.value)
         for e in self.model.expressions:
             str_expr = str(expression_to_muparser(e))
             self.__content += "%%var: '%s' %s\n" % (e.name, str_expr)

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -49,7 +49,7 @@ class KappaGenerator(object):
 
     def generate_parameters(self):
         for p in self.model.parameters:
-            self.__content += "%%var: '%s' %e\n" % (p.name, p.value)
+            self.__content += "%%var: '%s' %.17g\n" % (p.name, p.value)
         for e in self.model.expressions:
             str_expr = str(expression_to_muparser(e))
             self.__content += "%%var: '%s' %s\n" % (e.name, str_expr)

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -199,9 +199,9 @@ class KappaGenerator(object):
         # Multi-bond (list of bonds)
         elif isinstance(state, list):
             raise KappaException("Kappa generator does not support multi-bonds")
-        # If there is a MultiBond, raise an Exception (not supported by Kappa)
-        elif isinstance(state, pysb.MultiSite):
-            raise KappaException("Kappa generator does not support MultiSites.")
+        # If there is a MultiState, raise an Exception (not supported by Kappa)
+        elif isinstance(state, pysb.MultiState):
+            raise KappaException("Kappa generator does not support MultiStates")
         # Site with state
         elif isinstance(state, basestring):
             state_code = '{%s}[.]' % state

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -196,6 +196,9 @@ class KappaGenerator(object):
         # If there is a bond number
         elif isinstance(state, int):
             state_code = '[%s]' % state
+        # Multi-bond (list of bonds)
+        elif isinstance(state, list):
+            raise KappaException("Kappa generator does not support multi-bonds")
         # If there is a MultiBond, raise an Exception (not supported by Kappa)
         elif isinstance(state, pysb.MultiSite):
             raise KappaException("Kappa generator does not support MultiSites.")

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -10,7 +10,6 @@ import pysb.logging
 import collections
 import numbers
 import os
-import math
 
 
 def _ns(tag_string):
@@ -66,7 +65,7 @@ class BnglBuilder(Builder):
 
         # Quick security check on the expression
         if re.match(r'^[\w\s()/+\-._*]*$', expression):
-            return eval(expression, {'ln': math.log}, self._model_env)
+            return parse_expr(expression, self._model_env)
         else:
             self._warn_or_except('Security check on expression "%s" failed' %
                                  expression)

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -187,8 +187,8 @@ class BnglBuilder(Builder):
                 except ValueError:
                     # Despite the "Constant" label, some constant expressions
                     # appear here e.g. ln(2)/120 in BNG's Repressilator model
-                    self.parameter(name=p_name,
-                                   value=self._eval_in_model_env(
+                    self.expression(name=p_name,
+                                    expr=self._eval_in_model_env(
                                         p.get('value')))
             elif p.get('type') == 'ConstantExpression':
                 self.expression(name=p_name,

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -1,5 +1,5 @@
 from pysb.core import MonomerPattern, ComplexPattern, RuleExpression, \
-    ReactionPattern, ANY, WILD, MultiSite
+    ReactionPattern, ANY, WILD, MultiState
 from pysb.builder import Builder
 from pysb.bng import BngFileInterface
 import xml.etree.ElementTree
@@ -126,7 +126,7 @@ class BnglBuilder(Builder):
                 else:
                     mon_states[state_nm].append(last_bond)
 
-            mon_states = {k: MultiSite(*v) if len(v) > 1 else v[0]
+            mon_states = {k: MultiState(*v) if len(v) > 1 else v[0]
                           for k, v in mon_states.items()}
 
             mon_cpt = self.model.compartments.get(mon.get('compartment'))

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -166,8 +166,8 @@ class BnglBuilder(Builder):
                         )
             try:
                 self.monomer(mon_name, sites,
-                             {c_name: statedict.values() for c_name, statedict
-                              in states.items()})
+                             {c_name: list(statedict.values())
+                              for c_name, statedict in states.items()})
             except Exception as e:
                 if str(e).startswith('Duplicate sites specified'):
                     self._warn_or_except('Molecule %s has multiple '
@@ -201,6 +201,10 @@ class BnglBuilder(Builder):
         for o in self._x.iterfind(_ns('{0}ListOfObservables/{0}Observable')):
             o_name = o.get('name')
             match_mode = o.get('type').lower()
+            # Some BNG observables have same name as a monomer, but in PySB
+            # these must be unique
+            if o_name in self.model.monomers.keys():
+                o_name = 'Obs_{}'.format(o_name)
             cplx_pats = []
             for mp in o.iterfind(_ns('{0}ListOfPatterns/{0}Pattern')):
                 cpt = self.model.compartments.get(mp.get('compartment'))

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -1,5 +1,5 @@
 from pysb.core import MonomerPattern, ComplexPattern, RuleExpression, \
-    ReactionPattern, ANY, WILD
+    ReactionPattern, ANY, WILD, MultiSite
 from pysb.builder import Builder
 from pysb.bng import BngFileInterface
 import xml.etree.ElementTree
@@ -127,7 +127,7 @@ class BnglBuilder(Builder):
                 else:
                     mon_states[state_nm].append(last_bond)
 
-            mon_states = {k: tuple(v) if len(v) > 1 else v[0]
+            mon_states = {k: MultiSite(*v) if len(v) > 1 else v[0]
                           for k, v in mon_states.items()}
 
             mon_cpt = self.model.compartments.get(mon.get('compartment'))

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -385,12 +385,22 @@ def test_duplicate_sites():
     Monomer('B', ['b', 'b'], {'b': ['u', 'p']})
 
     assert not A(a=1).is_concrete()
-    assert A(a=(1, 2)).is_concrete()
-    assert A(a=(1, None)).is_concrete()
+    assert A(a=MultiSite(1, 2)).is_concrete()
+    assert A(a=MultiSite(1, None)).is_concrete()
 
     assert not B(b=('u', 1)).is_concrete()
-    assert B(b=('u', 'p')).is_concrete()
-    assert B(b=(('u', 1), ('u', 2))).is_concrete()
+
+    assert B(b=MultiSite('u', 'p')).is_concrete()
+    assert B(b=MultiSite(('u', 1), ('u', 2))).is_concrete()
 
     # Check _as_graph() works for duplicate sites
-    B(b=(('u', 1), ('u', 2)))._as_graph()
+    B(b=MultiSite(('u', 1), ('u', 2)))._as_graph()
+
+    assert B(b=MultiSite('u', ('u', 1))).is_concrete()
+
+    # Syntax errors (should use MultiSite)
+    assert_raises(ValueError, B, b=('u', 'p'))
+    assert_raises(ValueError, B, b=['u', 'p'])
+
+    # Syntax error (can't nest MultiSite)
+    assert_raises(ValueError, MultiSite, MultiSite(1, 2), 'p')

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -418,3 +418,8 @@ def test_duplicate_sites():
 
     # Duplicate sites with multi-bond
     A(a=MultiSite([1, 2], [1, 2]))
+
+
+@raises(ValueError)
+def test_duplicate_site_single_site():
+    MultiSite('a')

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -378,3 +378,19 @@ def test_rulepattern_match_none_against_state():
     # so this should be a valid rule pattern
     A(phospho=None) + A(phospho=None) >> A(phospho=1) % A(phospho=1)
 
+
+@with_model
+def test_duplicate_sites():
+    Monomer('A', ['a', 'a'])
+    Monomer('B', ['b', 'b'], {'b': ['u', 'p']})
+
+    assert not A(a=1).is_concrete()
+    assert A(a=(1, 2)).is_concrete()
+    assert A(a=(1, None)).is_concrete()
+
+    assert not B(b=('u', 1)).is_concrete()
+    assert B(b=('u', 'p')).is_concrete()
+    assert B(b=(('u', 1), ('u', 2))).is_concrete()
+
+    # Check _as_graph() works for duplicate sites
+    B(b=(('u', 1), ('u', 2)))._as_graph()

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -380,6 +380,17 @@ def test_rulepattern_match_none_against_state():
 
 
 @with_model
+def test_multi_bonds():
+    Monomer('A', ['a'])
+    a_pat = A(a=[1, 2])
+
+    # Check _as_graph() works for multi-bonds
+    a_pat._as_graph()
+
+    assert a_pat.is_concrete()
+
+
+@with_model
 def test_duplicate_sites():
     Monomer('A', ['a', 'a'])
     Monomer('B', ['b', 'b'], {'b': ['u', 'p']})
@@ -404,3 +415,6 @@ def test_duplicate_sites():
 
     # Syntax error (can't nest MultiSite)
     assert_raises(ValueError, MultiSite, MultiSite(1, 2), 'p')
+
+    # Duplicate sites with multi-bond
+    A(a=MultiSite([1, 2], [1, 2]))

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -396,30 +396,30 @@ def test_duplicate_sites():
     Monomer('B', ['b', 'b'], {'b': ['u', 'p']})
 
     assert not A(a=1).is_concrete()
-    assert A(a=MultiSite(1, 2)).is_concrete()
-    assert A(a=MultiSite(1, None)).is_concrete()
+    assert A(a=MultiState(1, 2)).is_concrete()
+    assert A(a=MultiState(1, None)).is_concrete()
 
     assert not B(b=('u', 1)).is_concrete()
 
-    assert B(b=MultiSite('u', 'p')).is_concrete()
-    assert B(b=MultiSite(('u', 1), ('u', 2))).is_concrete()
+    assert B(b=MultiState('u', 'p')).is_concrete()
+    assert B(b=MultiState(('u', 1), ('u', 2))).is_concrete()
 
     # Check _as_graph() works for duplicate sites
-    B(b=MultiSite(('u', 1), ('u', 2)))._as_graph()
+    B(b=MultiState(('u', 1), ('u', 2)))._as_graph()
 
-    assert B(b=MultiSite('u', ('u', 1))).is_concrete()
+    assert B(b=MultiState('u', ('u', 1))).is_concrete()
 
-    # Syntax errors (should use MultiSite)
+    # Syntax errors (should use MultiState)
     assert_raises(ValueError, B, b=('u', 'p'))
     assert_raises(ValueError, B, b=['u', 'p'])
 
-    # Syntax error (can't nest MultiSite)
-    assert_raises(ValueError, MultiSite, MultiSite(1, 2), 'p')
+    # Syntax error (can't nest MultiState)
+    assert_raises(ValueError, MultiState, MultiState(1, 2), 'p')
 
     # Duplicate sites with multi-bond
-    A(a=MultiSite([1, 2], [1, 2]))
+    A(a=MultiState([1, 2], [1, 2]))
 
 
 @raises(ValueError)
 def test_duplicate_site_single_site():
-    MultiSite('a')
+    MultiState('a')

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -12,11 +12,14 @@ import shutil
 from pysb.logging import get_logger
 
 # Some models don't match BNG originals exactly due to loss of numerical
-# precision.
+# precision. See https://github.com/pysb/pysb/issues/443
 REDUCED_PRECISION = {
     'CaOscillate_Func': 1e-4,
     'michment': 1e-8,
-    'motor': 1e-8
+    'motor': 1e-8,
+    'fceri_ji': 1e-4,
+    'test_paramname': 1e-4,
+    'tlmr': 1e-4
 }
 
 logger = get_logger(__name__)

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -55,13 +55,17 @@ def bngl_import_compare_simulations(bng_file, force=False,
         return
 
     # Check all species trajectories are equal (within numerical tolerance)
-    assert yfull1.dtype.names == yfull2.dtype.names
+    assert len(yfull1.dtype.names) == len(yfull2.dtype.names)
     for species in yfull1.dtype.names:
         logger.debug(species)
         logger.debug(yfull1[species])
-        logger.debug(yfull2[species])
-        assert numpy.allclose(yfull1[species], yfull2[species], atol=precision,
-                              rtol=precision)
+        if species in yfull2.dtype.names:
+            renamed_species = species
+        else:
+            renamed_species = 'Obs_{}'.format(species)
+        logger.debug(yfull2[renamed_species])
+        assert numpy.allclose(yfull1[species], yfull2[renamed_species],
+                              atol=precision, rtol=precision)
 
 
 def _bng_validate_directory():
@@ -110,7 +114,8 @@ def test_bngl_import_expected_passes_no_sim():
                      'hybrid_test',  # Population maps are not converted
                      'tlbr'):
         full_filename = _bngl_location(filename)
-        yield (bngl_import_compare_simulations, full_filename, False, None)
+        yield (bngl_import_compare_simulations, full_filename, False, None,
+               None)
 
 
 def test_bngl_import_expected_passes():
@@ -158,7 +163,7 @@ def test_bngl_import_expected_errors():
                        'heise': errtype['statelabels'],
                        'isingspin_energy': errtype['ratelawmissing'],
                        'isingspin_localfcn': errtype['localfn'],
-                       'localfunc': 'Species \$Trash\(\) is fixed',
+                       'localfunc': errtype['localfn'],
                        'test_MM': errtype['ratelawtype'],
                        'test_sat': errtype['ratelawtype'],
                        }


### PR DESCRIPTION
Duplicate sites are monomer sites with the same name. The following becomes valid PySB with this PR:

    Monomer('A', ['a', 'a'])

One can then reference the sites using a tuple, with one entry
for each of the sites, for example:

    A(a=(1, 2))   # Example 1

Note that this is distinct from multiple bonds to the *same* site:

    A(a=[1,2])    # Example 2

In example 1, there are two sites, each named `A`, one with bond `1`
and one with bond `2`. In example 2, there is one site called `A` with
two bonds, `1` and `2`.

The syntax is similar in both cases so users will have to be careful to
check their syntax matches their use case.

Note that the data types are checked, so that expressing a
(state, bond) tuple is still valid, noting that states must be strings:

    A(a=('p', 1))

Most of the refactoring in this PR in `core.py` is to pull out the
site and state checking logic into separate functions, so that it
can be applied to check each site in a tuple of duplicate sites.
This includes `_handle_site_instance` within `_as_graph`
and `_site_instance_concrete`; these are mostly refactors rather
than new code. Likewise with `_check_bond`, `is_state_bond_tuple`,
and `_check_state_bond_tuple`.

Modifications outside `core.py`:
* `pysb/bng.py` modified to support import of duplicate sites 
from netfiles, and to use the model's name as a file stem (L61-64)
to aid debugging.
* `generator/bng.py` modified to export models with duplicate
sites to BioNetGen. This is straightforward: we just loop
over each duplicate site and export them individually
* `importers/bngl.py` modified to import BNGL models with
duplicate sites. A couple of other modifications have snuck in,
to make unit tests pass on new models with duplicate sites:
  - Model name is now set based on the .bngl filename
to make it more meaningful than just `pysb` (line 43)
  - `ln` (natural log) now supported in BNGL import (line 64)
  - Support for constant expressions import marked as 
`Constant` in BNGXML (lines 178-185)
  - Support for BNG observables with same name as monomers,
which is illegal in PySB (lines 196-199)
* `simulator/bng.py` modified to support using model name's
in the BNG output file
* `pysb/tests/test_core.py` unit tests for duplicate sites
* `pysb/tests/test_importers.py` update import tests
to support duplicate sites

Closes: #59