### PR TITLE
Support for simulation initials, params as DataFrames

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -334,6 +334,10 @@ class Simulator(object):
         if pd and isinstance(new_initials, pd.DataFrame):
             new_initials = new_initials.to_dict(orient='list')
 
+        # If new_initials is a list, convert to numpy array
+        if isinstance(new_initials, list):
+            new_initials = np.array(new_initials, copy=False)
+
         # Check if new_initials is a dict, and if so validate the keys
         # (ComplexPatterns)
         if isinstance(new_initials, dict):
@@ -358,14 +362,7 @@ class Simulator(object):
                 if not np.isfinite(val).all():
                     raise ValueError('Please check initial {} for non-finite '
                                      'values'.format(cplx_pat))
-        else:
-            if not isinstance(new_initials, np.ndarray):
-                if not isinstance(new_initials, list):
-                    raise ValueError(
-                        'Implicit conversion of data type "{}" is not '
-                        'supported. Please supply initials as a numpy array '
-                        'or a pandas DataFrame.'.format(type(new_initials)))
-                new_initials = np.array(new_initials, copy=False)
+        elif isinstance(new_initials, np.ndarray):
             # if new_initials is a 1D array, convert to a 2D array of length 1
             if len(new_initials.shape) == 1:
                 new_initials = np.resize(new_initials, (1, len(new_initials)))
@@ -377,6 +374,11 @@ class Simulator(object):
             if not np.isfinite(new_initials).all():
                 raise ValueError('Please check initials array '
                                  'for non-finite values')
+        else:
+            raise ValueError(
+                'Implicit conversion of data type "{}" is not '
+                'supported. Please supply initials as a numpy array, list, '
+                'or a pandas DataFrame.'.format(type(new_initials)))
 
         if n_sims > 1:
             if not self._supports['multi_initials']:
@@ -465,6 +467,10 @@ class Simulator(object):
         if pd and isinstance(new_params, pd.DataFrame):
             new_params = new_params.to_dict(orient='list')
 
+        # If new_params is a list, convert to numpy array
+        if isinstance(new_params, list):
+            new_params = np.array(new_params)
+
         if isinstance(new_params, dict):
             n_sims = 1
             if len(new_params) > 0:
@@ -481,14 +487,7 @@ class Simulator(object):
                 if len(val) != n_sims:
                     raise ValueError("all arrays in params dictionary "
                                      "must be equal length")
-        else:
-            if not isinstance(new_params, np.ndarray):
-                if not isinstance(new_params, list):
-                    raise ValueError(
-                        'Implicit conversion of data type "{}" is not '
-                        'supported. Please supply parameters as a numpy array '
-                        'or a pandas DataFrame.'.format(type(new_params)))
-                new_params = np.array(new_params)
+        elif isinstance(new_params, np.ndarray):
             # if new_params is a 1D array, convert to a 2D array of length 1
             if len(new_params.shape) == 1:
                 new_params = np.resize(new_params, (1, len(new_params)))
@@ -497,6 +496,11 @@ class Simulator(object):
             if new_params.shape[1] != len(self._model.parameters):
                 raise ValueError("new_params must be the same length as "
                                  "model.parameters")
+        else:
+            raise ValueError(
+                'Implicit conversion of data type "{}" is not '
+                'supported. Please supply parameters as a numpy array, list, '
+                'or a pandas DataFrame.'.format(type(new_params)))
 
         # Check whether simulator supports multiple param_values
         if n_sims > 1 and not self._supports['multi_param_values']:

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -330,6 +330,10 @@ class Simulator(object):
         if new_initials is None:
             return None
 
+        # If new_initials is a pandas dataframe, convert to a dict
+        if pd and isinstance(new_initials, pd.DataFrame):
+            new_initials = new_initials.to_dict(orient='list')
+
         # Check if new_initials is a dict, and if so validate the keys
         # (ComplexPatterns)
         if isinstance(new_initials, dict):
@@ -356,6 +360,11 @@ class Simulator(object):
                                      'values'.format(cplx_pat))
         else:
             if not isinstance(new_initials, np.ndarray):
+                if not isinstance(new_initials, list):
+                    raise ValueError(
+                        'Implicit conversion of data type "{}" is not '
+                        'supported. Please supply initials as a numpy array '
+                        'or a pandas DataFrame.'.format(type(new_initials)))
                 new_initials = np.array(new_initials, copy=False)
             # if new_initials is a 1D array, convert to a 2D array of length 1
             if len(new_initials.shape) == 1:
@@ -451,6 +460,11 @@ class Simulator(object):
     def _process_incoming_params(self, new_params):
         if new_params is None:
             return None
+
+        # Convert pandas dataframe to dictionary
+        if pd and isinstance(new_params, pd.DataFrame):
+            new_params = new_params.to_dict(orient='list')
+
         if isinstance(new_params, dict):
             n_sims = 1
             if len(new_params) > 0:
@@ -469,6 +483,11 @@ class Simulator(object):
                                      "must be equal length")
         else:
             if not isinstance(new_params, np.ndarray):
+                if not isinstance(new_params, list):
+                    raise ValueError(
+                        'Implicit conversion of data type "{}" is not '
+                        'supported. Please supply parameters as a numpy array '
+                        'or a pandas DataFrame.'.format(type(new_params)))
                 new_params = np.array(new_params)
             # if new_params is a 1D array, convert to a 2D array of length 1
             if len(new_params.shape) == 1:


### PR DESCRIPTION
Add support for supplying simulation initial conditions and parameter
values as pandas DataFrames. Previously this was handled by implict
conversion to numpy array, which might lose the column order (i.e.,
initials species or parameters get swapped).

Implicit conversion or simulation initials or param values from anything
other than a list is now disabled, meaning that users must now supply
a DataFrame, numpy array, or list for initials and param_values.

Fixes: #415