### PR TITLE
fix exception when calling expand_obs() on Observable with no coeffs

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1352,8 +1352,7 @@ class Observable(Component, sympy.Symbol):
         """ Expand observables in terms of species and coefficients """
         return sympy.Add(*[a * b for a, b in zip(
             self.coefficients,
-            sympy.symbols(','.join('__s%d' % sp_id for sp_id in
-                                   self.species) + ',')
+            [sympy.Symbol('__s%d' % sp_id) for sp_id in self.species]
         )])
 
     def __repr__(self):

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -148,6 +148,14 @@ def test_observable_constructor_with_monomer():
     o = Observable('o', A, _export=False)
 
 @with_model
+def test_expand_obs_no_coeffs():
+    A = Monomer('A')
+    o = Observable('A_obs', A())
+    # Test that expand_obs works with observable when no coefficients or
+    # species are present
+    o.expand_obs()
+
+@with_model
 def test_compartment_initial_error():
     Monomer('A', ['s'])
     Parameter('A_0', 2.0)


### PR DESCRIPTION
`sympy.symbols(',')` throws a `ValueError`