### PR TITLE
make out of MonomerPattern.__repr__ deterministic

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -548,7 +548,7 @@ class MonomerPattern(object):
         value = '%s(' % self.monomer.name
         value += ', '.join([
                 k + '=' + repr(self.site_conditions[k])
-                for k in self.monomer.sites
+                for k in sorted(self.monomer.sites)
                 if k in self.site_conditions
                 ])
         value += ')'


### PR DESCRIPTION
Especially noticable when exporting models to pysb_flat. Currently, ordering of sites in MonomerPatterns seems to be changing arbitrarily.