### PR TITLE
Documentation fixes for Sphinx

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -144,7 +144,7 @@ Install Docker and the PySB software stack
 
    To use PySB with Docker, first you'll need to install Docker, which can be
    obtained from https://www.docker.com/community-edition#/download (Windows
-    and Mac). Linux users should use their package manager (e.g. ``apt-get``).
+   and Mac). Linux users should use their package manager (e.g. ``apt-get``).
 
 2. **Download the PySB software stack from the Docker Hub**
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1456,7 +1456,7 @@ class Initial(object):
     fixed : bool
         Whether or not the species should be held fixed (never consumed).
 
-    Parameters
+    Attributes
     ----------
     Identical to Parameters (see above).
 


### PR DESCRIPTION
Duplicate `Parameters` section is causing readthedocs to fail.