### PR TITLE
Deprecate ScipyOdeSimulator Theano backend

### DIFF
--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -247,6 +247,12 @@ class ScipyOdeSimulator(Simulator):
                                           + ',') + tuple(model.parameters)
 
             if self._compiler == 'theano':
+                warnings.warn(
+                    "theano backend is deprecated; cython backend is "
+                    "recommended instead",
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
                 if theano is None:
                     raise ImportError('Theano library is not installed')
 


### PR DESCRIPTION
Theano itself is "dead", so we'll remove compiler='theano' support
in a future version of ScipyOdeSimulator.