### PR TITLE
Include StockKit log file in exceptions

### DIFF
--- a/pysb/simulator/stochkit.py
+++ b/pysb/simulator/stochkit.py
@@ -318,8 +318,10 @@ class StochKitSimulator(Simulator):
 
 
 class StochKitSimulatorException(SimulatorException):
-    def __init__(self, *args, stdout=None, stderr=None):
+    def __init__(self, *args, **kwargs):
         super(StochKitSimulatorException, self).__init__(*args)
+        stdout = kwargs.get('stdout')
+        stderr = kwargs.get('stderr')
         log_data = None
         m = re.search(r'Check log file "(.*?)" for error messages', stdout)
         if m:


### PR DESCRIPTION
I've added a custom Exception class, StochKitSimulatorException.

StochKit often has STDOUT messages that include something like:

    Check log file "compile-log.txt" for error messages

The new Exception class parses the log message with a regex,
and attempts to read the log file for inclusion in the error
message. This is helpful since the log file and other temp
files are cleanup up by default.