### PR TITLE
Fix Simulator #sims calculation for NFsim

### DIFF
--- a/pysb/simulator/bng.py
+++ b/pysb/simulator/bng.py
@@ -17,8 +17,11 @@ class BngSimulator(Simulator):
     }
     _SIMULATOR_TYPES = ['ssa', 'nf', 'pla', 'ode']
 
-    def __init__(self, model, tspan=None, cleanup=True, verbose=False):
+    def __init__(self, model, tspan=None, initials=None, param_values=None,
+                 cleanup=True, verbose=False):
         super(BngSimulator, self).__init__(model, tspan=tspan,
+                                           initials=initials,
+                                           param_values=param_values,
                                            verbose=verbose)
         self.cleanup = cleanup
         self._outdir = None

--- a/pysb/tests/test_simulator_bng.py
+++ b/pysb/tests/test_simulator_bng.py
@@ -88,20 +88,68 @@ def test_bng_ode_with_expressions():
     assert len(x.observables) == 50
 
 
-def test_nfsim():
-    model = robertson.model
-    # Reset equations from any previous network generation
-    model.reset_equations()
+class TestNfSim(object):
+    def setUp(self):
+        self.model = robertson.model
+        self.model.reset_equations()
+        self.sim = BngSimulator(self.model, tspan=np.linspace(0, 1))
+        self.param_values_2sets = [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]]
 
-    sim = BngSimulator(model, tspan=np.linspace(0, 1))
-    x = sim.run(n_runs=1, method='nf', seed=_BNG_SEED)
-    observables = np.array(x.observables)
-    assert len(observables) == 50
+    def test_nfsim_2runs(self):
+        x = self.sim.run(n_runs=1, method='nf', seed=_BNG_SEED)
+        observables = np.array(x.observables)
+        assert len(observables) == 50
 
-    A = model.monomers['A']
-    x = sim.run(n_runs=2, method='nf', tspan=np.linspace(0, 1),
-                initials={A(): 100}, seed=_BNG_SEED)
-    assert np.allclose(x.dataframe.loc[0, 0.0], [100.0, 0.0, 0.0])
+        A = self.model.monomers['A']
+        x = self.sim.run(n_runs=2, method='nf', tspan=np.linspace(0, 1),
+                    initials={A(): 100}, seed=_BNG_SEED)
+        assert (x.nsims == 2)
+        assert np.allclose(x.dataframe.loc[0, 0.0], [100.0, 0.0, 0.0])
+
+    def test_nfsim_2initials(self):
+        # Test with two initials
+        A = self.model.monomers['A']
+        x2 = self.sim.run(method='nf', tspan=np.linspace(0, 1),
+                     initials={A(): [100, 200]}, seed=_BNG_SEED)
+        assert x2.nsims == 2
+        assert np.allclose(x2.dataframe.loc[0, 0.0], [100.0, 0.0, 0.0])
+        assert np.allclose(x2.dataframe.loc[1, 0.0], [200.0, 0.0, 0.0])
+
+    def test_nfsim_2params(self):
+        # Test with two param_values
+        x3 = self.sim.run(method='nf', tspan=np.linspace(0, 1),
+                          param_values=self.param_values_2sets, seed=_BNG_SEED)
+        assert x3.nsims == 2
+        assert np.allclose(x3.param_values, self.param_values_2sets)
+
+    def test_nfsim_2initials_2params(self):
+        # Test with two initials and two param_values
+        A = self.model.monomers['A']
+        x = self.sim.run(method='nf',
+                         tspan=np.linspace(0, 1),
+                         initials={A(): [101, 201]},
+                         param_values=[[1, 2, 3, 4, 5, 6],
+                                       [7, 8, 9, 10, 11, 12]],
+                         seed=_BNG_SEED)
+        assert x.nsims == 2
+        assert np.allclose(x.dataframe.loc[0, 0.0], [101.0, 0.0, 0.0])
+
+    @raises(ValueError)
+    def test_nfsim_different_initials_lengths(self):
+        A = self.model.monomers['A']
+        B = self.model.monomers['B']
+
+        sim = BngSimulator(self.model, tspan=np.linspace(0, 1),
+                           initials={B(): [150, 250, 350]})
+        sim.run(initials={A(): [275, 375]})
+
+    @raises(ValueError)
+    def test_nfsim_different_initials_params_lengths(self):
+        A = self.model.monomers['A']
+
+        sim = BngSimulator(self.model, tspan=np.linspace(0, 1),
+                           initials={A(): [150, 250, 350]},
+                           param_values=self.param_values_2sets)
 
 
 def test_hpp():


### PR DESCRIPTION
Network free simulators use initials_dict instead of initials,
as they don't always have a full list of species available.
The Simulator class calculates the number of simulations by
checking the number of initials and parameter sets defined.
With one parameter set and multiple initials defined, only
one NFsim simulation was run (with the first set of initials).

This PR fixes this issue and adds multiple unit tests for NFsim.