### PR TITLE
Fix ModelNotDefinedError

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -2056,8 +2056,7 @@ class CompartmentAlreadySpecifiedError(ValueError):
 class ModelNotDefinedError(RuntimeError):
     """SelfExporter method was called before a model was defined."""
     def __init__(self):
-        ValueError.__init__(
-            self,
+        super(RuntimeError, self).__init__(
             "A Model must be declared before declaring any model components"
         )
 

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -478,3 +478,7 @@ def test_update_initial_condition():
     assert len(model.initials) == 1
     assert as_complex_pattern(B()).is_equivalent_to(
         as_complex_pattern(model.initials[0].pattern))
+
+
+def test_model_not_defined():
+    assert_raises(ModelNotDefinedError, Monomer, 'A')


### PR DESCRIPTION
This error should be raised when self exporter is used and a model
component is declared before Model(). It's broken on
Python 3.7 without this PR:

    TypeError: descriptor '__init__' requires a 'ValueError' object but received a 'ModelNotDefinedError'