### PR TITLE
Local function export fixes, example model

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -782,15 +782,15 @@ def _parse_parameter(model, line):
     _, pname, pval, _, ptype = line.strip().split()
     par_names = model.components.keys()
     if pname not in par_names:
+        # Need to parse the value even for constants, since BNG considers some
+        # expressions to be "Constant", e.g. "2^2"
+        parsed_expr = parse_bngl_expr(pval)
         if ptype == 'Constant' and pname not in model._derived_parameters.keys():
-            # Need to parse the value, since BNG considers some expressions
-            # to be "Constant", e.g. "2^2"
-            p = pysb.core.Parameter(pname, parse_bngl_expr(pval), _export=False)
+            p = pysb.core.Parameter(pname, parsed_expr, _export=False)
             model._derived_parameters.add(p)
         elif ptype == 'ConstantExpression' and \
                 pname not in model._derived_expressions.keys():
-            p = pysb.core.Expression(pname, parse_bngl_expr(pval),
-                                     _export=False)
+            p = pysb.core.Expression(pname, parsed_expr, _export=False)
             model._derived_expressions.add(p)
         else:
             raise ValueError('Unknown type {} for parameter {}'.format(

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -783,7 +783,9 @@ def _parse_parameter(model, line):
     par_names = model.components.keys()
     if pname not in par_names:
         if ptype == 'Constant' and pname not in model._derived_parameters.keys():
-            p = pysb.core.Parameter(pname, pval, _export=False)
+            # Need to parse the value, since BNG considers some expressions
+            # to be "Constant", e.g. "2^2"
+            p = pysb.core.Parameter(pname, parse_bngl_expr(pval), _export=False)
             model._derived_parameters.add(p)
         elif ptype == 'ConstantExpression' and \
                 pname not in model._derived_expressions.keys():

--- a/pysb/examples/localfunc.py
+++ b/pysb/examples/localfunc.py
@@ -1,0 +1,51 @@
+# Based on the BioNetGen model 'localfunc.bngl'
+# https://github.com/RuleWorld/bionetgen/blob/master/bng2/Models2/localfunc.bngl
+#
+# This model demonstrates the use of MultiState and local functions in PySB
+#
+# Requires Python 3.x or greater (will give a SyntaxError on Python 2.7)
+
+from pysb import Model, Monomer, Parameter, Expression, Rule, \
+    Observable, Initial, Tag, MultiState
+
+Model()
+
+Monomer('A', ['b', 'b', 'b'])
+Monomer('B', ['a'])
+Monomer('C')
+
+Parameter('kp', 0.5)
+Parameter('km', 0.1)
+Parameter('k_synthC', 1e3)
+Parameter('k_degrC', 0.5)
+Parameter('Ab_b_b_0', 1.0)
+Parameter('Ba_0', 3.0)
+Parameter('C_0', 0.0)
+
+Observable('Atot', A())
+Observable('Btot', B())
+Observable('Ctot', C())
+Observable('AB0', A(b=MultiState(None, None, None)), match='species')
+Observable('AB1', A(b=MultiState(1, None, None)) % B(a=1), match='species')
+Observable('AB2', A(b=MultiState(1, 2, None)) % B(a=1) % B(a=2),
+           match='species')
+Observable('AB3', A(b=MultiState(1, 2, 3)) % B(a=1) % B(a=2) % B(a=3),
+           match='species')
+Observable('AB_motif', A(b=1) % B(a=1))
+
+Tag('x')
+
+Expression('f_synth', k_synthC * AB_motif(x) ** 2)
+
+# A synthesizes C with rate dependent on bound B
+Rule('_R1', A() @ x >> A() @ x + C(), f_synth)
+
+# A binds B
+Rule('_R2', A(b=None) + B(a=None) | A(b=1) % B(a=1), kp, km)
+
+# degradation of C
+Rule('_R3', C() >> None, k_degrC)
+
+Initial(A(b=MultiState(None, None, None)), Ab_b_b_0)
+Initial(B(a=None), Ba_0)
+Initial(C(), C_0)

--- a/pysb/export/__init__.py
+++ b/pysb/export/__init__.py
@@ -146,6 +146,10 @@ class CompartmentsNotSupported(ExportError, NotImplementedError):
     """ Compartments are not supported by this exporter """
 
 
+class LocalFunctionsNotSupported(ExportError, NotImplementedError):
+    """ Local functions are not supported by this exporter """
+
+
 def export(model, format, docstring=None):
     """Top-level function for exporting a model to a given format.
 

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -10,6 +10,7 @@ from pysb.export import Exporter
 from sympy.printing.mathml import MathMLPrinter
 from sympy import Symbol
 from xml.dom.minidom import Document
+import itertools
 try:
     import libsbml
 except ImportError:
@@ -151,7 +152,11 @@ class SbmlExporter(Exporter):
             _check(c.setConstant(True))
 
         # Expressions
-        for i, expr in enumerate(self.model.expressions):
+        for expr in itertools.chain(
+                self.model.expressions_constant(),
+                self.model.expressions_dynamic(include_local=False),
+                self.model._derived_expressions
+        ):
             # create an observable "parameter"
             e = smodel.createParameter()
             _check(e)
@@ -215,7 +220,8 @@ class SbmlExporter(Exporter):
 
         # Parameters
 
-        for i, param in enumerate(self.model.parameters):
+        for param in itertools.chain(self.model.parameters,
+                                     self.model._derived_parameters):
             p = smodel.createParameter()
             _check(p)
             _check(p.setId(param.name))

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -6,7 +6,7 @@ from sympy.core import S
 import collections
 import re
 import pysb.logging
-from pysb.export import CompartmentsNotSupported
+from pysb.export import CompartmentsNotSupported, LocalFunctionsNotSupported
 # Alias basestring under Python 3 for forwards compatibility
 try:
     basestring
@@ -19,8 +19,11 @@ class KappaGenerator(object):
     # Dialect can be either 'complx' or 'kasim' (default)
     def __init__(self, model, dialect='kasim', _warn_no_ic=True,
                  _exclude_ic_param=False):
-        if model and model.compartments:
-            raise CompartmentsNotSupported()
+        if model:
+            if model.compartments:
+                raise CompartmentsNotSupported()
+            if model.tags:
+                raise LocalFunctionsNotSupported()
         self.model = model
         self.__content = None
         self.dialect = dialect

--- a/pysb/simulator/cupsoda.py
+++ b/pysb/simulator/cupsoda.py
@@ -15,7 +15,7 @@ import shutil
 from pysb.pathfinder import get_path
 import sympy
 import collections
-
+import itertools
 try:
     import pandas as pd
 except ImportError:
@@ -553,6 +553,9 @@ class CupSodaSimulator(Simulator):
             time_max.write(str(float(self.tspan[-1])))
 
     def _get_cmatrix(self):
+        if self.model.tags:
+            raise ValueError('cupSODA does not currently support local '
+                             'functions')
         self._logger.debug("Constructing the c_matrix:")
         c_matrix = np.zeros((len(self.param_values), self._len_rxns))
         par_names = [p.name for p in self._model_parameters_rules]

--- a/pysb/simulator/cupsoda.py
+++ b/pysb/simulator/cupsoda.py
@@ -15,7 +15,6 @@ import shutil
 from pysb.pathfinder import get_path
 import sympy
 import collections
-import itertools
 try:
     import pandas as pd
 except ImportError:

--- a/pysb/tests/test_examples.py
+++ b/pysb/tests/test_examples.py
@@ -3,6 +3,7 @@ from pysb.core import SelfExporter
 import traceback
 import os
 import importlib
+import sys
 
 
 def test_generate_network():
@@ -18,6 +19,11 @@ def get_example_models():
         if filename.endswith('.py') and not filename.startswith('run_') \
                and not filename.startswith('__'):
             modelname = filename[:-3]  # strip .py
+
+            if modelname == 'localfunc' and sys.version_info.major < 3:
+                # Uses __matmul__ for local function, skip it on Python 2.7
+                continue
+
             package = 'pysb.examples.' + modelname
             module = importlib.import_module(package)
             # Reset do_export to the default in case the model changed it.

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -47,6 +47,8 @@ def check_convert(model, format):
         pass
     except export.CompartmentsNotSupported:
         pass
+    except export.LocalFunctionsNotSupported:
+        pass
     except Exception as e:
         # Some example models are deliberately incomplete, so here we
         # will treat any of these "expected" exceptions as a success.


### PR DESCRIPTION
* New `localfunc.py` example model, based on a BioNetGen example model
* Fix export of models with local functions to SBML and StochKit
* Show meaningful error messages when attempting to export models
with local functions to cupSODA or Kappa
* Fix local function parameter reads from BioNetGen when parameter
is actually a constant expression, e.g. `2^2`