### PR TITLE
ReusedBondError when bond binds >2 sites within Complex

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -2514,6 +2514,10 @@ class RedundantSiteConditionsError(ValueError):
 class DanglingBondError(ValueError):
     pass
 
+
+class ReusedBondError(ValueError):
+    pass
+
 # Some light infrastructure for defining symbols that act like "keywords", i.e.
 # they are immutable singletons that stringify to their own name. Regular old
 # classes almost fit the bill, except that their __str__ method prepends the

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -1,6 +1,7 @@
 import collections
 from .core import ComplexPattern, MonomerPattern, Monomer, \
-    ReactionPattern, ANY, as_complex_pattern, DanglingBondError, Rule
+    ReactionPattern, ANY, as_complex_pattern, DanglingBondError, \
+    ReusedBondError, Rule
 import networkx as nx
 from networkx.algorithms.isomorphism.vf2userfunc import GraphMatcher
 from networkx.algorithms.isomorphism import categorical_node_match
@@ -254,6 +255,12 @@ def check_dangling_bonds(pattern):
     if dangling_bonds:
         raise DanglingBondError('Dangling bond(s) {} in {}'
                                 .format(dangling_bonds, pattern))
+
+    reused_bonds = [bond for bond, count in bond_counts.items()
+                    if count > 2]
+    if reused_bonds:
+        raise ReusedBondError('Bond(s) {} used more than twice in pattern '
+                              '{}'.format(reused_bonds, pattern))
 
 
 def _match_graphs(pattern, candidate, exact, count):

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -556,3 +556,12 @@ def test_update_initial_condition():
 
 def test_model_not_defined():
     assert_raises(ModelNotDefinedError, Monomer, 'A')
+
+
+@raises(ReusedBondError)
+@with_model
+def test_bind_multiple():
+    Monomer('A', ['a'])
+    Monomer('B', ['b'])
+
+    as_reaction_pattern(A(a=1) % B(b=1) % B(b=1))


### PR DESCRIPTION
Each bond number can connect at most two sites, otherwise an error occurs in both BNG and Kappa. This PR adds a check for this as part of the dangling bond check, during ReactionPattern instantation. E.g., the following will now generate a `ReusedBondError`:

    as_reaction_pattern(A(a=1) % B(b=1) % B(b=1))

Fixes: #465 