### PR TITLE
JSON model import and export

### DIFF
--- a/pysb/annotation.py
+++ b/pysb/annotation.py
@@ -22,12 +22,12 @@ class Annotation(object):
 
     """
 
-    def __init__(self, subject, object_, predicate="is"):
+    def __init__(self, subject, object_, predicate="is", _export=True):
         self.subject = subject
         self.object = object_
         self.predicate = predicate
         # if SelfExporter is in use, add the annotation to the model
-        if SelfExporter.do_export:
+        if SelfExporter.do_export and _export:
             SelfExporter.default_model.add_annotation(self)
 
     def __repr__(self):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1271,8 +1271,16 @@ class Parameter(Component, sympy.Symbol):
         return (self.name, self.value, False)
 
     def __init__(self, name, value=0.0, _export=True):
-        self.value = float(value)
+        self.value = value
         Component.__init__(self, name, _export)
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self._value = float(new_value)
     
     def get_value(self):
         return self.value

--- a/pysb/examples/bngwiki_egfr_simple.py
+++ b/pysb/examples/bngwiki_egfr_simple.py
@@ -39,7 +39,7 @@ Parameter('deg', 0.01)            # degradation of receptor dimers
 
 
 Monomer('EGF', ['R'])
-Monomer('EGFR', ['L','CR1','Y1068'], {'Y1068':('U','P')})
+Monomer('EGFR', ['L','CR1','Y1068'], {'Y1068': ['U', 'P']})
 Monomer('Grb2', ['SH2','SH3'])
 Monomer('Sos1', ['PxxP'])
 

--- a/pysb/export/__init__.py
+++ b/pysb/export/__init__.py
@@ -17,6 +17,7 @@ contains an instance of ``pysb.core.Model`` instantiated as a global variable).
 
 - ``bngl``
 - ``bng_net``
+- ``json``
 - ``kappa``
 - ``potterswheel``
 - ``sbml``
@@ -24,6 +25,7 @@ contains an instance of ``pysb.core.Model`` instantiated as a global variable).
 - ``pysb_flat``
 - ``mathematica``
 - ``matlab``
+- ``stochkit``
 
 In all cases, the exported model code will be printed to standard
 out, allowing it to be inspected or redirected to another file.
@@ -71,6 +73,7 @@ documentation for the exporter classes in the package :py:mod:`pysb.export`:
    python
    pysb_flat
    stochkit
+   json
 """
 
 import re
@@ -123,6 +126,7 @@ class Exporter(object):
 formats = {
         'bngl': 'BnglExporter',
         'bng_net': 'BngNetExporter',
+        'json': 'JsonExporter',
         'kappa': 'KappaExporter',
         'potterswheel': 'PottersWheelExporter',
         'sbml': 'SbmlExporter',

--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -39,7 +39,7 @@ class JsonExporter(Exporter):
 
 
 class PySBJSONEncoder(json.JSONEncoder):
-    FORMAT = 1
+    PROTOCOL = 1
 
     @classmethod
     def encode_keyword(cls, keyword):
@@ -164,7 +164,7 @@ class PySBJSONEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_model(cls, model):
-        d = dict(format=cls.FORMAT, name=model.name)
+        d = dict(protocol=cls.PROTOCOL, name=model.name)
 
         encoders = {
             'monomers': cls.encode_monomer,

--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -1,0 +1,188 @@
+"""
+Module containing a class for exporting a PySB model to JSON
+
+For information on how to use the model exporters, see the documentation
+for :py:mod:`pysb.export`.
+"""
+
+from __future__ import absolute_import
+from pysb.export import Exporter
+import json
+from pysb.core import Model, MultiState, KeywordMeta
+
+
+class JsonExporter(Exporter):
+    """A class for returning the JSON for a given PySB model.
+
+    Inherits from :py:class:`pysb.export.Exporter`, which implements
+    basic functionality for all exporters.
+    """
+
+    def export(self):
+        """Generate the corresponding JSON for the PySB model associated
+        with the exporter.
+
+        Returns
+        -------
+        string
+            The JSON output for the model.
+        """
+        return json.dumps(self.model, cls=PySBJSONEncoder)
+
+
+class PySBJSONEncoder(json.JSONEncoder):
+    FORMAT = 1
+
+    @classmethod
+    def encode_keyword(cls, keyword):
+        return {'__object__': str(keyword)}
+
+    @classmethod
+    def encode_multistate(cls, stateval):
+        return {
+            '__object__': '__multistate__',
+            'sites': stateval.sites
+        }
+
+    @classmethod
+    def encode_monomer(cls, mon):
+        return {
+            'name': mon.name,
+            'sites': mon.sites,
+            'states': mon.site_states
+        }
+
+    @classmethod
+    def encode_compartment(cls, cpt):
+        return {
+            'name': cpt.name,
+            'parent': cpt.parent.name if cpt.parent else None,
+            'dimension': cpt.dimension,
+            'size': cpt.size.name if cpt.size else None
+        }
+
+    @classmethod
+    def encode_parameter(cls, par):
+        return {
+            'name': par.name,
+            'value': par.value
+        }
+
+    @classmethod
+    def encode_expression(cls, expr):
+        return {
+            'name': expr.name,
+            'expr': str(expr.expr)
+        }
+
+    @classmethod
+    def encode_monomer_pattern(cls, mp):
+        return {
+            'monomer': mp.monomer.name,
+            'site_conditions': mp.site_conditions,
+            'compartment': mp.compartment.name if mp.compartment else None,
+            'tag': mp._tag.name if mp._tag else None
+        }
+
+    @classmethod
+    def encode_complex_pattern(cls, cp):
+        return {
+            'monomer_patterns': [cls.encode_monomer_pattern(mp)
+                                 for mp in cp.monomer_patterns],
+            'compartment': cp.name if cp.compartment else None,
+            'match_once': cp.match_once,
+            'tag': cp._tag.name if cp._tag else None
+        }
+
+    @classmethod
+    def encode_reaction_pattern(cls, rp):
+        return {
+            'complex_patterns': [cls.encode_complex_pattern(cp)
+                                 for cp in rp.complex_patterns]
+        }
+
+    @classmethod
+    def encode_rule_expression(cls, rexp):
+        return {
+            'reactant_pattern': cls.encode_reaction_pattern(
+                rexp.reactant_pattern),
+            'product_pattern': cls.encode_reaction_pattern(
+                rexp.product_pattern),
+            'reversible': rexp.is_reversible
+        }
+
+    @classmethod
+    def encode_rule(cls, r):
+        return {
+            'name': r.name,
+            'rule_expression': cls.encode_rule_expression(r.rule_expression),
+            'rate_forward': r.rate_forward.name,
+            'rate_reverse': r.rate_reverse.name if r.rate_reverse else None,
+            'delete_molecules': r.delete_molecules,
+            'move_connected': r.move_connected
+        }
+
+    @classmethod
+    def encode_observable(cls, obs):
+        return {
+            'name': obs.name,
+            'reaction_pattern': cls.encode_reaction_pattern(
+                obs.reaction_pattern),
+            'match': obs.match
+        }
+
+    @classmethod
+    def encode_initial(cls, init):
+        return {
+            'pattern': cls.encode_complex_pattern(init.pattern),
+            'parameter_or_expression': init.value.name,
+            'fixed': init.fixed
+        }
+
+    @classmethod
+    def encode_annotation(cls, ann):
+        return {
+            'subject': 'model' if isinstance(ann.subject, Model)
+            else ann.subject.name,
+            'object': str(ann.object),
+            'predicate': str(ann.predicate)
+        }
+
+    @classmethod
+    def encode_tag(cls, tag):
+        return {
+            'name': tag.name
+        }
+
+    @classmethod
+    def encode_model(cls, model):
+        d = dict(format=cls.FORMAT, name=model.name)
+
+        encoders = {
+            'monomers': cls.encode_monomer,
+            'compartments': cls.encode_compartment,
+            'tags': cls.encode_tag,
+            'parameters': cls.encode_parameter,
+            'expressions': cls.encode_expression,
+            'rules': cls.encode_rule,
+            'observables': cls.encode_observable,
+            'initials': cls.encode_initial,
+            'annotations': cls.encode_annotation
+        }
+
+        for component_type, encoder in encoders.items():
+            d[component_type] = [encoder(component)
+                                 for component in
+                                 getattr(model, component_type)]
+
+        return d
+
+    def default(self, o):
+        if isinstance(o, Model):
+            return self.encode_model(o)
+        elif isinstance(o, MultiState):
+            return self.encode_multistate(o)
+        elif isinstance(o, KeywordMeta):
+            return self.encode_keyword(o)
+
+        return super(PySBJSONEncoder, self).default(o)

--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -39,6 +39,24 @@ class JsonExporter(Exporter):
 
 
 class PySBJSONEncoder(json.JSONEncoder):
+    """
+    Encode a PySB model in JSON
+
+    This encoder stores the model without caching the reaction network. To also
+    store the reaction network, see :py:class:`PySBJSONWithNetworkEncoder`.
+
+    Attributes correspond to their PySB equivalents (monomers, parameters, etc.)
+    and are mostly stored verbatim, with the following exceptions.
+
+    * MultiStates and the ANY and WILD state values use a special object format
+    * References to other components are stored using the component name
+    * Sympy expressions are encoded as strings using the default encoder
+
+    The protocol number (currently: 1) specifies semantic model compatibility,
+    and should be incremented if new features are added which affect how a model
+    is simulated or prevent a model being loaded by
+    :py:func:`pysb.importers.json.PySBJSONDecoder`.
+    """
     PROTOCOL = 1
 
     @classmethod
@@ -197,6 +215,14 @@ class PySBJSONEncoder(json.JSONEncoder):
 
 
 class PySBJSONWithNetworkEncoder(PySBJSONEncoder):
+    """
+    Encode a PySB model and its reaction network in JSON
+
+    This encoder stores the model including the cached reaction network. To
+    encode the model without the reaction network, see
+    :py:class:`PySBJSONEncoder`, which also includes implementation details.
+    """
+
     @classmethod
     def encode_reaction(cls, rxn):
         rxn = rxn.copy()

--- a/pysb/importers/json.py
+++ b/pysb/importers/json.py
@@ -21,6 +21,11 @@ class PySBJSONDecodeError(ValueError):
 
 
 class PySBJSONDecoder(JSONDecoder):
+    """
+    Decode a JSON-encoded PySB model
+
+    See :py:mod:`pysb.export.json` for implementation details.
+    """
     MAX_SUPPORTED_PROTOCOL = 1
 
     def _modelget(self, name):

--- a/pysb/importers/json.py
+++ b/pysb/importers/json.py
@@ -91,7 +91,7 @@ class PySBJSONDecoder(JSONDecoder):
             )
         else:
             self.b.expression(
-                expr['name'],
+                str(expr['name']),  # Need str() to avoid unicode errors on Py2
                 expression
             )
 

--- a/pysb/importers/json.py
+++ b/pysb/importers/json.py
@@ -21,7 +21,7 @@ class PySBJSONDecodeError(ValueError):
 
 
 class PySBJSONDecoder(JSONDecoder):
-    MAX_SUPPORTED_FORMAT = 1
+    MAX_SUPPORTED_PROTOCOL = 1
 
     def _modelget(self, name):
         if name is None:
@@ -187,20 +187,20 @@ class PySBJSONDecoder(JSONDecoder):
 
         if not isinstance(res, dict):
             raise PySBJSONDecodeError('Decode error (not dictionary)')
-        if 'format' not in res:
+        if 'protocol' not in res:
             raise PySBJSONDecodeError(
-                'No "format" entry found - is this a PySB model?')
-        if not isinstance(res['format'], int):
-            raise PySBJSONDecodeError('"format" attribute is not an integer')
+                'No "protocol" entry found - is this a PySB model?')
+        if not isinstance(res['protocol'], int):
+            raise PySBJSONDecodeError('"protocol" attribute is not an integer')
 
-        if res['format'] < 1:
-            raise PySBJSONDecodeError('"Invalid format value: {}'.format(
-                res['format']))
+        if res['protocol'] < 1:
+            raise PySBJSONDecodeError('"Invalid "protocol" value: {}'.format(
+                res['protocol']))
 
-        if res['format'] > self.MAX_SUPPORTED_FORMAT:
+        if res['protocol'] > self.MAX_SUPPORTED_PROTOCOL:
             raise PySBJSONDecodeError(
-                'Format {} is not supported (max: {})'.format(
-                    res['format'], self.MAX_SUPPORTED_FORMAT
+                'Protocol {} is not supported (max: {})'.format(
+                    res['protocol'], self.MAX_SUPPORTED_PROTOCOL
                 )
             )
 

--- a/pysb/importers/json.py
+++ b/pysb/importers/json.py
@@ -1,0 +1,192 @@
+from __future__ import absolute_import
+from json import JSONDecoder
+from pysb.builder import Builder
+from pysb.core import RuleExpression, ReactionPattern, ComplexPattern, \
+    MonomerPattern, MultiState, ANY, WILD
+from pysb.annotation import Annotation
+import sympy
+import collections
+import json
+import re
+try:
+    basestring
+except NameError:
+    # Python 3 compatibility.
+    basestring = str
+
+
+class PySBJSONDecodeError(ValueError):
+    pass
+
+
+class PySBJSONDecoder(JSONDecoder):
+    MAX_SUPPORTED_FORMAT = 1
+
+    def _modelget(self, name):
+        if name is None:
+            return None
+        if name == 'model':
+            return self.b.model
+
+        return self.b.model.components[name]
+
+    def decode_state_value(self, sv):
+        if isinstance(sv, collections.Mapping) and '__object__' in sv:
+            if sv['__object__'] == '__multistate__':
+                return MultiState(*sv['sites'])
+            if sv['__object__'] == 'ANY':
+                return ANY
+            if sv['__object__'] == 'WILD':
+                return WILD
+        try:
+            if len(sv) == 2 and isinstance(sv[0], basestring) \
+                    and isinstance(sv[1], (int, collections.Mapping)):
+                return sv[0], self.decode_state_value(sv[1])
+        except TypeError:
+            pass
+        return sv
+
+    def decode_monomer(self, mon):
+        self.b.monomer(mon['name'], mon['sites'], mon['states'])
+
+    def decode_parameter(self, par):
+        self.b.parameter(par['name'], par['value'])
+
+    def decode_expression(self, expr):
+        e = expr['expr']
+        # Quick security check on the expression
+        if not re.match(r'^[\w\s()/+\-._*]*$', e):
+            raise PySBJSONDecodeError(
+                'Security check on expression "%s" failed' % expr['name']
+            )
+
+        self.b.expression(
+            expr['name'],
+            sympy.sympify(e, locals={
+                c.name: c for c in self.b.model.components
+            }, evaluate=False)
+        )
+
+    def decode_observable(self, obs):
+        self.b.observable(
+            obs['name'],
+            self.decode_reaction_pattern(obs['reaction_pattern']),
+            obs['match']
+        )
+
+    def decode_monomer_pattern(self, mp):
+        mon = self._modelget(mp['monomer'])
+        mp_obj = MonomerPattern(
+            mon,
+            {site: self.decode_state_value(sv)
+             for site, sv in mp['site_conditions'].items()},
+            self._modelget(mp['compartment'])
+        )
+        mp_obj._tag = self._modelget(mp['tag'])
+        return mp_obj
+
+    def decode_complex_pattern(self, cp):
+        cp_obj = ComplexPattern(
+            [self.decode_monomer_pattern(mp) for mp in cp['monomer_patterns']],
+            self._modelget(cp['compartment']),
+            cp['match_once']
+        )
+        cp_obj._tag = self._modelget(cp['tag'])
+        return cp_obj
+
+    def decode_reaction_pattern(self, rp):
+        return ReactionPattern(
+            [self.decode_complex_pattern(cp) for cp in rp['complex_patterns']]
+        )
+
+    def decode_rule_expression(self, rexp):
+        return RuleExpression(
+            self.decode_reaction_pattern(rexp['reactant_pattern']),
+            self.decode_reaction_pattern(rexp['product_pattern']),
+            rexp['reversible']
+        )
+
+    def decode_rule(self, r):
+        self.b.rule(
+            r['name'],
+            self.decode_rule_expression(r['rule_expression']),
+            self._modelget(r['rate_forward']),
+            self._modelget(r['rate_reverse']),
+            r['delete_molecules'],
+            r['move_connected']
+        )
+
+    def decode_tag(self, tag):
+        self.b.tag(tag['name'])
+
+    def decode_compartment(self, cpt):
+        self.b.compartment(
+            cpt['name'],
+            self._modelget(cpt['parent']),
+            cpt['dimension'],
+            self._modelget(cpt['size'])
+        )
+
+    def decode_initial(self, init):
+        self.b.initial(
+            self.decode_complex_pattern(init['pattern']),
+            self._modelget(init['parameter_or_expression']),
+            init['fixed']
+        )
+
+    def decode_annotation(self, ann):
+        self.b.model.add_annotation(
+            Annotation(
+                self._modelget(ann['subject']),
+                ann['object'],
+                ann['predicate'],
+                _export=False
+            )
+        )
+
+    def decode(self, s):
+        res = super(PySBJSONDecoder, self).decode(s)
+
+        if not isinstance(res, dict):
+            raise PySBJSONDecodeError('Decode error (not dictionary)')
+        if 'format' not in res:
+            raise PySBJSONDecodeError(
+                'No "format" entry found - is this a PySB model?')
+        if not isinstance(res['format'], int):
+            raise PySBJSONDecodeError('"format" attribute is not an integer')
+
+        if res['format'] < 1:
+            raise PySBJSONDecodeError('"Invalid format value: {}'.format(
+                res['format']))
+
+        if res['format'] > self.MAX_SUPPORTED_FORMAT:
+            raise PySBJSONDecodeError(
+                'Format {} is not supported (max: {})'.format(
+                    res['format'], self.MAX_SUPPORTED_FORMAT
+                )
+            )
+
+        self.b = Builder()
+        self.b.model.name = res['name']
+
+        decoders = collections.OrderedDict((
+            ('monomers', self.decode_monomer),
+            ('parameters', self.decode_parameter),
+            ('expressions', self.decode_expression),
+            ('compartments', self.decode_compartment),
+            ('tags', self.decode_tag),
+            ('rules', self.decode_rule),
+            ('observables', self.decode_observable),
+            ('initials', self.decode_initial),
+            ('annotations', self.decode_annotation),
+        ))
+
+        for component_type, decoder in decoders.items():
+            for component in res[component_type]:
+                decoder(component)
+
+        return self.b.model
+
+
+def model_from_json(json_str):
+    return json.loads(json_str, cls=PySBJSONDecoder)

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -1117,7 +1117,7 @@ class SimulationResult(object):
 
         # np.void maps to bytes in HDF5.
         enpickle = lambda obj: np.void(pickle.dumps(obj, -1))
-        model_json = JsonExporter(self._model).export()
+        model_json = JsonExporter(self._model).export(include_netgen=True)
 
         with h5py.File(filename, 'a' if append else 'w-') as hdf:
             # Get or create the group
@@ -1261,7 +1261,6 @@ class SimulationResult(object):
 
             if '_model_json' in grp:
                 model = model_from_json(grp['_model_json'][()])
-                generate_equations(model)
             else:
                 warn('The SimulationResult file uses an old model '
                      'format (pickled). It\'s recommended you re-save '

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -5,15 +5,20 @@ import sympy
 import collections
 import numbers
 from pysb.core import MonomerPattern, ComplexPattern, as_complex_pattern, \
-                      Parameter, Expression, Tag
+                      Parameter, Expression, Model, ComponentSet
 from pysb.logging import get_logger, EXTENDED_DEBUG
 import pickle
+from pysb.export.json import JsonExporter
+from pysb.importers.json import model_from_json
 from pysb import __version__ as PYSB_VERSION
 from datetime import datetime
 import dateutil.parser
 import copy
 from warnings import warn
 from pysb.pattern import SpeciesPatternMatcher
+from pysb.bng import generate_equations
+from contextlib import contextmanager
+import weakref
 try:
     basestring
 except NameError:
@@ -1059,7 +1064,7 @@ class SimulationResult(object):
         multiple SimulationResults for a specific model.
 
         A group is first created in the HDF file root (see group_name
-        argument). Within that group, a dataset "_model" has a pickled
+        argument). Within that group, a dataset "_model" has a JSON
         version of the PySB model. SimulationResult are stored as groups
         within the model group.
 
@@ -1112,15 +1117,22 @@ class SimulationResult(object):
 
         # np.void maps to bytes in HDF5.
         enpickle = lambda obj: np.void(pickle.dumps(obj, -1))
+        model_json = JsonExporter(self._model).export()
 
         with h5py.File(filename, 'a' if append else 'w-') as hdf:
             # Get or create the group
             try:
                 grp = hdf.create_group(group_name)
-                grp.create_dataset('_model', data=enpickle(self._model))
+                grp.create_dataset('_model_json', data=model_json)
+                if '_model' in grp:
+                    raise ValueError()
             except ValueError:
                 grp = hdf[group_name]
-                model = pickle.loads(grp['_model'][()])
+                if '_model_json' in grp:
+                    model = model_from_json(grp['_model_json'][()])
+                else:
+                    with _patch_model_setstate():
+                        model = pickle.loads(grp['_model'][()])
                 if model.name != self._model.name:
                     raise ValueError('SimulationResult model has name "{}", '
                                      'but the model in HDF5 file group "{}" '
@@ -1210,8 +1222,8 @@ class SimulationResult(object):
             grp = hdf[group_name]
 
             if dataset_name is None:
-                datasets = list(grp.keys())
-                datasets.remove('_model')
+                datasets = [k for k in grp.keys() if k not in
+                            ('_model', '_model_json')]
                 if len(datasets) > 1:
                     raise ValueError("dataset_name must be specified when "
                                      "group contains more than one dataset. "
@@ -1247,9 +1259,19 @@ class SimulationResult(object):
             except KeyError:
                 initials = pickle.loads(dset['initials_dict'][()])
 
+            if '_model_json' in grp:
+                model = model_from_json(grp['_model_json'][()])
+                generate_equations(model)
+            else:
+                warn('The SimulationResult file uses an old model '
+                     'format (pickled). It\'s recommended you re-save '
+                     'the SimulationResult to use the new format (JSON).')
+                with _patch_model_setstate():
+                    model = pickle.loads(grp['_model'][()])
+
             simres = cls(
                 simulator=None,
-                model=pickle.loads(grp['_model'][()]),
+                model=model,
                 initials=initials,
                 param_values=np.array(dset['param_values']),
                 tout=np.array(dset['tout']),
@@ -1288,3 +1310,24 @@ def _allow_unicode_recarray():
     except TypeError:
         return False
     return True
+
+
+def _model_setstate_monkey_patch(self, state):
+    """Monkey patch for Model.__setstate__ for restoring from older pickles"""
+
+    # restore the 'model' weakrefs on all components
+    self.__dict__.update(state)
+    # Set "tags" attribute for older, pickled models
+    self.__dict__.setdefault('tags', ComponentSet())
+    for c in self.all_components():
+        c.model = weakref.ref(self)
+
+
+@contextmanager
+def _patch_model_setstate():
+    old_setstate = Model.__setstate__
+    Model.__setstate__ = _model_setstate_monkey_patch
+    try:
+        yield
+    finally:
+        Model.__setstate__ = old_setstate

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -1,5 +1,5 @@
 from nose.tools import *
-from pysb.core import Model, SelfExporter
+from pysb.core import Model, SelfExporter, Parameter
 import pickle
 
 def with_model(func):

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -19,6 +19,7 @@ except ImportError:
     roadrunner = None
 from nose.plugins.skip import SkipTest
 from pysb.importers.json import model_from_json
+from pysb.testing import check_model_against_component_list
 
 
 # Pairs of model, format that are expected to be incompatible.
@@ -113,6 +114,7 @@ def check_convert(model, format):
             if model.name not in ('pysb.examples.tutorial_b',
                                   'pysb.examples.tutorial_c'):
                 ScipyOdeSimulator(m, compiler='cython')
+                check_model_against_component_list(m, model.all_components())
         elif format == 'bngl':
             if model.name.endswith('tutorial_b') or \
                     model.name.endswith('tutorial_c'):

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import tempfile
 import os
+import sys
 try:
     import roadrunner
 except ImportError:
@@ -114,7 +115,11 @@ def check_convert(model, format):
             if model.name not in ('pysb.examples.tutorial_b',
                                   'pysb.examples.tutorial_c'):
                 ScipyOdeSimulator(m, compiler='cython')
-                check_model_against_component_list(m, model.all_components())
+                if sys.version_info.major >= 3:
+                    # Only check on Python 3 to avoid string-to-unicode encoding
+                    # issues
+                    check_model_against_component_list(
+                        m, model.all_components())
         elif format == 'bngl':
             if model.name.endswith('tutorial_b') or \
                     model.name.endswith('tutorial_c'):

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -111,7 +111,7 @@ def check_convert(model, format):
         elif format == 'json':
             # Round-trip the model by re-importing the JSON
             m = model_from_json(exported_file)
-            # Check network generation and single-step integrator
+            # Check network generation and force RHS evaluation
             if model.name not in ('pysb.examples.tutorial_b',
                                   'pysb.examples.tutorial_c'):
                 ScipyOdeSimulator(m, compiler='cython')
@@ -133,7 +133,7 @@ def check_convert(model, format):
 
                 try:
                     m = model_from_bngl(tf.name)
-                    # Generate network, single-step the integrator
+                    # Generate network and force RHS evaluation
                     ScipyOdeSimulator(m, compiler='cython')
                 finally:
                     os.unlink(tf.name)

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     roadrunner = None
 from nose.plugins.skip import SkipTest
+from pysb.importers.json import model_from_json
 
 
 # Pairs of model, format that are expected to be incompatible.
@@ -98,3 +99,6 @@ def check_convert(model, format):
                     print(pd.DataFrame(dict(rr=rr_obs, pysb=py_obs)))
                     raise ValueError('Model {}, observable__o{} "{}" trajectories do not match:'.format(
                         model.name, obs_idx, model.observables[obs_idx].name))
+        elif format == 'json':
+            # Round-trip the model by re-importing the JSON
+            model_from_json(exported_file)

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -101,4 +101,8 @@ def check_convert(model, format):
                         model.name, obs_idx, model.observables[obs_idx].name))
         elif format == 'json':
             # Round-trip the model by re-importing the JSON
-            model_from_json(exported_file)
+            m = model_from_json(exported_file)
+            # Check network generation and single-step integrator
+            if model.name not in ('pysb.examples.tutorial_b',
+                                  'pysb.examples.tutorial_c'):
+                ScipyOdeSimulator(m)

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -6,6 +6,7 @@ Based on code submitted in a PR by @keszybz in pysb/pysb#113
 """
 from pysb.tests.test_examples import get_example_models, expected_exceptions
 from pysb import export
+from pysb.export.json import JsonExporter
 from pysb.simulator import ScipyOdeSimulator
 import numpy as np
 import pandas as pd
@@ -43,7 +44,10 @@ def check_convert(model, format):
     """ Test exporters run without error """
     exported_file = None
     try:
-        exported_file = export.export(model, format)
+        if format == 'json':
+            exported_file = JsonExporter(model).export(include_netgen=True)
+        else:
+            exported_file = export.export(model, format)
     except export.ExpressionsNotSupported:
         pass
     except export.CompartmentsNotSupported:

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -112,7 +112,7 @@ def check_convert(model, format):
             # Check network generation and single-step integrator
             if model.name not in ('pysb.examples.tutorial_b',
                                   'pysb.examples.tutorial_c'):
-                ScipyOdeSimulator(m)
+                ScipyOdeSimulator(m, compiler='cython')
         elif format == 'bngl':
             if model.name.endswith('tutorial_b') or \
                     model.name.endswith('tutorial_c'):
@@ -127,6 +127,6 @@ def check_convert(model, format):
                 try:
                     m = model_from_bngl(tf.name)
                     # Generate network, single-step the integrator
-                    ScipyOdeSimulator(m)
+                    ScipyOdeSimulator(m, compiler='cython')
                 finally:
                     os.unlink(tf.name)


### PR DESCRIPTION
Add JSON model import and export capabilities. JSON
is a text-serializable format, which is good for storing
models within other objects, or for purposes like HTTP
APIs.

SimulationResult.save() now saves models in JSON
rather than pickle.

See discussion on #467 which prompted the need for
a durable and serializable model storage format.