### PR TITLE
Fixes for BNGL importer

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -714,6 +714,11 @@ class ComplexPattern(object):
         if compartment and not isinstance(compartment, Compartment):
             raise Exception("compartment is not a Compartment object")
 
+        # Drop species cpt, if redundant
+        if compartment and len(monomer_patterns) == 1 and \
+                monomer_patterns[0].compartment == compartment:
+            compartment = None
+
         self.monomer_patterns = monomer_patterns
         self.compartment = compartment
         self.match_once = match_once

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -287,9 +287,11 @@ class BngPrinter(StrPrinter):
 
         if_stmt = expr.args[-1][0]
         for pos in range(len(expr.args) - 2, -1, -1):
-            if_stmt = 'if({},{},{})'.format(expr.args[pos][1],
-                                            expr.args[pos][0],
-                                            if_stmt)
+            if_stmt = 'if({},{},{})'.format(
+                self._print(expr.args[pos][1]),
+                self._print(expr.args[pos][0]),
+                self._print(if_stmt)
+            )
 
         return if_stmt
 

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -45,6 +45,7 @@ class BnglBuilder(Builder):
         self._force = force
         self._model_env = {}
         self._renamed_states = collections.defaultdict(dict)
+        self._renamed_observables = {}
         self._log = pysb.logging.get_logger(__name__)
         self._parse_bng_xml()
 
@@ -217,7 +218,9 @@ class BnglBuilder(Builder):
             # Some BNG observables have same name as a monomer, but in PySB
             # these must be unique
             if o_name in self.model.monomers.keys():
+                o_name_old = o_name
                 o_name = 'Obs_{}'.format(o_name)
+                self._renamed_observables[o_name_old] = o_name
             cplx_pats = []
             for mp in o.iterfind(_ns('{0}ListOfPatterns/{0}Pattern')):
                 cpt = self.model.compartments.get(mp.get('compartment'))
@@ -398,8 +401,15 @@ class BnglBuilder(Builder):
                                                           str(ex)))
             # Replace observables now, so they get expanded by .expand_expr()
             # Doing this as part of expr_symbols breaks local functions!
-            expr_val = expr_val.xreplace(
-                {sympy.Symbol(o.name): o for o in self.model.observables})
+            observables = {
+                sympy.Symbol(o.name): o for o in self.model.observables
+            }
+            # Add renamed observables
+            observables.update({
+                sympy.Symbol(obs_old): self.model.observables[obs_new]
+                for obs_old, obs_new in self._renamed_observables.items()
+            })
+            expr_val = expr_val.xreplace(observables)
 
             if isinstance(expr_val, numbers.Number):
                 self.parameter(expr_name, expr_val)


### PR DESCRIPTION
Fixes for importing BNGL models containing the following:

* Expressions referencing observables (ScipyOdeSimulator failure;
  observables don't get expanded by `expand_expr()`)
* Parameters containing ^ (exponentation) (model fails to import)

This PR adds unit tests which round-trips BNGL export for PySB
example models, runs network generation, and single-steps an
integrator. These tests caught the above issues.