### PR TITLE
ValueError if reverse rate specified on irreversible rule

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1390,6 +1390,9 @@ class Rule(Component):
         validate_expr(rate_forward, "forward rate")
         if rule_expression.is_reversible:
             validate_expr(rate_reverse, "reverse rate")
+        elif rate_reverse:
+            raise ValueError('Reverse rate specified, but rule expression is '
+                             'not reversible. Use | instead of >>.')
         self.rule_expression = rule_expression
         self.reactant_pattern = rule_expression.reactant_pattern
         self.product_pattern = rule_expression.product_pattern

--- a/pysb/examples/fricker_2010_apoptosis.py
+++ b/pysb/examples/fricker_2010_apoptosis.py
@@ -47,8 +47,7 @@ Rule('R_L_Binding', L (b=None) + pR (b=None, rf=None) >> L (b=1) % pR (b=1, rf=N
 
 # FADD binds
 Parameter('kf29', 84.4211e-03) #84.4211e-03
-Parameter('kr29', 0)
-Rule('RL_FADD_Binding', pR (b=ANY, rf=None) + FADD (rf=None, fe=None) >> pR (b=ANY, rf=2) % FADD (rf=2, fe=None), kf29,kr29)
+Rule('RL_FADD_Binding', pR (b=ANY, rf=None) + FADD (rf=None, fe=None) >> pR (b=ANY, rf=2) % FADD (rf=2, fe=None), kf29)
 
 #C8 binds to L:R:FADD
 Parameter('kf30', 3.19838e-03) #3.19838e-03

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -565,3 +565,12 @@ def test_bind_multiple():
     Monomer('B', ['b'])
 
     as_reaction_pattern(A(a=1) % B(b=1) % B(b=1))
+
+
+@raises(ValueError)
+@with_model
+def test_reverse_rate_non_reversible_rule():
+    Monomer('A')
+    Parameter('kf', 1)
+    Parameter('kr', 2)
+    Rule('r1', None >> A(), kf, kr)


### PR DESCRIPTION
For example, the following should cause an error, because a reverse
rate has been specified but the rule expression is not reversible:

    Rule('r1', None >> A(), kf, kr)