### PR TITLE
fix usage of super in multiple inheritance of sympy.Symbol

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1265,7 +1265,7 @@ class Parameter(Component, sympy.Symbol):
     """
 
     def __new__(cls, name, value=0.0, _export=True):
-        return super(sympy.Symbol, cls).__new__(cls, name)
+        return super(Parameter, cls).__new__(cls, name)
 
     def __getnewargs__(self):
         return (self.name, self.value, False)
@@ -1545,7 +1545,7 @@ class Observable(Component, sympy.Symbol):
     """
 
     def __new__(cls, name, reaction_pattern, match='molecules', _export=True):
-        return super(sympy.Symbol, cls).__new__(cls, name)
+        return super(Observable, cls).__new__(cls, name)
 
     def __getnewargs__(self):
         return (self.name, self.reaction_pattern, self.match, False)
@@ -1613,7 +1613,7 @@ class Expression(Component, sympy.Symbol):
     """
 
     def __new__(cls, name, expr, _export=True):
-        return super(sympy.Symbol, cls).__new__(cls, name)
+        return super(Expression, cls).__new__(cls, name)
 
     def __getnewargs__(self):
         return (self.name, self.expr, False)
@@ -1685,7 +1685,7 @@ class Expression(Component, sympy.Symbol):
 class Tag(Component, sympy.Symbol):
     """Tag for labelling MonomerPatterns and ComplexPatterns"""
     def __new__(cls, name, _export=True):
-        return super(sympy.Symbol, cls).__new__(cls, name)
+        return super(Tag, cls).__new__(cls, name)
 
     def __getnewargs__(self):
         return self.name, False

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1674,7 +1674,7 @@ class Expression(Component, Symbol):
         return sympy.Function(self.name)(tag)
 
 
-class Tag(Component, sympy.Dummy):
+class Tag(Component, Symbol):
     """Tag for labelling MonomerPatterns and ComplexPatterns"""
     def __new__(cls, name, _export=True):
         return super(Tag, cls).__new__(cls, name)

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -154,7 +154,7 @@ class SelfExporter(object):
 
 
 class Symbol(sympy.Dummy):
-    def __new__(cls, name, value=0.0, _export=True):
+    def __new__(cls, name):
         return super(Symbol, cls).__new__(cls, name)
 
     def _lambdacode(self, printer, **kwargs):

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -153,6 +153,16 @@ class SelfExporter(object):
                              "name '%s'" % obj.name)
 
 
+class Symbol(sympy.Dummy):
+    def __new__(cls, name, value=0.0, _export=True):
+        return super(Symbol, cls).__new__(cls, name)
+
+    def _lambdacode(self, printer, **kwargs):
+        """ custom printer method that ensures that the dummyid is not
+        appended when printing code """
+        return self.name
+
+
 class Component(object):
 
     """
@@ -1243,7 +1253,7 @@ def build_rule_expression(reactant, product, is_reversible):
     return RuleExpression(reactant, product, is_reversible)
 
 
-class Parameter(Component, sympy.Symbol):
+class Parameter(Component, Symbol):
 
     """
     Model component representing a named constant floating point number.
@@ -1284,12 +1294,6 @@ class Parameter(Component, sympy.Symbol):
     
     def get_value(self):
         return self.value
-    
-    # This is needed to make sympy's evalf machinery treat this class like a
-    # Symbol.
-    @property
-    def func(self):
-        return sympy.Symbol
 
     def __repr__(self):
         return  '%s(%s, %s)' % (self.__class__.__name__, repr(self.name), repr(self.value))
@@ -1505,7 +1509,7 @@ def validate_const_expr(obj, description):
 
 
 
-class Observable(Component, sympy.Symbol):
+class Observable(Component, Symbol):
 
     """
     Model component representing a linear combination of species.
@@ -1563,12 +1567,6 @@ class Observable(Component, sympy.Symbol):
         self.species = []
         self.coefficients = []
 
-    # This is needed to make sympy's evalf machinery treat this class like a
-    # Symbol.
-    @property
-    def func(self):
-        return sympy.Symbol
-
     def expand_obs(self):
         """ Expand observables in terms of species and coefficients """
         return sympy.Add(*[a * b for a, b in zip(
@@ -1595,7 +1593,7 @@ class Observable(Component, sympy.Symbol):
         return sympy.Function(self.name)(tag)
 
 
-class Expression(Component, sympy.Symbol):
+class Expression(Component, Symbol):
 
     """
     Model component representing a symbolic expression of other variables.
@@ -1653,12 +1651,6 @@ class Expression(Component, sympy.Symbol):
                 subs[a] = a.get_value()
         return self.expr.xreplace(subs)
 
-    # This is needed to make sympy's evalf machinery treat this class like a
-    # Symbol.
-    @property
-    def func(self):
-        return sympy.Symbol
-
     @property
     def is_local(self):
         return len(self.expr.atoms(Tag)) > 0
@@ -1682,7 +1674,7 @@ class Expression(Component, sympy.Symbol):
         return sympy.Function(self.name)(tag)
 
 
-class Tag(Component, sympy.Symbol):
+class Tag(Component, sympy.Dummy):
     """Tag for labelling MonomerPatterns and ComplexPatterns"""
     def __new__(cls, name, _export=True):
         return super(Tag, cls).__new__(cls, name)

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -295,6 +295,9 @@ class BngPrinter(StrPrinter):
 
         return if_stmt
 
+    def _print_Dummy(self, expr):
+        return expr.name
+
     def _print_Pow(self, expr, rational=False):
         return super(BngPrinter, self)._print_Pow(expr, rational)\
             .replace('**', '^')

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -953,8 +953,8 @@ def drug_binding(drug, d_site, substrate, s_site, t_action, klist):
          Monomer('__t'),
          Parameter('__k_t', 1.0),
          Observable('t', __t()),
-         Expression('kf_expr_drug_substrate', (t > 10)*kf_drug_substrate),
-         Expression('kr_expr_drug_substrate', (t > 10)*kr_drug_substrate),
+         Expression('kf_expr_drug_substrate', kf_drug_substrate*(t > 10)),
+         Expression('kr_expr_drug_substrate', kr_drug_substrate*(t > 10)),
          ])
 
     """

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -928,7 +928,7 @@ class ReactionPatternMatcher(object):
     [Rxn (reversible):
         Reactants: {'__s15': mSmac(b=None), '__s45': AMito(b=None)}
         Products: {'__s47': AMito(b=1) % mSmac(b=1)}
-        Rate: __s15*__s45*kf21 - __s47*kr21
+        Rate: kf21*__s15*__s45 - kr21*__s47
         Rules: [Rule('bind_mSmac_AMito', AMito(b=None) + mSmac(b=None) |
                 AMito(b=1) % mSmac(b=1), kf21, kr21)]]
 
@@ -938,13 +938,13 @@ class ReactionPatternMatcher(object):
     [Rxn (one-way):
         Reactants: {'__s46': AMito(b=1) % mCytoC(b=1)}
         Products: {'__s45': AMito(b=None), '__s48': ACytoC(b=None)}
-        Rate: __s46*kc20
+        Rate: kc20*__s46
         Rules: [Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
                 AMito(b=None) + ACytoC(b=None), kc20)],
      Rxn (one-way):
         Reactants: {'__s47': AMito(b=1) % mSmac(b=1)}
         Products: {'__s45': AMito(b=None), '__s49': ASmac(b=None)}
-        Rate: __s47*kc21
+        Rate: kc21*__s47
         Rules: [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
                 AMito(b=None) + ASmac(b=None), kc21)]]
 
@@ -952,7 +952,7 @@ class ReactionPatternMatcher(object):
     [Rxn (reversible):
         Reactants: {'__s7': XIAP(b=None), '__s51': cSmac(b=None)}
         Products: {'__s53': XIAP(b=1) % cSmac(b=1)}
-        Rate: __s51*__s7*kf28 - __s53*kr28
+        Rate: kf28*__s51*__s7 - kr28*__s53
         Rules: [Rule('inhibit_cSmac_by_XIAP', cSmac(b=None) + XIAP(b=None) |
                 cSmac(b=1) % XIAP(b=1), kf28, kr28)]]
 
@@ -962,7 +962,7 @@ class ReactionPatternMatcher(object):
     [Rxn (one-way):
         Reactants: {'__s47': AMito(b=1) % mSmac(b=1)}
         Products: {'__s45': AMito(b=None), '__s49': ASmac(b=None)}
-        Rate: __s47*kc21
+        Rate: kc21*__s47
         Rules: [Rule('produce_ASmac_via_AMito', AMito(b=1) % mSmac(b=1) >>
                 AMito(b=None) + ASmac(b=None), kc21)]]
 
@@ -971,13 +971,13 @@ class ReactionPatternMatcher(object):
     [Rxn (reversible):
         Reactants: {'__s14': mCytoC(b=None), '__s45': AMito(b=None)}
         Products: {'__s46': AMito(b=1) % mCytoC(b=1)}
-        Rate: __s14*__s45*kf20 - __s46*kr20
+        Rate: kf20*__s14*__s45 - kr20*__s46
         Rules: [Rule('bind_mCytoC_AMito', AMito(b=None) + mCytoC(b=None) |
                 AMito(b=1) % mCytoC(b=1), kf20, kr20)],
      Rxn (one-way):
         Reactants: {'__s46': AMito(b=1) % mCytoC(b=1)}
         Products: {'__s45': AMito(b=None), '__s48': ACytoC(b=None)}
-        Rate: __s46*kc20
+        Rate: kc20*__s46
         Rules: [Rule('produce_ACytoC_via_AMito', AMito(b=1) % mCytoC(b=1) >>
                 AMito(b=None) + ACytoC(b=None), kc20)]]
     """

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -19,7 +19,8 @@ REDUCED_PRECISION = {
     'motor': 1e-8,
     'fceri_ji': 1e-4,
     'test_paramname': 1e-4,
-    'tlmr': 1e-4
+    'tlmr': 1e-4,
+    'Repressilator': 1e-11,
 }
 
 logger = get_logger(__name__)
@@ -67,7 +68,7 @@ def bngl_import_compare_simulations(bng_file, force=False,
             renamed_species = 'Obs_{}'.format(species)
         logger.debug(yfull2[renamed_species])
         assert numpy.allclose(yfull1[species], yfull2[renamed_species],
-                              atol=precision*10, rtol=precision*10)
+                              atol=precision, rtol=precision)
 
 
 def bngl_import_compare_nfsim(bng_file):

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -67,7 +67,7 @@ def bngl_import_compare_simulations(bng_file, force=False,
             renamed_species = 'Obs_{}'.format(species)
         logger.debug(yfull2[renamed_species])
         assert numpy.allclose(yfull1[species], yfull2[renamed_species],
-                              atol=precision, rtol=precision)
+                              atol=precision*10, rtol=precision*10)
 
 
 def bngl_import_compare_nfsim(bng_file):


### PR DESCRIPTION
`super(sympy.Symbol, cls).__new__` calls `sympy.Basic.__new__`, not `sympy.Symbol.__new__`