### PR TITLE
Remove CI testing for Python 2.7, add 3.8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: required
 dist: trusty
 env:
-- PYVER=2.7
 - PYVER=3.6
 - PYVER=3.7
 - PYVER=3.8
@@ -15,7 +14,6 @@ before_install:
 - conda install --yes -c conda-forge python="$PYVER"
     numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
     pydot codecov mock cython
-- if [[ $PYVER == 2.7 ]]; then pip install weave; fi
 - if [[ $PYVER != 3.8 ]]; then conda install --yes -c SBMLTeam python-libsbml; else pip install python-libsbml; fi
 # libroadrunner is not currently available for Python 3.8
 - if [[ $PYVER != 3.8 ]]; then pip install libroadrunner twine; else pip install twine; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 - PYVER=2.7
 - PYVER=3.6
 - PYVER=3.7
+- PYVER=3.8
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda${PYVER:0:1}-latest-Linux-x86_64.sh
     -O miniconda.sh
@@ -15,8 +16,9 @@ before_install:
     numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
     pydot codecov mock cython
 - if [[ $PYVER == 2.7 ]]; then pip install weave; fi
-- conda install --yes -c SBMLTeam python-libsbml
-- pip install libroadrunner twine
+- if [[ $PYVER != 3.8 ]]; then conda install --yes -c SBMLTeam python-libsbml; else pip install python-libsbml; fi
+# libroadrunner is not currently available for Python 3.8
+- if [[ $PYVER != 3.8 ]]; then pip install libroadrunner twine; else pip install twine; fi
 - mkdir -p ~/.config/matplotlib
 - echo "backend:Agg" > ~/.config/matplotlib/matplotlibrc
 # Install BioNetGen, Kappa, StochKit and Atomizer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,14 @@ build: false
 
 environment:
   matrix:
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda-x64
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda36-x64
-
+    - PYTHON_VERSION: 3.7
+      MINICONDA: C:\Miniconda37-x64
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
 install:
-  # https://stackoverflow.com/questions/13596407/errors-while-building-installing-c-module-for-python-2-7
-  - if "%PYTHON_VERSION%"=="2.7" (copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsamd64.bat")
-  - if "%PYTHON_VERSION%"=="2.7" (copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat")
-
   # Issues have been encountered with installing numpy and scipy on
   # AppVeyor e.g.
   # http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/


### PR DESCRIPTION
As per #463 and #414, the next version on PySB will remove Python 2.7 support. This PR removes Python 2.7 testing on Travis and Anaconda. Travis will test on 3.6, 3.7, and 3.8; Appveyor on 3.6 and 3.7 (3.8 not yet available by default on Appveyor).