### PR TITLE
Remove weave and theano from ScipyOdeSimulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - conda install --yes -c conda-forge python="$PYVER"
-    numpy scipy matplotlib sympy nose h5py pexpect pandas theano networkx
+    numpy scipy matplotlib sympy nose h5py pexpect pandas networkx
     pydot codecov mock cython
 - if [[ $PYVER != 3.8 ]]; then conda install --yes -c SBMLTeam python-libsbml; else pip install python-libsbml; fi
 # libroadrunner is not currently available for Python 3.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,7 @@ install:
 
   # Majority of dependencies can be installed with Anaconda
   - conda install -c conda-forge "numpy>=1.14" scipy matplotlib sympy
-    networkx nose h5py pandas theano mkl pydot mock cython
-  - if "%PYTHON_VERSION%"=="2.7" (conda install -c conda-forge weave)
+    networkx nose h5py pandas mkl pydot mock cython
 
   - conda install -c SBMLTeam python-libsbml
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ MOCK_MODULES = [ 'pandas', 'pygraphviz', 'sympy',  'sympy.core', 'sympy.parsing'
                  'sympy.printing', 'sympy.printing.mathml',
                  'sympy.printing.lambdarepr', 'numpy',
                  'scipy', 'scipy.integrate', 'scipy.constants', 'scipy.sparse',
-                 'h5py', 'theano', 'theano.tensor', 'dateutil',
+                 'h5py', 'dateutil',
                  'dateutil.parser', 'networkx', 'networkx.algorithms',
                  'networkx.algorithms.isomorphism',
                  'networkx.algorithms.isomorphism.vf2userfunc',

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -71,16 +71,15 @@ Simulation
 
 * How can I speed up my `ScipyOdeSimulator` simulation?
 
-    **Check the weave library is installed.** `weave` is a Python library
+    **Check the cython library is installed.** `cython` is a Python library
     which converts your system of ordinary differential equations (ODEs) to
     C code, which is faster to execute than pure Python code. You can check
-    if `weave` is installed by trying to import it at the Python prompt::
+    if `cython` is installed by trying to import it at the Python prompt::
 
-        import weave
+        import cython
 
-    If no `ImportError` appears, `weave` is available. Note that `weave` is
-    only available for Python 2. We are working on an alternative for Python
-    3 using `Cython <http://cython.org>`_.
+    If no `ImportError` appears, `cython` is available. Otherwise, you'll
+    need to install it using `pip` or `conda`.
 
     When running large numbers of simulations, consider using the
     `CupSodaSimulator` if you have an NVIDIA graphics card (GPU) available.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -71,18 +71,13 @@ Recommended additional software
 The following software is not required for the basic operation of PySB, but
 provides extra capabilities and features when installed.
 
-* `cython`_ or `weave`_
+* `cython`_
   Cython is a package for compiling Python code into C code on the fly. It
   is used by :class:`pysb.simulator.ScipyOdeSimulator` to greatly improve the
   speed of ODE integration. PySB will detect and use Cython automatically,
   if available. To install with Anaconda, type
   :command:`conda install cython`.
   With pip, type :command:`pip install cython`.
-
-  Weave performs the same job as Cython, and is slightly faster in some
-  circumstances. It is only available on Python 2. To install with Anaconda,
-  type :command:`conda install -c conda-forge weave`. With pip, type
-  :command:`pip install weave`.
 
 * `matplotlib`_
 
@@ -209,4 +204,3 @@ https://hub.docker.com/r/jupyter/scipy-notebook/
 .. _BioNetGen: http://www.bionetgen.org/
 .. _Perl: http://www.perl.org/
 .. _Cython: http://cython.org/
-.. _weave: https://pypi.python.org/pypi/weave

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -1,18 +1,6 @@
 from pysb.simulator.base import Simulator, SimulationResult
 import scipy.integrate
 try:
-    # weave is not available under Python 3.
-    from weave import inline as weave_inline
-    import weave.build_tools
-    import distutils.errors
-except ImportError:
-    weave_inline = None
-try:
-    import theano.tensor
-    from sympy.printing.theanocode import theano_function
-except ImportError:
-    theano = None
-try:
     import Cython
 except ImportError:
     Cython = None
@@ -77,9 +65,8 @@ class ScipyOdeSimulator(Simulator):
         * ``integrator_options``: A dictionary of keyword arguments to
           supply to the integrator. See :func:`scipy.integrate.ode`.
         * ``compiler``: Choice of compiler for ODE system: ``cython``,
-          ``weave`` (Python 2 only), ``theano`` or ``python``. Leave
-          unspecified or equal to None for auto-select (tries weave,
-          then cython, then python). Cython, weave and theano all compile the
+          or ``python``. Leave unspecified or equal to None for auto-select
+          (tries cython, then python). Cython compiles the
           equation system into C code. Python is the slowest but most
           compatible.
         * ``cleanup``: Boolean, `cleanup` argument used for
@@ -177,10 +164,9 @@ class ScipyOdeSimulator(Simulator):
                 self._logger.warning(
                     "This system of ODEs will be evaluated in pure Python. "
                     "This may be slow for large models. We recommend "
-                    "installing a package for compiling the ODEs to C code: "
-                    "'weave' (recommended for Python 2) or "
-                    "'cython' (recommended for Python 3). This warning can "
-                    "be suppressed by specifying compiler='python'.")
+                    "installing the 'cython' package for compiling the ODEs to "
+                    "C code. This warning can be suppressed by specifying "
+                    "compiler='python'.")
             self._logger.debug('Equation mode set to "%s"' % self._compiler)
         else:
             self._compiler = compiler_mode
@@ -190,7 +176,7 @@ class ScipyOdeSimulator(Simulator):
         # Use lambdarepr (Python code) with Cython, otherwise use C code
         eqn_repr = lambdarepr if self._compiler == 'cython' else sympy.ccode
 
-        if self._compiler in ('weave', 'cython'):
+        if self._compiler == 'cython':
             # Prepare the string representations of the RHS equations
 
             code_eqs = '\n'.join(['ydot[%d] = %s;' %
@@ -201,77 +187,31 @@ class ScipyOdeSimulator(Simulator):
             # Allocate ydot here, once.
             ydot = np.zeros(len(self.model.species))
 
-            if self._compiler == 'cython':
-                self._compiler_directives = kwargs.pop(
-                    'cython_directives', self.default_cython_directives
-                )
+            self._compiler_directives = kwargs.pop(
+                'cython_directives', self.default_cython_directives
+            )
 
-                if not Cython:
-                    raise ImportError('Cython library is not installed')
+            if not Cython:
+                raise ImportError('Cython library is not installed')
 
-                rhs = _get_rhs(self._compiler,
-                               code_eqs,
-                               ydot=ydot,
-                               compiler_directives=self._compiler_directives
-                               )
+            rhs = _get_rhs(self._compiler,
+                           code_eqs,
+                           ydot=ydot,
+                           compiler_directives=self._compiler_directives
+                           )
 
-                with _set_cflags_no_warnings(self._logger):
-                    rhs(0.0, self.initials[0], self.param_values[0])
-            else:
-                # Weave
-                self._compiler_directives = []
-                # Inhibit weave C compiler warnings unless log
-                # level <= EXTENDED_DEBUG. Note that since the output goes
-                # straight to stderr rather than via the logging system, the
-                # threshold must be lower than DEBUG or else the Nose
-                # logcapture plugin will cause the warnings to be shown and
-                # tests will fail due to unexpected output.
-                if not self._logger.isEnabledFor(EXTENDED_DEBUG):
-                    self._compiler_directives.append('-w')
-                if not weave_inline:
-                    raise ImportError('Weave library is not installed')
-                for arr_name in ('ydot', 'y', 'p'):
-                    macro = arr_name.upper() + '1'
-                    code_eqs = re.sub(r'\b%s\[(\d+)\]' % arr_name,
-                                      '%s(\\1)' % macro, code_eqs)
-
-                rhs = _get_rhs(self._compiler,
-                               code_eqs,
-                               ydot=ydot,
-                               compiler_directives=self._compiler_directives
-                               )
-
-                # Call rhs once just to trigger the weave C compilation step
-                # while asserting control over distutils logging.
-                with self._patch_distutils_logging:
-                    rhs(0.0, self.initials[0], self.param_values[0])
+            with _set_cflags_no_warnings(self._logger):
+                rhs(0.0, self.initials[0], self.param_values[0])
 
             self._code_eqs = code_eqs
 
-        elif self._compiler in ('theano', 'python'):
+        elif self._compiler == 'python':
             self._symbols = sympy.symbols(','.join('__s%d' % sp_id for sp_id in
                                                    range(len(
                                                        self.model.species)))
                                           + ',') + tuple(model.parameters)
 
-            if self._compiler == 'theano':
-                warnings.warn(
-                    "theano backend is deprecated; cython backend is "
-                    "recommended instead",
-                    category=DeprecationWarning,
-                    stacklevel=2
-                )
-                if theano is None:
-                    raise ImportError('Theano library is not installed')
-
-                self._code_eqs = theano_function(
-                    self._symbols,
-                    [o if not o.is_zero else theano.tensor.zeros(1)
-                     for o in ode_mat],
-                    on_unused_input='ignore'
-                )
-            else:
-                self._code_eqs = (self._symbols, sympy.flatten(ode_mat))
+            self._code_eqs = (self._symbols, sympy.flatten(ode_mat))
         else:
             raise ValueError('Unknown compiler_mode: %s' % self._compiler)
 
@@ -285,21 +225,7 @@ class ScipyOdeSimulator(Simulator):
                                for i in range(len(self._model.species))]
             jac_matrix = ode_mat.jacobian(species_symbols)
 
-            if self._compiler == 'theano':
-                jac_eqs_py = theano_function(
-                    self._symbols,
-                    [j if not j.is_zero else theano.tensor.zeros(1)
-                     for j in jac_matrix],
-                    on_unused_input='ignore'
-                )
-
-                def jac_fn(t, y, p):
-                    jacmat = np.asarray(jac_eqs_py(*itertools.chain(y, p)))
-                    jacmat.shape = (len(self.model.odes),
-                                    len(self.model.species))
-                    return jacmat
-
-            elif self._compiler in ('weave', 'cython'):
+            if self._compiler == 'cython':
                 # Prepare the stringified Jacobian equations.
                 jac_eqs_list = []
                 for i in range(jac_matrix.shape[0]):
@@ -319,36 +245,15 @@ class ScipyOdeSimulator(Simulator):
                 jac = np.zeros(
                     (len(self._model.odes), len(self._model.species)))
 
-                if self._compiler == 'weave':
-                    # Substitute array refs with calls to the JAC1 macro
-                    jac_eqs = re.sub(r'\bjac\[(\d+), (\d+)\]',
-                                     r'JAC2(\1, \2)', jac_eqs)
-                    # Substitute calls to the Y1 and P1 macros
-                    for arr_name in ('y', 'p'):
-                        macro = arr_name.upper() + '1'
-                        jac_eqs = re.sub(r'\b%s\[(\d+)\]' % arr_name,
-                                         '%s(\\1)' % macro, jac_eqs)
+                jac_fn = _get_rhs(
+                    self._compiler,
+                    jac_eqs,
+                    compiler_directives=self._compiler_directives,
+                    jac=jac
+                )
 
-                    jac_fn = _get_rhs(
-                        self._compiler,
-                        jac_eqs,
-                        compiler_directives=self._compiler_directives,
-                        jac=jac
-                    )
-
-                    # Manage distutils logging, as above for rhs.
-                    with self._patch_distutils_logging:
-                        jac_fn(0.0, self.initials[0], self.param_values[0])
-                else:
-                    jac_fn = _get_rhs(
-                        self._compiler,
-                        jac_eqs,
-                        compiler_directives=self._compiler_directives,
-                        jac=jac
-                    )
-
-                    with _set_cflags_no_warnings(self._logger):
-                        jac_fn(0.0, self.initials[0], self.param_values[0])
+                with _set_cflags_no_warnings(self._logger):
+                    jac_fn(0.0, self.initials[0], self.param_values[0])
                 self._jac_eqs = jac_eqs
             else:
                 self._jac_eqs = (self._symbols, jac_matrix, "numpy")
@@ -375,36 +280,6 @@ class ScipyOdeSimulator(Simulator):
     def _patch_distutils_logging(self):
         """Return distutils logging context manager based on our logger."""
         return _patch_distutils_logging(self._logger.logger)
-
-    @classmethod
-    def _test_inline(cls):
-        """
-        Detect whether weave.inline is functional.
-
-        Produces compile warnings, which we suppress by capturing STDERR.
-        """
-        if not hasattr(cls, '_use_inline'):
-            cls._use_inline = False
-            if weave_inline is not None:
-                logger = get_logger(__name__)
-                extra_compile_args = []
-                # See comment in __init__ for why this must be EXTENDED_DEBUG.
-                if not logger.isEnabledFor(EXTENDED_DEBUG):
-                    if os.name == 'posix':
-                        extra_compile_args.append('2>/dev/null')
-                    elif os.name == 'nt':
-                        extra_compile_args.append('2>NUL')
-                try:
-                    with _patch_distutils_logging(logger):
-                        weave_inline('int i=0; i=i;', force=1,
-                                     extra_compile_args=extra_compile_args)
-                    cls._use_inline = True
-                except (weave.build_tools.CompileError,
-                        distutils.errors.CompileError,
-                        ImportError,
-                        ValueError) as e:
-                    if not cls._check_compiler_error(e, 'weave'):
-                        raise
 
     @classmethod
     def _test_cython(cls):
@@ -447,11 +322,6 @@ class ScipyOdeSimulator(Simulator):
     @classmethod
     def _autoselect_compiler(cls):
         """ Auto-select equation backend """
-
-        # Try weave
-        cls._test_inline()
-        if cls._use_inline:
-            return 'weave'
 
         # Try cython
         cls._test_cython()
@@ -621,13 +491,6 @@ def _get_rhs(compiler, code_eqs, ydot=None, jac=None, compiler_directives=None):
             Cython.inline(code_eqs, quiet=True,
                           cython_compiler_directives=compiler_directives)
 
-            return ydot if ydot is not None else jac
-    elif compiler == 'weave':
-        def rhs(t, y, p):
-            # note that the evaluated code sets ydot as a side effect
-            weave_inline(code_eqs, ['ydot' if ydot is not None else 'jac',
-                                    't', 'y', 'p'],
-                         extra_compile_args=compiler_directives)
             return ydot if ydot is not None else jac
     else:
         def rhs(t, y, p):

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -69,7 +69,7 @@ def check_convert(model, format):
     if exported_file is not None:
         if format == 'python':
             # linspace arguments picked to avoid VODE warning
-            exec(exported_file + 'Model().simulate(tspan=numpy.linspace(0,1,501))\n', {'_use_inline': False})
+            exec(exported_file + 'Model().simulate(tspan=numpy.linspace(0,1,501))\n')
         elif format == 'pysb_flat':
             exec(exported_file, {'__name__': model.name})
         elif format == 'sbml':

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -69,7 +69,7 @@ def check_convert(model, format):
     if exported_file is not None:
         if format == 'python':
             # linspace arguments picked to avoid VODE warning
-            exec(exported_file + 'Model().simulate(tspan=numpy.linspace(0,1,501))\n')
+            exec(exported_file + 'Model().simulate(tspan=numpy.linspace(0,1,501))\n', {'numpy': np})
         elif format == 'pysb_flat':
             exec(exported_file, {'__name__': model.name})
         elif format == 'sbml':

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -194,20 +194,6 @@ class TestScipyOdeCompilerTests(TestScipySimulatorBase):
         assert simres.species.shape[0] == self.args['tspan'].shape[0]
         assert np.allclose(self.python_res.dataframe, simres.dataframe)
 
-    def test_theano(self):
-        sim = ScipyOdeSimulator(compiler='theano', **self.args)
-        simres = sim.run()
-        assert simres.species.shape[0] == self.args['tspan'].shape[0]
-        assert np.allclose(self.python_res.dataframe, simres.dataframe)
-
-    @unittest.skipIf(sys.version_info.major >= 3, 'weave not available for '
-                                                  'Python 3')
-    def test_weave(self):
-        sim = ScipyOdeSimulator(compiler='weave', **self.args)
-        simres = sim.run()
-        assert simres.species.shape[0] == self.args['tspan'].shape[0]
-        assert np.allclose(self.python_res.dataframe, simres.dataframe)
-
 
 class TestScipySimulatorSequential(TestScipySimulatorBase):
     def test_sequential_initials(self):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def main():
                             'futures; python_version == "2.7"'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',
-                         'pandas', 'theano>=1.0.4', 'h5py', 'mock', 'cython',
+                         'pandas', 'h5py', 'mock', 'cython',
                          'python-libsbml', 'libroadrunner'],
           cmdclass=cmdclass,
           keywords=['systems', 'biology', 'model', 'rules'],


### PR DESCRIPTION
Remove legacy weave and theano support from ScipyOdeSimulator.
The Python exporter has also been updated to use Cython
rather than weave.