### PR TITLE
remove deprecate python2 try/excepts

### DIFF
--- a/pysb/anneal_mod.py
+++ b/pysb/anneal_mod.py
@@ -3,7 +3,6 @@
 # Bug-fixes and changes by Carlos Lopez 2012
 #
 
-from __future__ import print_function
 import numpy
 from numpy import asarray, tan, exp, ones, squeeze, sign, \
      all, log, sqrt, pi, shape, array, minimum, where

--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -18,20 +18,7 @@ import pysb.pathfinder as pf
 import tokenize
 from pysb.logging import get_logger, EXTENDED_DEBUG
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-try:
-    from future_builtins import zip
-except ImportError:
-    pass
-
-# Alias basestring under Python 3 for forwards compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
+from io import StringIO
 
 
 def set_bng_path(dir):
@@ -116,7 +103,7 @@ class BngBaseInterface(object):
         param :
             An argument to a BNG action call
         """
-        if isinstance(param, basestring):
+        if isinstance(param, str):
             return '"%s"' % param
         elif isinstance(param, bool):
             return 1 if param else 0
@@ -443,7 +430,7 @@ class BngFileInterface(BngBaseInterface):
                 output += self.generator.get_content()
             if reload_netfile:
                 filename = reload_netfile if \
-                    isinstance(reload_netfile, basestring) \
+                    isinstance(reload_netfile, str) \
                     else self.net_filename
                 output += '\n  readFile({file=>"%s",skip_actions=>%d})\n' \
                     % (filename, int(skip_file_actions))
@@ -534,7 +521,7 @@ class BngFileInterface(BngBaseInterface):
             Initial concentration
 
         """
-        if isinstance(cplx_pat, basestring):
+        if isinstance(cplx_pat, str):
             formatted_name = cplx_pat
         else:
             formatted_name = format_complexpattern(

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -9,10 +9,8 @@ import weakref
 import copy
 import itertools
 import sympy
-import numpy as np
 import scipy.sparse
 import networkx as nx
-
 
 from importlib import reload
 

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -13,16 +13,8 @@ import numpy as np
 import scipy.sparse
 import networkx as nx
 
-try:
-    reload
-except NameError:
-    from imp import reload
-try:
-    basestring
-except NameError:
-    # Under Python 3, do not pretend that bytes are a valid string
-    basestring = str
-    long = int
+
+from importlib import reload
 
 
 def MatchOnce(pattern):
@@ -285,7 +277,7 @@ class Monomer(Component):
         # ensure sites is some kind of list (presumably of strings) but not a
         # string itself
         if not isinstance(sites, collections.Iterable) or \
-               isinstance(sites, basestring):
+               isinstance(sites, str):
             raise ValueError("sites must be a list of strings")
 
         # ensure no duplicate sites and validate each site name
@@ -303,7 +295,7 @@ class Monomer(Component):
                              str(unknown_sites))
         # ensure site_states values are all strings
         invalid_sites = [site for (site, states) in site_states.items()
-                         if not all([isinstance(s, basestring)
+                         if not all([isinstance(s, str)
                                      and self._VARIABLE_NAME_REGEX.match(s)
                                      for s in states])]
         if invalid_sites:
@@ -366,7 +358,7 @@ def is_state_bond_tuple(state):
     return (
         isinstance(state, tuple)
         and len(state) == 2
-        and isinstance(state[0], basestring)
+        and isinstance(state[0], str)
         and _check_bond(state[1])
     )
 
@@ -379,7 +371,7 @@ def _check_state_bond_tuple(monomer, site, state):
 def validate_site_value(state, monomer=None, site=None, _in_multistate=False):
     if state is None:
         return True
-    elif isinstance(state, basestring):
+    elif isinstance(state, str):
         if monomer and site:
             if not _check_state(monomer, site, state):
                 return False
@@ -573,7 +565,7 @@ class MonomerPattern(object):
         return True
 
     def _site_instance_concrete(self, site_name, site_val):
-        if isinstance(site_val, basestring):
+        if isinstance(site_val, str):
             site_state = site_val
             site_bond = None
         elif isinstance(site_val, tuple):
@@ -842,7 +834,7 @@ class ComplexPattern(object):
             bond_num = None
             if state_or_bond is WILD:
                 return
-            elif isinstance(state_or_bond, basestring):
+            elif isinstance(state_or_bond, str):
                 state = state_or_bond
             elif is_state_bond_tuple(state_or_bond):
                 state = state_or_bond[0]
@@ -2273,7 +2265,7 @@ class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
         # stringified integer Mapping keys (like "0") are forbidden, but since
         # all Component names must be valid Python identifiers, integers are
         # ruled out anyway.
-        if isinstance(key, (int, long, slice)):
+        if isinstance(key, (int, slice)):
             return self._elements[key]
         else:
             return self._map[key]
@@ -2291,7 +2283,7 @@ class ComponentSet(collections.Set, collections.Mapping, collections.Sequence):
         return self.keys()
 
     def get(self, key, default=None):
-        if isinstance(key, (int, long)):
+        if isinstance(key, int):
             raise ValueError("get is undefined for integer arguments, use []"
                              "instead")
         try:

--- a/pysb/export/__main__.py
+++ b/pysb/export/__main__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import re

--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -5,7 +5,6 @@ For information on how to use the model exporters, see the documentation
 for :py:mod:`pysb.export`.
 """
 
-from __future__ import absolute_import
 from pysb.export import Exporter
 from pysb.bng import generate_equations
 import json

--- a/pysb/export/mathematica.py
+++ b/pysb/export/mathematica.py
@@ -104,10 +104,7 @@ import pysb
 import pysb.bng
 import sympy
 import re
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 from pysb.export import Exporter, ExpressionsNotSupported, \
     CompartmentsNotSupported
 

--- a/pysb/export/matlab.py
+++ b/pysb/export/matlab.py
@@ -167,10 +167,7 @@ import pysb
 import pysb.bng
 import sympy
 import re
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 from pysb.export import Exporter, pad, ExpressionsNotSupported, \
     CompartmentsNotSupported
 

--- a/pysb/export/potterswheel.py
+++ b/pysb/export/potterswheel.py
@@ -63,12 +63,7 @@ import pysb
 import pysb.bng
 import sympy
 import re
-import sys
-import os
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 from pysb.export import Exporter, ExpressionsNotSupported, \
     CompartmentsNotSupported
 

--- a/pysb/export/pysb_flat.py
+++ b/pysb/export/pysb_flat.py
@@ -23,12 +23,8 @@ following line::
 
 """
 
-import pysb
 from pysb.export import Exporter
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 class PysbFlatExporter(Exporter):
     """A class for generating PySB "flat" model source code from a model.

--- a/pysb/export/python.py
+++ b/pysb/export/python.py
@@ -72,10 +72,7 @@ import pysb.bng
 import sympy
 from pysb.export import Exporter, pad, ExpressionsNotSupported, \
     CompartmentsNotSupported
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import re
 
 class PythonExporter(Exporter):

--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -5,12 +5,6 @@ from pysb.core import MultiState
 import sympy
 from sympy.printing import StrPrinter
 
-# Alias basestring under Python 3 for forwards compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
-
 
 class BngGenerator(object):
     def __init__(self, model, additional_initials=None, population_maps=None):
@@ -238,7 +232,7 @@ def format_site_condition(site, state):
     elif isinstance(state, list) and all(isinstance(s, int) for s in state):
         state_code = ''.join('!%d' % s for s in state)
     # state
-    elif isinstance(state, basestring):
+    elif isinstance(state, str):
         state_code = '~' + state
     # state AND single bond
     elif isinstance(state, tuple):

--- a/pysb/generator/kappa.py
+++ b/pysb/generator/kappa.py
@@ -7,11 +7,6 @@ import collections
 import re
 import pysb.logging
 from pysb.export import CompartmentsNotSupported, LocalFunctionsNotSupported
-# Alias basestring under Python 3 for forwards compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
 
 
 class KappaGenerator(object):
@@ -210,7 +205,7 @@ class KappaGenerator(object):
         elif isinstance(state, pysb.MultiState):
             raise KappaException("Kappa generator does not support MultiStates")
         # Site with state
-        elif isinstance(state, basestring):
+        elif isinstance(state, str):
             state_code = '{%s}[.]' % state
         # Site with state and a bond
         elif isinstance(state, tuple):

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -5,7 +5,6 @@ from pysb.bng import BngFileInterface, parse_bngl_expr
 import xml.etree.ElementTree
 import re
 import sympy
-from sympy.parsing.sympy_parser import parse_expr
 import warnings
 import pysb.logging
 import collections

--- a/pysb/importers/json.py
+++ b/pysb/importers/json.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from json import JSONDecoder
 from pysb.builder import Builder
 from pysb.core import RuleExpression, ReactionPattern, ComplexPattern, \
@@ -9,11 +8,6 @@ import collections
 import json
 import re
 from sympy.parsing.sympy_parser import parse_expr
-try:
-    basestring
-except NameError:
-    # Python 3 compatibility.
-    basestring = str
 
 
 class PySBJSONDecodeError(ValueError):
@@ -45,7 +39,7 @@ class PySBJSONDecoder(JSONDecoder):
             if sv['__object__'] == 'WILD':
                 return WILD
         try:
-            if len(sv) == 2 and isinstance(sv[0], basestring) \
+            if len(sv) == 2 and isinstance(sv[0], str) \
                     and isinstance(sv[1], (int, collections.Mapping)):
                 return sv[0], self.decode_state_value(sv[1])
         except TypeError:

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -1,4 +1,3 @@
-from __future__ import print_function as _
 from pysb.importers.bngl import model_from_bngl
 import pysb.pathfinder as pf
 import subprocess
@@ -6,12 +5,7 @@ import os
 import tempfile
 import shutil
 import re
-try:
-    # Python 3
-    from urllib.request import urlretrieve
-except ImportError:
-    # Python 2
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 from pysb.logging import get_logger, EXTENDED_DEBUG
 
 BIOMODELS_REGEX = re.compile(r'(BIOMD|MODEL)[0-9]{10}')

--- a/pysb/kappa.py
+++ b/pysb/kappa.py
@@ -11,7 +11,6 @@ specified in one of three ways:
   runtime
 """
 
-from __future__ import print_function as _
 import pysb.pathfinder as pf
 from pysb.generator.kappa import KappaGenerator
 import os
@@ -24,11 +23,6 @@ import warnings
 from collections import namedtuple
 from pysb.util import read_dot
 import pysb.logging
-
-try:
-    from future_builtins import zip
-except ImportError:
-    pass
 
 logger = pysb.logging.get_logger(__name__)
 

--- a/pysb/logging.py
+++ b/pysb/logging.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import platform
 import socket

--- a/pysb/macros.py
+++ b/pysb/macros.py
@@ -33,10 +33,8 @@ pattern, which can be harder for the caller to debug.
 """
 
 
-import inspect
 from pysb import *
-import pysb.core
-from pysb.core import ComponentSet, as_reaction_pattern, as_complex_pattern, MonomerPattern, ComplexPattern
+from pysb.core import ComponentSet, as_complex_pattern, MonomerPattern, ComplexPattern
 import numbers
 import functools
 import itertools

--- a/pysb/pathfinder.py
+++ b/pysb/pathfinder.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import sysconfig
 
 # Set to False to not utilize the system PATH environment variable

--- a/pysb/pattern.py
+++ b/pysb/pattern.py
@@ -8,11 +8,6 @@ from networkx.algorithms.isomorphism import categorical_node_match
 import numpy as np
 from abc import ABCMeta, abstractmethod
 import re
-try:
-    basestring
-except NameError:
-    # Under Python 3, do not pretend that bytes are a valid string
-    basestring = str
 
 
 class FilterPredicate(object):
@@ -190,7 +185,7 @@ def get_half_bonds_in_pattern(pat):
         for sc in mp.site_conditions.values():
             if isinstance(sc, int):
                 bonds_used.append(sc)
-            elif not isinstance(sc, basestring) and \
+            elif not isinstance(sc, str) and \
                     isinstance(sc, collections.Iterable):
                 [bonds_used.append(b) for b in sc if isinstance(b, int)]
 

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -16,14 +16,8 @@ import dateutil.parser
 import copy
 from warnings import warn
 from pysb.pattern import SpeciesPatternMatcher
-from pysb.bng import generate_equations
 from contextlib import contextmanager
 import weakref
-try:
-    basestring
-except NameError:
-    # Python 3 compatibility.
-    basestring = str
 
 try:
     import pandas as pd
@@ -1176,7 +1170,7 @@ class SimulationResult(object):
             for attr_name, attr_val in self.custom_attrs.items():
                 # Pass HDF5-native values straight through, pickling others.
                 if (not (isinstance(attr_val,
-                                    (basestring, bytes, float, complex))
+                                    (str, bytes, float, complex))
                          or (isinstance(attr_val, numbers.Integral)
                              and int_min <= attr_val <= int_max))):
                     attr_val = enpickle(attr_val)

--- a/pysb/simulator/cupsoda.py
+++ b/pysb/simulator/cupsoda.py
@@ -1,4 +1,3 @@
-from __future__ import print_function as _
 from pysb.simulator.base import Simulator, SimulatorException, SimulationResult
 import pysb
 import pysb.bng

--- a/pysb/testing/__init__.py
+++ b/pysb/testing/__init__.py
@@ -1,5 +1,5 @@
 from nose.tools import *
-from pysb.core import Model, SelfExporter, Parameter
+from pysb.core import Model, SelfExporter
 import pickle
 
 def with_model(func):

--- a/pysb/testing/modeltests.py
+++ b/pysb/testing/modeltests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pysb
 import abc
 from pysb.core import SelfExporter

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -3,7 +3,6 @@ from pysb.core import *
 from functools import partial
 from nose.tools import assert_raises
 import operator
-import unittest
 
 
 @with_model

--- a/pysb/tests/test_integrate.py
+++ b/pysb/tests/test_integrate.py
@@ -1,5 +1,5 @@
 from pysb.testing import *
-from pysb.integrate import odesolve, Solver
+from pysb.integrate import Solver
 import numpy as np
 from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.bng import run_ssa

--- a/pysb/tests/test_simulator_bng.py
+++ b/pysb/tests/test_simulator_bng.py
@@ -3,7 +3,7 @@ import numpy as np
 from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.simulator.bng import BngSimulator, PopulationMap
 from pysb.bng import generate_equations
-from pysb.examples import robertson, expression_observables, earm_1_0
+from pysb.examples import robertson, expression_observables
 
 _BNG_SEED = 123
 

--- a/pysb/tools/render_reactions.py
+++ b/pysb/tools/render_reactions.py
@@ -55,7 +55,6 @@ as a "modifier" (enzyme or catalyst).
 
 """
 
-from __future__ import print_function
 import pysb
 import pysb.bng
 import re

--- a/pysb/tools/render_species.py
+++ b/pysb/tools/render_species.py
@@ -23,7 +23,6 @@ Note that some PDF viewers will auto-reload a changed PDF, so you may not even
 need to manually reopen it every time you rerun the tool.
 """
 
-from __future__ import print_function
 import sys
 import os
 import re
@@ -33,11 +32,6 @@ except ImportError:
     pygraphviz = None
 import pysb.bng
 
-# Alias basestring under Python 3 for forwards compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
 
 def run(model):
     """
@@ -84,7 +78,7 @@ def render_species_as_dot(species_list, graph_name=""):
             for site in mp.monomer.sites:
                 site_state = None
                 cond = mp.site_conditions[site]
-                if isinstance(cond, basestring):
+                if isinstance(cond, str):
                     site_state = cond
                 elif isinstance(cond, tuple):
                     site_state = cond[0]

--- a/pysb/tools/species_graph.py
+++ b/pysb/tools/species_graph.py
@@ -27,7 +27,6 @@ need to manually reopen it every time you rerun the tool.
 
 """
 
-from __future__ import print_function
 import pysb
 import pysb.bng
 import re

--- a/pysb/util.py
+++ b/pysb/util.py
@@ -1,15 +1,9 @@
-from __future__ import print_function as _
 from pysb import ComponentSet
 import pysb.core
 import inspect
 import numpy
 import io
 import networkx as nx
-try:
-    basestring
-except NameError:
-    basestring = str
-
 __all__ = ['alias_model_components', 'rules_using_parameter', 'read_dot']
 
 
@@ -189,13 +183,13 @@ def _from_pydot(P):
         s = []
         d = []
 
-        if isinstance(u, basestring):
+        if isinstance(u, str):
             s.append(u.strip('"'))
         else:
             for unodes in u['nodes']:
                 s.append(unodes.strip('"'))
 
-        if isinstance(v, basestring):
+        if isinstance(v, str):
             d.append(v.strip('"'))
         else:
             for vnodes in v['nodes']:


### PR DESCRIPTION
- replaces python2 `basestring` with `str`
- replace python2 `long` with `int`
- removes `__future__` imports
- removes python2 import of `StringIO` from `cStringIO`
- removes a couple of stale imports statements