### PR TITLE
Faster SimulationResult loading: use slices

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -1237,10 +1237,10 @@ class SimulationResult(object):
             obs_and_exprs = None
 
             if 'observables' in dset.keys():
-                obs_and_exprs = list(dset['observables'])
+                obs_and_exprs = list(dset['observables'][:])
 
             if 'expressions' in dset.keys():
-                exprs = dset['expressions']
+                exprs = dset['expressions'][:]
                 if obs_and_exprs is None:
                     obs_and_exprs = list(exprs)
                 else:
@@ -1275,7 +1275,7 @@ class SimulationResult(object):
                 model=model,
                 initials=initials,
                 param_values=dset['param_values'][:],
-                tout=np.array(dset['tout']),
+                tout=dset['tout'][:],
                 trajectories=trajectories,
                 observables_and_expressions=obs_and_exprs,
                 squeeze=dset.attrs['squeeze'],

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -1252,12 +1252,12 @@ class SimulationResult(object):
 
             trajectories = None
             try:
-                trajectories = dset['trajectories']
+                trajectories = dset['trajectories'][:]
             except KeyError:
                 pass
 
             try:
-                initials = np.array(dset['initials'])
+                initials = dset['initials'][:]
             except KeyError:
                 initials = pickle.loads(dset['initials_dict'][()])
 
@@ -1274,7 +1274,7 @@ class SimulationResult(object):
                 simulator=None,
                 model=model,
                 initials=initials,
-                param_values=np.array(dset['param_values']),
+                param_values=dset['param_values'][:],
                 tout=np.array(dset['tout']),
                 trajectories=trajectories,
                 observables_and_expressions=obs_and_exprs,


### PR DESCRIPTION
According to [h5py](https://h5py.readthedocs.io/en/stable/high/dataset.html#reading-writing-data):  Slice specifications are translated directly to HDF5 “hyperslab” selections, and are a fast and efficient way to access data in the file.

PySB currently passes the `trajectories` h5py Dataset object to the `SimulationResult` object. Then, it iterates over the trajectories. This iteration is slow because it uses the Dataset` __iter__` method. If we access the data first (which it already returns a numpy.array) and iterate over these objects, loading the simulations become faster.

Some benchmarks:

```python
from pysb.simulator import SimulationResult, ScipyOdeSimulator
from pysb.examples.tyson_oscillator import model
import numpy as np

tspan = np.linspace(0, 100, 100)
pars = np.array([p.value for p in model.parameters])
all_pars_10000 = np.tile(pars, (10000, 1))
simulation = ScipyOdeSimulator(model, tspan).run(param_values=all_pars_10000, num_processors=4)
simulation.save('tyson_sims.h5')


def load_function():
    sim = SimulationResult.load('tyson_sims.h5')

if __name__ == '__main__':
    from timeit import Timer
    t1 = Timer("load_function()", "from __main__ import load_function")
    print('Loading sim with 10000 pars            : ', t1.timeit(1))
```
**Results on a Mac**

Slicing Datasets:
Loading sim with 10000 pars            :  1.49567398900035

Current PySB approach:
Loading sim with 10000 pars            :  53.9273291490008
