### PR TITLE
Implement BNG boolean treatment within expressions

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 import pysb.pathfinder as pf
 import tokenize
 from pysb.logging import get_logger, EXTENDED_DEBUG
-from sympy.logic.boolalg import BooleanTrue, BooleanFalse
+from sympy.logic.boolalg import BooleanTrue, BooleanFalse, BooleanAtom
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -944,13 +944,17 @@ def parse_bngl_expr(text, *args, **kwargs):
         + (sympy_parser.convert_equals_signs, _convert_tokens)
     )
     # BNG treats True and 1, False as 0 within expressions. Patch this...
-    orig_true, orig_false = BooleanTrue.__mul__, BooleanFalse.__mul__
     BooleanTrue.__mul__ = lambda self, other: 1 * other
     BooleanFalse.__mul__ = lambda self, other: 0 * other
+    BooleanTrue.__rmul__ = BooleanTrue.__mul__
+    BooleanFalse.__rmul__ = BooleanTrue.__mul__
     try:
         expr = sympy_parser.parse_expr(text, *args, transformations=trans, **kwargs)
     finally:
-        BooleanTrue.__mul__, BooleanFalse.__mul__ = orig_true, orig_false
+        BooleanTrue.__mul__ = BooleanAtom._noop
+        BooleanFalse.__mul__ = BooleanAtom._noop
+        BooleanTrue.__rmul__ = BooleanAtom._noop
+        BooleanFalse.__rmul__ = BooleanAtom._noop
     # Transforming 'if' to Piecewise requires subexpression rearrangement, so we
     # use sympy's replace functionality rather than attempt it using text
     # replacements above.

--- a/pysb/importers/bngl.py
+++ b/pysb/importers/bngl.py
@@ -67,8 +67,7 @@ class BnglBuilder(Builder):
 
         # Quick security check on the expression
         if re.match(r'^[\w\s()/+\-._*^]*$', expression):
-            return parse_bngl_expr(expression, local_dict=self._model_env,
-                                   evaluate=False)
+            return parse_bngl_expr(expression, local_dict=self._model_env)
         else:
             self._warn_or_except('Security check on expression "%s" failed' %
                                  expression)

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -333,3 +333,4 @@ def test_parse_bngl_expression_and_or_equals():
 
 def test_bng_boolean_multiply_number():
     assert parse_bngl_expr('(2 > 1) * 4') == 4
+    assert parse_bngl_expr('4 * (2 > 1)') == 4

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -329,3 +329,7 @@ def test_parse_bngl_expression_and_or_equals():
     assert parse_bngl_expr('x and y') == sympy.And(x, y)
     assert parse_bngl_expr('x or y') == sympy.Or(x, y)
     assert parse_bngl_expr('x == y') == sympy.Eq(x, y)
+
+
+def test_bng_boolean_multiply_number():
+    assert parse_bngl_expr('(2 > 1) * 4') == 4


### PR DESCRIPTION
BNG treats booleans as integers within expressions (1=True,
0=False), so an expression like `(2 > 1) * 4` will get evaluated
to `4`. Sometimes these expressions get produced by BNG
local functions and may be present in other imported models as
well. However, doesn't implement multiplication of
BooleanAtoms, which causes a TypeError.

This PR implements the BNG style behaviour on import by
patching BooleanTrue.__mul__ and BooleanFalse.__mul__.
Not very elegant, but it works.