### PR TITLE
Fix eqn_mode='python' with local fxns

### DIFF
--- a/pysb/bng.py
+++ b/pysb/bng.py
@@ -785,7 +785,8 @@ def _parse_parameter(model, line):
     if pname not in par_names:
         # Need to parse the value even for constants, since BNG considers some
         # expressions to be "Constant", e.g. "2^2"
-        parsed_expr = parse_bngl_expr(pval)
+        parsed_expr = parse_bngl_expr(pval, local_dict={
+            e.name: e for e in model.parameters | model.expressions})
         if ptype == 'Constant' and pname not in model._derived_parameters.keys():
             p = pysb.core.Parameter(pname, parsed_expr, _export=False)
             model._derived_parameters.add(p)

--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1682,8 +1682,12 @@ class Expression(Component, Symbol):
         return sorted(self.expr.atoms(Tag), key=lambda tag: tag.name)
 
     def __repr__(self):
+        if isinstance(self.expr, (Parameter, Expression)):
+            expr_repr = self.expr.name
+        else:
+            expr_repr = repr(self.expr)
         ret = '%s(%s, %s)' % (self.__class__.__name__, repr(self.name),
-                              repr(self.expr))
+                              expr_repr)
         return ret
 
     def __str__(self):

--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -98,7 +98,8 @@ class PySBJSONEncoder(json.JSONEncoder):
     def encode_expression(cls, expr):
         return {
             'name': expr.name,
-            'expr': str(expr.expr)
+            'expr': expr.expr.name if isinstance(
+                expr.expr, (Parameter, Expression)) else str(expr.expr)
         }
 
     @classmethod

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -4,7 +4,7 @@ import copy
 import numpy as np
 from pysb import Monomer, Parameter, Initial, Observable, Rule, Expression
 from pysb.simulator import ScipyOdeSimulator, InconsistentParameterError
-from pysb.examples import robertson, earm_1_0, tyson_oscillator
+from pysb.examples import robertson, earm_1_0, tyson_oscillator, localfunc
 import unittest
 import pandas as pd
 
@@ -507,3 +507,8 @@ def test_multiprocessing_lambdify():
         model, tspan=tspan, compiler='python',
         use_analytic_jacobian=True
     ).run(param_values=[pars, pars], num_processors=2)
+
+
+def test_lambdify_localfunc():
+    model = localfunc.model
+    ScipyOdeSimulator(model, tspan=range(100), compiler='python').run()


### PR DESCRIPTION
Fixes an issue when a model with local functions is used
with the ScipyOdeSimulator eqn_mode='python'. Lambdify would
show a NameError and wouldn't pick up model parameters, due to
those not being referenced when local functions are read back
in from BNG during network generation.

Includes a unit test as an example.

**Also:** I had to fix a second issue to get tests to pass:

PySB currently prints expressions consisting of one
parameter or expression like so:

    Expression('e', Parameter('p', 1.0))

Whereas, for consistency, export etc., it should be:

    Expression('e', p)