### PR TITLE
Implement reversible synthesis rules

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -649,6 +649,9 @@ class MonomerPattern(object):
     def __or__(self, other):
         return build_rule_expression(self, other, True)
 
+    def __ror__(self, other):
+        return build_rule_expression(other, self, True)
+
     def __ne__(self, other):
         warnings.warn("'<>' for reversible rules will be removed in a future "
                       "version of PySB. Use '|' instead.",
@@ -1056,6 +1059,9 @@ class ComplexPattern(object):
 
     def __or__(self, other):
         return build_rule_expression(self, other, True)
+
+    def __ror__(self, other):
+        return build_rule_expression(other, self, True)
 
     def __ne__(self, other):
         warnings.warn("'<>' for reversible rules will be removed in a future "

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -613,3 +613,10 @@ def test_parameter_negative_nonnegative_setter():
     Parameter('k3', 0.0, nonnegative=True)
     k3.value = -0.2
 
+
+@with_model
+def test_reversible_synthesis():
+    Monomer('A')
+    Parameter('k', 1)
+    Rule('r1', None | A(), k, k)
+    Rule('r2', None | as_complex_pattern(A()), k, k)


### PR DESCRIPTION
Currently, patterns like `None | A()` are not recognised, although they
work if one reverses the order. This PR fixes reversible synthesis
rules like this, and adds some tests.