### PR TITLE
Add timeout argument to the ScipyOdeSimulation run function

### DIFF
--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -402,10 +402,11 @@ class ScipyOdeSimulator(Simulator):
             results = [executor.submit(sim_partial, *args)
                        for args in zip(self.initials, self.param_values)]
             trajectories = []
-            for r in results:
+            for sim_idx, r in enumerate(results):
                 try:
                     trajectories.append(r.result(timeout=timeout))
-                except TimeoutError as e:
+                except TimeoutError:
+                    self._logger.warning('Simulation %d has timeout' % sim_idx)
                     nan_array = np.empty((len(self.tspan), num_species))
                     nan_array[:] = np.nan
                     trajectories.append(nan_array)

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -175,6 +175,14 @@ class TestScipySimulatorSingle(TestScipySimulatorBase):
     def test_result_dataframe(self):
         df = self.sim.run().dataframe
 
+    def test_simulation_timeout(self):
+        """Test simulation with timeout."""
+        t = np.linspace(0, 20000, 101)
+        # Run with or without inline
+        sim = ScipyOdeSimulator(earm_1_0.model, tspan=t)
+        simres = sim.run(timeout=0.1, num_processors=2).species
+        assert np.all(np.isnan(simres))
+
 
 class TestScipyOdeCompilerTests(TestScipySimulatorBase):
     """Test vode and analytic jacobian with different compiler backends"""


### PR DESCRIPTION
In the Lopez lab we have found out that during model calibration, the fitting algorithm can sample parameters that generate stiff dynamics that take too long to integrate. Thus this PR takes advantage of the concurrent futures implementation to set a timeout for each simulation submitted to the ProcessPoolExecutor