### PR TITLE
Fix observable trajectories on HDF5 load

### DIFF
--- a/pysb/export/json.py
+++ b/pysb/export/json.py
@@ -233,6 +233,13 @@ class PySBJSONWithNetworkEncoder(PySBJSONEncoder):
         return rxn
 
     @classmethod
+    def encode_observable(cls, obs):
+        o = super(PySBJSONWithNetworkEncoder, cls).encode_observable(obs)
+        o['species'] = obs.species
+        o['coefficients'] = obs.coefficients
+        return o
+
+    @classmethod
     def encode_model(cls, model):
         d = super(PySBJSONWithNetworkEncoder, cls).encode_model(model)
 

--- a/pysb/tests/test_exporters.py
+++ b/pysb/tests/test_exporters.py
@@ -120,6 +120,12 @@ def check_convert(model, format):
                     # issues
                     check_model_against_component_list(
                         m, model.all_components())
+                # Check observable generation
+                for obs in model.observables:
+                    assert obs.coefficients == \
+                        m.observables[obs.name].coefficients
+                    assert obs.species == \
+                        m.observables[obs.name].species
         elif format == 'bngl':
             if model.name.endswith('tutorial_b') or \
                     model.name.endswith('tutorial_c'):

--- a/pysb/tests/test_simulationresult.py
+++ b/pysb/tests/test_simulationresult.py
@@ -218,7 +218,7 @@ def _check_resultsets_equal(res1, res2):
         for k, v in res1.initials.items():
             assert np.allclose(res1.initials[k], v)
 
-    assert np.allclose(res1._yobs_view, res1._yobs_view)
+    assert np.allclose(res1._yobs_view, res2._yobs_view)
     if res1._model.expressions_dynamic():
         assert np.allclose(res1._yexpr_view, res2._yexpr_view)
 


### PR DESCRIPTION
When loading a SimulationResult from an HDF5 file using the .load()
method, observables are left as zeroes (if the observables were not
saved with the results using the include_obs_exprs=True argument).

The issue is due to the fact that Observable species and coefficients
are not saved in the JSON representation, despite the
include_netgen=True argument. This was missed due to a typo in the
SimulationResult unit tests, also fixed here.

This PR addresses the issue by calculating the Observable species
and coefficients using PySB's built-in pattern matching during
the JSON import process. This approach allows existing HDF5 files
to be used without resaving.