### PR TITLE
fix typehints PEP0484

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -323,9 +323,9 @@ class Monomer(Component):
 
         Parameters
         ----------
-        conditions : dict, optional
+        conditions: dict, optional
             See MonomerPattern.site_conditions.
-        **kwargs : dict
+        **kwargs: Union[None, int, str, Tuple[str,int], MultiSite, List[int]]
             See MonomerPattern.site_conditions.
 
         """


### PR DESCRIPTION
see https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values