### PR TITLE
Allow constant expressions for compartment sizes

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1345,9 +1345,10 @@ class Compartment(Component):
     dimension : integer, optional
         The number of spatial dimensions in the compartment, either 2 (i.e. a
         membrane) or 3 (a volume).
-    size : Parameter, optional
-        A parameter object whose value defines the volume or area of the
-        compartment. If not specified, the size will be fixed at 1.0.
+    size : Parameter or Expression, optional
+        A parameter or constant expression object whose value defines the
+        volume or area of the compartment. If not specified, the size will be
+        fixed at 1.0.
 
     Attributes
     ----------
@@ -1372,8 +1373,10 @@ class Compartment(Component):
         if parent != None and isinstance(parent, Compartment) == False:
             raise Exception("parent must be a predefined Compartment or None")
         #FIXME: check for only ONE "None" parent? i.e. only one compartment can have a parent None?
-        if size is not None and not isinstance(size, Parameter):
-            raise Exception("size must be a parameter (or omitted)")
+        if size is not None and not isinstance(size, Parameter) and not \
+                (isinstance(size, Expression) and size.is_constant_expression()):
+            raise Exception("size must be a parameter or a constant expression"
+                            " (or omitted)")
         self.parent = parent
         self.dimension = dimension
         self.size = size

--- a/pysb/tests/test_core.py
+++ b/pysb/tests/test_core.py
@@ -193,6 +193,17 @@ def test_compartment_initial_error():
     Initial(A(s=None)**c2, A_0)
 
 @with_model
+def test_compartment():
+    # Ensure that compartment size can be specified by a parameter,
+    #  a constant expression, or be omitted.
+    Parameter('A', 1.0)
+    Parameter('B', 2.0)
+    Expression('E', A * B)
+    Compartment("C1")
+    Compartment("C2", C1, 2, A)
+    Compartment("C3", C1, 2, E)
+
+@with_model
 def test_monomer_pattern_add_to_none():
     """Ensure that MonomerPattern + None returns a ReactionPattern."""
     Monomer('A', ['s'])
@@ -530,6 +541,13 @@ def test_invalid_parameter():
 @with_model
 def test_invalid_compartment():
     assert_raises(Exception, Compartment, 'c1', 'invalid_parent')
+
+    # Invalid dynamic expression as compartment size
+    Monomer('A')
+    Observable('O', A)
+    Expression('E', O)
+    assert_raises(Exception, Compartment, 'c2', size=E)
+
     assert len(model.compartments) == 0
 
 


### PR DESCRIPTION
Previously, only parameters were allowed for compartment sizes.
This change allows specifying compartment sizes using constant expressions.

Closes pysb/pysb#524