### PR TITLE
Fix BNG code generation for Eq and Ne

### DIFF
--- a/pysb/generator/bng.py
+++ b/pysb/generator/bng.py
@@ -4,6 +4,7 @@ import pysb
 from pysb.core import MultiState
 import sympy
 from sympy.printing import StrPrinter
+from sympy.printing.precedence import precedence
 
 # Alias basestring under Python 3 for forwards compatibility
 try:
@@ -307,6 +308,18 @@ class BngPrinter(StrPrinter):
 
     def _print_Or(self, expr):
         return super(BngPrinter, self)._print_Or(expr).replace('|', '||')
+
+    def _print_Relational(self, expr):
+        if getattr(expr, "rel_op", None) not in {"==", "!=", "<", "<=", ">", ">="}:
+            raise NotImplementedError(
+                "Relational operator not supported: %s" % type(expr).__name__
+            )
+        # Adapted from StrPrinter._print_Relational.
+        return '%s %s %s' % (
+            self.parenthesize(expr.lhs, precedence(expr)),
+            expr.rel_op,
+            self.parenthesize(expr.rhs, precedence(expr)),
+        )
 
     def _print_log(self, expr):
         # BNG doesn't accept "log", only "ln".

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -321,6 +321,13 @@ def test_bng_printer():
     assert _bng_print(x >= y) == 'x >= y'
 
 
+def test_bng_printer_relational_unknown():
+    class NewRelational(sympy.core.relational.Relational):
+        rel_op = "??????????"  # A highly unlikely rel_op for a new subclass.
+    x = sympy.Symbol("x")
+    assert_raises(NotImplementedError, _bng_print, NewRelational(x, x))
+
+
 def test_parse_bngl_expression_if():
     x, y = sympy.symbols('x y')
     assert parse_bngl_expr('if(x>y, 1, 3)') == \

--- a/pysb/tests/test_bng.py
+++ b/pysb/tests/test_bng.py
@@ -312,6 +312,14 @@ def test_bng_printer():
     assert _bng_print(sympy.Min(x, y)) == 'min(x, y)'
     assert _bng_print(sympy.Max(x, y)) == 'max(x, y)'
 
+    # Relational
+    assert _bng_print(sympy.Eq(x, y)) == 'x == y'
+    assert _bng_print(sympy.Ne(x, y)) == 'x != y'
+    assert _bng_print(x < y) == 'x < y'
+    assert _bng_print(x <= y) == 'x <= y'
+    assert _bng_print(x > y) == 'x > y'
+    assert _bng_print(x >= y) == 'x >= y'
+
 
 def test_parse_bngl_expression_if():
     x, y = sympy.symbols('x y')


### PR DESCRIPTION
Previously, Eq generated `Eq(...)` instead of `==`, and similarly for Ne.
This changes them to generate `==` and `!=`, as BNGL (muparser) expects.
The code is copied and simplified from StrPrinter's _print_Relational
implementation.