### PR TITLE
Scipyode simulator refactor

### DIFF
--- a/pysb/core.py
+++ b/pysb/core.py
@@ -1964,6 +1964,10 @@ class Model(object):
     def components(self):
         return self.all_components()
 
+    def parameters_all(self):
+        """Return a ComponentSet of all parameters and derived parameters."""
+        return self.parameters | self._derived_parameters
+
     def parameters_rules(self):
         """Return a ComponentSet of the parameters used in rules."""
         # rate_reverse is None for irreversible rules, so we'll need to filter those out
@@ -1999,16 +2003,21 @@ class Model(object):
         cset_used = (self.parameters_rules() | self.parameters_initial_conditions() |
                      self.parameters_compartments() | self.parameters_expressions())
         return self.parameters - cset_used
-    
-    def expressions_constant(self):
+
+    def expressions_constant(self, include_derived=False):
         """Return a ComponentSet of constant expressions."""
-        cset = ComponentSet(e for e in self.expressions
-                            if e.is_constant_expression())
+        expressions = self.expressions
+        if include_derived:
+            expressions = expressions | self._derived_expressions
+        cset = ComponentSet(e for e in expressions if e.is_constant_expression())
         return cset
 
-    def expressions_dynamic(self, include_local=True):
+    def expressions_dynamic(self, include_local=True, include_derived=False):
         """Return a ComponentSet of non-constant expressions."""
-        cset = self.expressions - self.expressions_constant()
+        expressions = self.expressions
+        if include_derived:
+            expressions = expressions | self._derived_expressions
+        cset = expressions - self.expressions_constant(include_derived)
         if not include_local:
             cset = ComponentSet(e for e in cset if not e.is_local)
         return cset

--- a/pysb/logging.py
+++ b/pysb/logging.py
@@ -191,10 +191,10 @@ def get_logger(logger_name=BASE_LOGGER_NAME, model=None, log_level=None,
     if model is None:
         return logger
     else:
-        return PySBModelLoggerAdapter(logger, {'model': model})
+        return PySBModelLoggerAdapter(logger, {'model_name': model.name})
 
 
 class PySBModelLoggerAdapter(logging.LoggerAdapter):
     """ A logging adapter to prepend a model's name to log entries """
     def process(self, msg, kwargs):
-        return '[%s] %s' % (self.extra['model'].name, msg), kwargs
+        return '[%s] %s' % (self.extra['model_name'], msg), kwargs

--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -190,7 +190,7 @@ class Simulator(object):
                         and all(isinstance(v, numbers.Number) for v in value_obj):
                     value = value_obj
                 elif isinstance(value_obj, Expression):
-                    value = [value_obj.expand_expr().evalf(subs=subs[sim]) for sim in range(len(subs))]
+                    value = [value_obj.expand_expr().xreplace(subs[sim]) for sim in range(len(subs))]
                 elif isinstance(value_obj, Parameter):
                     # Set parameter using param_values
                     pi = self._model.parameters.index(value_obj)

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -204,8 +204,6 @@ class ScipyOdeSimulator(Simulator):
                                            _run_kwargs=[])
         n_sims = len(self.param_values)
 
-        num_species = len(self._model.species)
-        num_odes = len(self._model.odes)
         if num_processors == 1:
             self._logger.debug('Single processor (serial) mode')
         else:

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -71,8 +71,7 @@ class ScipyOdeSimulator(Simulator):
           (tries cython, then python). Cython compiles the
           equation system into C code. Python is the slowest but most
           compatible.
-        * ``cleanup``: Boolean, `cleanup` argument used for
-          :func:`pysb.bng.generate_equations` call
+        * ``cleanup``: Boolean, whether to delete temporary files.
 
     Notes
     -----
@@ -358,7 +357,7 @@ class RhsBuilder:
     species concentrations with respect to all other species).
 
     This is an abstract base class; concrete subclasses must implement the
-    _get_rhs and _get_jacobian methods. These methods shall return function
+    `_get_rhs` and `_get_jacobian` methods. These methods shall return function
     objects for evaluating the RHS and Jacobian, respectively, of the system of
     ODEs. Subclasses may also implement the `check` classmethod which should
     return a bool indicating whether it is usable in the current environment
@@ -366,8 +365,8 @@ class RhsBuilder:
 
     All implementations of this class must be picklable so they can be sent
     across to the ProcessPoolExecutor workers in separate processes. The
-    _get_rhs and _get_jacobian methods may return process-specific non-picklable
-    values such as closures or native functions.
+    `_get_rhs` and `_get_jacobian` methods may return process-specific
+    non-picklable values.
 
     Parameters
     ----------
@@ -647,6 +646,8 @@ class CythonRhsBuilder(RhsBuilder):
             filepath=self.work_path,
             extra_compile_args=extra_compile_args,
         )
+        # Build a module-name-safe string that identifies the model as uniquely
+        # as possible to assist in debugging.
         escaped_name = re.sub(
             r"[^A-Za-z0-9]",
             "_",

--- a/pysb/simulator/scipyode.py
+++ b/pysb/simulator/scipyode.py
@@ -13,7 +13,7 @@ import numpy as np
 import warnings
 import os
 import inspect
-from pysb.logging import get_logger, EXTENDED_DEBUG
+from pysb.logging import get_logger, PySBModelLoggerAdapter, EXTENDED_DEBUG
 import logging
 import contextlib
 import importlib
@@ -483,7 +483,17 @@ class RhsBuilder:
         state["_expressions_constant_fn"] = None
         state["_rhs_fn"] = None
         state["_jacobian_fn"] = None
+        # Loggers are not picklable in Python 3.6.
+        state["_logger_extra"] = state["_logger"].extra
+        del state["_logger"]
         return state
+
+    def __setstate__(self, state):
+        state["_logger"] = PySBModelLoggerAdapter(
+            get_logger(self.__module__), state["_logger_extra"]
+        )
+        del state["_logger_extra"]
+        self.__dict__.update(state)
 
     @property
     def work_path(self):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def main():
                     'pysb.testing', 'pysb.tests'],
           scripts=['scripts/pysb_export'],
           # We should really specify some minimum versions here.
-          install_requires=['numpy', 'scipy>=1.1', 'sympy', 'networkx',
+          install_requires=['numpy', 'scipy>=1.1', 'sympy>=1.6', 'networkx',
                             'futures; python_version == "2.7"'],
           setup_requires=['nose'],
           tests_require=['coverage', 'pygraphviz', 'matplotlib', 'pexpect',


### PR DESCRIPTION
This moves all codegen out of the simulator class. A new abstract class
RhsBuilder is introduced to manage codegen, and Python and Cython concrete
implementations are provided. The codegen itself is now performed using sympy
expression manipulation and sympy's own codegen rather than hand-rolled string
manipulations and Cython.inline. Performance is improved since Cython.inline's
overhead on long code strings was really hurting us.