### PR TITLE
Fix travis h5py issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ before_install:
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - conda install --yes -c conda-forge python="$PYVER"
-    numpy scipy matplotlib sympy nose h5py pexpect pandas networkx
+    numpy scipy matplotlib sympy nose pexpect pandas networkx
     pydot codecov mock cython
+- pip install h5py  # use pip due to travis/conda undefined symbol error
 - if [[ $PYVER != 3.8 ]]; then conda install --yes -c SBMLTeam python-libsbml; else pip install python-libsbml; fi
 # libroadrunner is not currently available for Python 3.8
 - if [[ $PYVER != 3.8 ]]; then pip install libroadrunner twine; else pip install twine; fi
@@ -26,4 +27,7 @@ install:
 before_script:
   python setup.py sdist && twine check dist/*
 script:
-  python -c "import h5py"
+  nosetests build/lib/pysb --with-coverage --cover-inclusive
+  --cover-package=build/lib/pysb -a '!gpu'
+after_success:
+  codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,4 @@ install:
 before_script:
   python setup.py sdist && twine check dist/*
 script:
-  nosetests build/lib/pysb --with-coverage --cover-inclusive
-  --cover-package=build/lib/pysb -a '!gpu'
-after_success:
-  codecov
+  python -c "import h5py"


### PR DESCRIPTION
Conda-installed `h5py` is currently failing on Travis using Python 3.7 and 3.8:

```
$ python -c "import h5py"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/miniconda/lib/python3.7/site-packages/h5py/__init__.py", line 33, in <module>
    from . import version
  File "/home/travis/miniconda/lib/python3.7/site-packages/h5py/version.py", line 15, in <module>
    from . import h5 as _h5
  File "h5py/h5.pyx", line 1, in init h5py.h5
ImportError: /home/travis/miniconda/lib/python3.7/site-packages/h5py/defs.cpython-37m-x86_64-linux-gnu.so: undefined symbol: H5Pset_fapl_ros3
```

This PR works around the issue by using pip-installed `h5py` rather than the conda-installed one.