### PR TITLE
Fix numpy v1.24 compatibility

### DIFF
--- a/pysb/simulator/base.py
+++ b/pysb/simulator/base.py
@@ -748,7 +748,7 @@ class SimulationResult(object):
             self.run_kwargs = {}
 
         self.squeeze = squeeze
-        self.tout = np.asarray(tout)
+        self.tout = tout
         self._yfull = None
         self.n_sims_per_parameter_set = simulations_per_param_set
         self.pysb_version = PYSB_VERSION


### PR DESCRIPTION
Numpy v1.24 deprecated ragged arrays unless dtype=object is passed (numpy/numpy#22004). The SimulationResult class needs to support different length entries in tout in the case these differ across simulations. PySB shouldn't convert these to a numpy array, instead preferring to keep them as a list/iterable, which avoids causing an error with Numpy v1.24 when running the PySB test suite.