### PR TITLE
Disable GitHub Actions fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: Tests & Coverage
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
This lets us see all the possible problems across the entire CI matrix rather than cancelling all the jobs as soon as any one fails.