### PR TITLE
Switch MacOS CI runner to ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,14 @@ jobs:
           activate-environment: pysb
       - name: Install StochKit (Linux only)
         if: matrix.os == 'ubuntu-latest'
-        run: conda install -y -c alubbock stochkit
+        run: |
+          conda install -y -c alubbock stochkit
+          echo "HAS_STOCHKIT=1" >> "$GITHUB_ENV"
       - name: Install StochKit Lite (Windows only)
         if: matrix.os == 'windows-latest'
-        run: conda install -y -c alubbock -c conda-forge stochkit-lite
+        run: |
+          conda install -y -c alubbock -c conda-forge stochkit-lite
+          echo "HAS_STOCHKIT=1" >> "$GITHUB_ENV"
       - name: Fix gfortran DLL linker error on Windows/Python 3.8
         if: matrix.os == 'windows-latest' && matrix.python-version == '3.8'
         run: pip install --upgrade --force-reinstall scipy
@@ -48,6 +52,7 @@ jobs:
           --with-coverage --cover-inclusive --cover-package=build/lib/pysb
           --cover-xml
           -a '!gpu'
+          ${{ env.HAS_STOCHKIT && ' ' || '--exclude stochkit' }}
       - uses: codecov/codecov-action@v4
         with:
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: .github/pysb-conda-env.yml
           activate-environment: pysb
-      - name: Install StochKit (except on Windows)
-        if: matrix.os != 'windows-latest'
+      - name: Install StochKit (Linux only)
+        if: matrix.os == 'ubuntu-latest'
         run: conda install -y -c alubbock stochkit
       - name: Install StochKit Lite (Windows only)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
           --with-coverage --cover-inclusive --cover-package=build/lib/pysb
           --cover-xml
           -a '!gpu'
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           verbose: true
           flags: os-${{ matrix.os }},python-${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           environment-file: .github/pysb-conda-env.yml


### PR DESCRIPTION
Mostly straightforward changes to the matrix `os` entry to get the guaranteed arm64 runner with `macos-14`. I think since I started this work, `macos-latest` is now arm64, but sticking with `macos-14` for now seems fine.

I needed to rework how stochkit presence/absence is handled since it no longer works on macOS at all (no arm64 stochkit build). My solution sets an environment variable in the steps that install stochkit, then checks that variable in the actual nosetests step to conditionally exclude stochkit tests. I needed to use the nosetests `--exclude` option because that's the only way to also skip specific doctests (there's no way to apply the `-a` attrs to doctests).

I also updated some action versions while I was editing the workflow.