### PR TITLE
fix: CI failures with updated BNG/NFsim

### DIFF
--- a/.github/pysb-conda-env.yml
+++ b/.github/pysb-conda-env.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - alubbock::bionetgen
+  - alubbock::nfsim==1.12.1
   - alubbock::atomizer
   - alubbock::kappa
   - numpy

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -196,7 +196,8 @@ def test_bngl_import_expected_errors():
     expected_errors = {'ANx': errtype['plusminus'],
                        'CaOscillate_Sat': errtype['ratelawtype'],
                        'heise': errtype['statelabels'],
-                       'isingspin_energy': errtype['ratelawmissing'],
+                       # following model's error differs between BNG versions
+                       'isingspin_energy': f"({errtype['ratelawmissing']})|({errtype['ratelawtype']})",
                        'test_MM': errtype['ratelawtype'],
                        'test_sat': errtype['ratelawtype'],
                        }


### PR DESCRIPTION
Two CI failures have crept in with updates to BNG and NFsim.

This first is an error simulating a hybrid particle-population model in our test suite. This looks like a bug in NFsim 1.14.1, which generates a segfault on the model which worked in 1.12.1. I've opened an issue with NFsim for this here:
https://github.com/RuleWorld/nfsim/issues/37

In the meantime, I've pinned the test suite GitHub Actions CI to NFsim 1.12.1.

The other is a test failure in a BNG model import, which looks like it's just a consequence of the rule order parsing changing between BNG versions. I've updated the test to test for the presence of either of the two expected error messages, both regarding rate laws.