### PR TITLE
Adapt to numpy 2.0

### DIFF
--- a/pysb/anneal_mod.py
+++ b/pysb/anneal_mod.py
@@ -29,9 +29,9 @@ class base_schedule(object):
     def init(self, **options):
         self.__dict__.update(options)
         self.lower = asarray(self.lower)
-        self.lower = where(self.lower == numpy.NINF, -_double_max, self.lower)
+        self.lower = where(self.lower == -numpy.inf, -_double_max, self.lower)
         self.upper = asarray(self.upper)
-        self.upper = where(self.upper == numpy.PINF, _double_max, self.upper)
+        self.upper = where(self.upper == numpy.inf, _double_max, self.upper)
         self.k = 0
         self.accepted = 0
         self.feval = 0


### PR DESCRIPTION
Numpy 2.0 was just released and I'm going over some repos to see if there are any incompatibilities. I found a couple of minor changes needed here to be compatible with the new version per https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide.