### PR TITLE
fix(ci): fix CI perf., Windows test discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-14", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           environment-file: .github/pysb-conda-env.yml
+          conda-remove-defaults: "true"
           activate-environment: pysb
       - name: Install StochKit (Linux only)
         if: matrix.os == 'ubuntu-latest'
@@ -33,6 +34,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           conda install -y -c alubbock -c conda-forge stochkit-lite
+          conda remove -y atomizer  # no upstream support
           echo "HAS_STOCHKIT=1" >> "$GITHUB_ENV"
       - name: Conda environment info
         run: |
@@ -43,13 +45,13 @@ jobs:
       - name: Run nosetests
         env:
           PYTHONFAULTHANDLER: 1
-        run: >
-          nosetests .
-          --with-coverage --cover-inclusive --cover-package=pysb
-          --cover-xml
-          -a '!gpu'
-          ${{ env.HAS_STOCHKIT && ' ' || '--exclude stochkit' }}
-      - uses: codecov/codecov-action@v4
+        run: |
+          nosetests pysb --traverse-namespace \
+            --with-coverage --cover-inclusive --cover-package=pysb \
+            --cover-xml \
+            -a '!gpu' \
+            ${{ env.HAS_STOCHKIT && ' ' || '--exclude stochkit' }}
+      - uses: codecov/codecov-action@v6
         with:
           verbose: true
           flags: os-${{ matrix.os }},python-${{ matrix.python-version }}

--- a/pysb/examples/run_bax_pore.py
+++ b/pysb/examples/run_bax_pore.py
@@ -8,11 +8,12 @@ from pysb.simulator import ScipyOdeSimulator
 from bax_pore import model
 
 
-t = linspace(0, 100)
-print("Simulating...")
-x = ScipyOdeSimulator(model).run(tspan=t).all
+if __name__ == '__main__':
+    t = linspace(0, 100)
+    print("Simulating...")
+    x = ScipyOdeSimulator(model).run(tspan=t).all
 
-plt.plot(t, x['BAX4'])
-plt.plot(t, x['BAX4_inh'])
-plt.legend(['BAX4', 'BAX4_inh'], loc='upper left')
-plt.show()
+    plt.plot(t, x['BAX4'])
+    plt.plot(t, x['BAX4_inh'])
+    plt.legend(['BAX4', 'BAX4_inh'], loc='upper left')
+    plt.show()

--- a/pysb/examples/run_bax_pore_sequential.py
+++ b/pysb/examples/run_bax_pore_sequential.py
@@ -8,25 +8,26 @@ from pysb.simulator import ScipyOdeSimulator
 from bax_pore_sequential import model, max_size
 
 
-# System is very stiff, and using logspace instead of linspace to produce the
-# vector of time points happens to help with the integration
-t = logspace(-3, 5) # 1e-3 to 1e5
-print("Simulating...")
-x = ScipyOdeSimulator(model).run(tspan=t).all
+if __name__ == '__main__':
+    # System is very stiff, and using logspace instead of linspace to produce the
+    # vector of time points happens to help with the integration
+    t = logspace(-3, 5) # 1e-3 to 1e5
+    print("Simulating...")
+    x = ScipyOdeSimulator(model).run(tspan=t).all
 
-# Plot trajectory of each pore
-for i in range(1, max_size + 1):
-    observable = 'Bax%d' % i
-    # Map pore size to the central 50% of the YlOrBr color map
-    color = plt.cm.YlOrBr(float(i) / max_size / 2 + 0.25)
-    plt.plot(t, x[observable], c=color, label=observable)
-# Plot Smac species
-plt.plot(t, x['mSmac'], c='magenta', label='mSmac')
-plt.plot(t, x['cSmac'], c='cyan', label='cSmac')
+    # Plot trajectory of each pore
+    for i in range(1, max_size + 1):
+        observable = 'Bax%d' % i
+        # Map pore size to the central 50% of the YlOrBr color map
+        color = plt.cm.YlOrBr(float(i) / max_size / 2 + 0.25)
+        plt.plot(t, x[observable], c=color, label=observable)
+    # Plot Smac species
+    plt.plot(t, x['mSmac'], c='magenta', label='mSmac')
+    plt.plot(t, x['cSmac'], c='cyan', label='cSmac')
 
-# Expand the limits a bit to show the min/max levels clearly
-plt.ylim([-0.01e5, 1.01e5])
-# Show time on a log scale 
-plt.xscale('log')
-plt.legend(loc='upper right')
-plt.show()
+    # Expand the limits a bit to show the min/max levels clearly
+    plt.ylim([-0.01e5, 1.01e5])
+    # Show time on a log scale
+    plt.xscale('log')
+    plt.legend(loc='upper right')
+    plt.show()

--- a/pysb/examples/run_bng_ssa_example.py
+++ b/pysb/examples/run_bng_ssa_example.py
@@ -3,14 +3,15 @@ import numpy as np
 from pysb.simulator.bng import BngSimulator
 from kinase_cascade import model
 
-# We will integrate from t=0 to t=40
-t = np.linspace(0, 40, 50)
+if __name__ == '__main__':
+    # We will integrate from t=0 to t=40
+    t = np.linspace(0, 40, 50)
 
-# Simulate the model
-print("Simulating...")
-sim = BngSimulator(model)
-x = sim.run(tspan=t, verbose=False, n_runs=5, method='ssa')
-tout = x.tout
-y = np.array(x.observables)
-plt.plot(tout.T, y['ppMEK'].T)
-plt.show()
+    # Simulate the model
+    print("Simulating...")
+    sim = BngSimulator(model)
+    x = sim.run(tspan=t, verbose=False, n_runs=5, method='ssa')
+    tout = x.tout
+    y = np.array(x.observables)
+    plt.plot(tout.T, y['ppMEK'].T)
+    plt.show()

--- a/pysb/examples/run_earm_1_0.py
+++ b/pysb/examples/run_earm_1_0.py
@@ -90,6 +90,7 @@ def fig_4b():
     a.set_ylim((-.05, 1.05))
 
 
-fig_4a()
-fig_4b()
-plt.show()
+if __name__ == '__main__':
+    fig_4a()
+    fig_4b()
+    plt.show()

--- a/pysb/examples/run_earm_hpp.py
+++ b/pysb/examples/run_earm_hpp.py
@@ -37,29 +37,30 @@ def plot_mean_min_max(name, title=None):
     plt.xlabel('Time')
     plt.ylabel('Population of %s' % name)
 
-PARP, CPARP, Mito, mCytoC = [model.monomers[x] for x in
-                             ['PARP', 'CPARP', 'Mito', 'mCytoC']]
-klump = Parameter('klump', 10000, _export=False)
-model.add_component(klump)
+if __name__ == '__main__':
+    PARP, CPARP, Mito, mCytoC = [model.monomers[x] for x in
+                                 ['PARP', 'CPARP', 'Mito', 'mCytoC']]
+    klump = Parameter('klump', 10000, _export=False)
+    model.add_component(klump)
 
-population_maps = [
-    PopulationMap(PARP(b=None), klump),
-    PopulationMap(CPARP(b=None), klump),
-    PopulationMap(Mito(b=None), klump),
-    PopulationMap(mCytoC(b=None), klump)
-]
+    population_maps = [
+        PopulationMap(PARP(b=None), klump),
+        PopulationMap(CPARP(b=None), klump),
+        PopulationMap(Mito(b=None), klump),
+        PopulationMap(mCytoC(b=None), klump)
+    ]
 
-sim = BngSimulator(model, tspan=np.linspace(0, 20000, 101))
-simres = sim.run(n_runs=20, method='nf', population_maps=population_maps)
+    sim = BngSimulator(model, tspan=np.linspace(0, 20000, 101))
+    simres = sim.run(n_runs=20, method='nf', population_maps=population_maps)
 
-trajectories = simres.all
-tout = simres.tout
+    trajectories = simres.all
+    tout = simres.tout
 
-plot_mean_min_max('Bid_unbound')
-plot_mean_min_max('PARP_unbound')
-plot_mean_min_max('mSmac_unbound')
-plot_mean_min_max('tBid_total')
-plot_mean_min_max('CPARP_total')
-plot_mean_min_max('cSmac_total')
+    plot_mean_min_max('Bid_unbound')
+    plot_mean_min_max('PARP_unbound')
+    plot_mean_min_max('mSmac_unbound')
+    plot_mean_min_max('tBid_total')
+    plot_mean_min_max('CPARP_total')
+    plot_mean_min_max('cSmac_total')
 
-plt.show()
+    plt.show()

--- a/pysb/examples/run_earm_stochkit.py
+++ b/pysb/examples/run_earm_stochkit.py
@@ -22,18 +22,19 @@ def plot_mean_min_max(name, title=None):
     plt.xlabel('Time')
     plt.ylabel('Population of %s' % name)
 
-tspan = np.linspace(0, 20000, 1000)
-sim = StochKitSimulator(model, tspan)
-simres = sim.run(n_runs=20, seed=None, algorithm="ssa")
+if __name__ == '__main__':
+    tspan = np.linspace(0, 20000, 1000)
+    sim = StochKitSimulator(model, tspan)
+    simres = sim.run(n_runs=20, seed=None, algorithm="ssa")
 
-trajectories = simres.all
-tout = simres.tout
+    trajectories = simres.all
+    tout = simres.tout
 
-plot_mean_min_max('Bid_unbound')
-plot_mean_min_max('PARP_unbound')
-plot_mean_min_max('mSmac_unbound')
-plot_mean_min_max('tBid_total')
-plot_mean_min_max('CPARP_total')
-plot_mean_min_max('cSmac_total')
+    plot_mean_min_max('Bid_unbound')
+    plot_mean_min_max('PARP_unbound')
+    plot_mean_min_max('mSmac_unbound')
+    plot_mean_min_max('tBid_total')
+    plot_mean_min_max('CPARP_total')
+    plot_mean_min_max('cSmac_total')
 
-plt.show()
+    plt.show()

--- a/pysb/examples/run_fixed_initial.py
+++ b/pysb/examples/run_fixed_initial.py
@@ -7,33 +7,34 @@ from pysb.simulator import ScipyOdeSimulator
 
 from pysb.examples.fixed_initial import model
 
-n_obs = len(model.observables)
-tspan = np.linspace(0, 0.5)
+if __name__ == '__main__':
+    n_obs = len(model.observables)
+    tspan = np.linspace(0, 0.5)
 
-plt.figure(figsize=(8,4))
+    plt.figure(figsize=(8,4))
 
-# Simulate the model as written, with free F fixed.
-sim = ScipyOdeSimulator(model, tspan)
-res = sim.run()
-obs = res.observables.view(float).reshape(-1, n_obs)
-plt.subplot(121)
-plt.plot(res.tout[0], obs)
-plt.ylabel('Amount')
-plt.xlabel('Time')
-plt.legend([x.name for x in model.observables], frameon=False)
-plt.title('Free F fixed')
+    # Simulate the model as written, with free F fixed.
+    sim = ScipyOdeSimulator(model, tspan)
+    res = sim.run()
+    obs = res.observables.view(float).reshape(-1, n_obs)
+    plt.subplot(121)
+    plt.plot(res.tout[0], obs)
+    plt.ylabel('Amount')
+    plt.xlabel('Time')
+    plt.legend([x.name for x in model.observables], frameon=False)
+    plt.title('Free F fixed')
 
-# Make a copy of the model and unfix the initial condition for free F.
-model2 = copy.deepcopy(model)
-model2.reset_equations()
-model2.initials[1].fixed = False
-sim2 = ScipyOdeSimulator(model2, tspan)
-res2 = sim2.run()
-obs2 = res2.observables.view(float).reshape(-1, n_obs)
-plt.subplot(122)
-plt.plot(res2.tout[0], obs2)
-plt.xlabel('Time')
-plt.legend([x.name for x in model.observables], frameon=False)
-plt.title('Free F can be consumed')
+    # Make a copy of the model and unfix the initial condition for free F.
+    model2 = copy.deepcopy(model)
+    model2.reset_equations()
+    model2.initials[1].fixed = False
+    sim2 = ScipyOdeSimulator(model2, tspan)
+    res2 = sim2.run()
+    obs2 = res2.observables.view(float).reshape(-1, n_obs)
+    plt.subplot(122)
+    plt.plot(res2.tout[0], obs2)
+    plt.xlabel('Time')
+    plt.legend([x.name for x in model.observables], frameon=False)
+    plt.title('Free F can be consumed')
 
-plt.show()
+    plt.show()

--- a/pysb/examples/run_kinase_cascade.py
+++ b/pysb/examples/run_kinase_cascade.py
@@ -5,10 +5,11 @@ from matplotlib.pylab import linspace
 from kinase_cascade import model
 
 
-tspan = linspace(0, 1200)
-print("Simulating...")
-yfull = ScipyOdeSimulator(model).run(tspan=tspan).all
-plot(tspan, yfull['ppMEK'], label='ppMEK')
-plot(tspan, yfull['ppERK'], label='ppERK')
-legend(loc='upper left')
-show()
+if __name__ == '__main__':
+    tspan = linspace(0, 1200)
+    print("Simulating...")
+    yfull = ScipyOdeSimulator(model).run(tspan=tspan).all
+    plot(tspan, yfull['ppMEK'], label='ppMEK')
+    plot(tspan, yfull['ppERK'], label='ppERK')
+    legend(loc='upper left')
+    show()

--- a/pysb/examples/run_michment.py
+++ b/pysb/examples/run_michment.py
@@ -4,26 +4,27 @@ import numpy as np
 import matplotlib.pyplot as plt
 import itertools
 
-# Construct initials dict
-mult = np.linspace(0.8, 1.2, 11)
-matrix = [mult*ic.value.value for ic in model.initials]
-initials = {}
-for i, ic in enumerate(model.initials):
-    initials[ic.pattern] = []
-    for tup in itertools.product(*matrix): # Cartesian product
-        initials[ic.pattern].append(tup[i])
+if __name__ == '__main__':
+    # Construct initials dict
+    mult = np.linspace(0.8, 1.2, 11)
+    matrix = [mult*ic.value.value for ic in model.initials]
+    initials = {}
+    for i, ic in enumerate(model.initials):
+        initials[ic.pattern] = []
+        for tup in itertools.product(*matrix): # Cartesian product
+            initials[ic.pattern].append(tup[i])
 
-tspan = np.linspace(0, 50, 501)
-sim = ScipyOdeSimulator(model, tspan, verbose=False)
-trajectories = sim.run(initials=initials).all
+    tspan = np.linspace(0, 50, 501)
+    sim = ScipyOdeSimulator(model, tspan, verbose=False)
+    trajectories = sim.run(initials=initials).all
 
-x = np.array([tr['Product'] for tr in trajectories]).T
+    x = np.array([tr['Product'] for tr in trajectories]).T
 
-plt.plot(tspan, x.mean(axis=1), 'b', lw=3, label="Product")
-plt.plot(tspan, x.max(axis=1), 'b--', lw=2, label="min/max")
-plt.plot(tspan, x.min(axis=1), 'b--', lw=2)
-plt.xlabel('time')
-plt.ylabel('concentration')
-plt.legend(loc='upper left')
+    plt.plot(tspan, x.mean(axis=1), 'b', lw=3, label="Product")
+    plt.plot(tspan, x.max(axis=1), 'b--', lw=2, label="min/max")
+    plt.plot(tspan, x.min(axis=1), 'b--', lw=2)
+    plt.xlabel('time')
+    plt.ylabel('concentration')
+    plt.legend(loc='upper left')
 
-plt.show()
+    plt.show()

--- a/pysb/examples/run_robertson.py
+++ b/pysb/examples/run_robertson.py
@@ -9,15 +9,16 @@ from pysb.simulator import ScipyOdeSimulator
 
 from robertson import model
 
-# We will integrate from t=0 to t=40
-t = linspace(0, 40)
-# Simulate the model
-print("Simulating...")
-y = ScipyOdeSimulator(model, integrator_options=dict(rtol=1e-4, atol=[1e-8, 1e-14, 1e-6])).run(
-    tspan=t).all
-# Gather the observables of interest into a matrix
-yobs = array([y[obs] for obs in ('A_total', 'B_total', 'C_total')]).T
-# Plot normalized trajectories
-plot(t, yobs / yobs.max(0))
-legend(['y1', 'y2', 'y3'], loc='lower right')
-show()
+if __name__ == '__main__':
+    # We will integrate from t=0 to t=40
+    t = linspace(0, 40)
+    # Simulate the model
+    print("Simulating...")
+    y = ScipyOdeSimulator(model, integrator_options=dict(rtol=1e-4, atol=[1e-8, 1e-14, 1e-6])).run(
+        tspan=t).all
+    # Gather the observables of interest into a matrix
+    yobs = array([y[obs] for obs in ('A_total', 'B_total', 'C_total')]).T
+    # Plot normalized trajectories
+    plot(t, yobs / yobs.max(0))
+    legend(['y1', 'y2', 'y3'], loc='lower right')
+    show()

--- a/pysb/examples/run_tutorial_a.py
+++ b/pysb/examples/run_tutorial_a.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 from pysb.simulator import ScipyOdeSimulator
 from tutorial_a import model
 
-t = [0, 10, 20, 30, 40, 50, 60]
-simulator = ScipyOdeSimulator(model, tspan=t)
-simresult = simulator.run()
-print(simresult.species)
+if __name__ == '__main__':
+    t = [0, 10, 20, 30, 40, 50, 60]
+    simulator = ScipyOdeSimulator(model, tspan=t)
+    simresult = simulator.run()
+    print(simresult.species)

--- a/pysb/examples/run_tyson_oscillator.py
+++ b/pysb/examples/run_tyson_oscillator.py
@@ -3,15 +3,16 @@ from pysb.simulator import ScipyOdeSimulator
 import numpy as np
 import matplotlib.pyplot as plt
 
-t = np.linspace(0, 100, 10001)
-x = ScipyOdeSimulator(model).run(tspan=t).all
+if __name__ == '__main__':
+    t = np.linspace(0, 100, 10001)
+    x = ScipyOdeSimulator(model).run(tspan=t).all
 
-plt.plot(t, x['CT'],  lw=2, label='CT')  # Good validation of mass balance for cdc2, should be constant at 1
-plt.plot(t, x['YT'], lw=2, label='YT')
-plt.plot(t, x['M'], lw=2, label='M')
+    plt.plot(t, x['CT'],  lw=2, label='CT')  # Good validation of mass balance for cdc2, should be constant at 1
+    plt.plot(t, x['YT'], lw=2, label='YT')
+    plt.plot(t, x['M'], lw=2, label='M')
 
-plt.legend(loc=0)
-plt.xlabel('time')
-plt.ylabel('population')
+    plt.legend(loc=0)
+    plt.xlabel('time')
+    plt.ylabel('population')
 
-plt.show()
+    plt.show()

--- a/pysb/examples/run_tyson_oscillator_stochkit.py
+++ b/pysb/examples/run_tyson_oscillator_stochkit.py
@@ -22,14 +22,15 @@ def plot_mean_min_max(name, title=None):
     plt.xlabel('Time')
     plt.ylabel('Population of %s' % name)
 
-tspan = np.linspace(0, 50, 5001)
-sim = StochKitSimulator(model, verbose=True)
-simres = sim.run(tspan=tspan, n_runs=5, seed=None, algorithm="ssa")
-tout = simres.tout
-trajectories = simres.all
+if __name__ == '__main__':
+    tspan = np.linspace(0, 50, 5001)
+    sim = StochKitSimulator(model, verbose=True)
+    simres = sim.run(tspan=tspan, n_runs=5, seed=None, algorithm="ssa")
+    tout = simres.tout
+    trajectories = simres.all
 
-plot_mean_min_max('__s0', str(model.species[0]))
-plot_mean_min_max('YT')
-plot_mean_min_max('M')
+    plot_mean_min_max('__s0', str(model.species[0]))
+    plot_mean_min_max('YT')
+    plot_mean_min_max('M')
 
-plt.show()
+    plt.show()

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -5,6 +5,7 @@ from pysb.importers.bngl import model_from_bngl, BnglImportError
 from pysb.importers.sbml import model_from_sbml, model_from_biomodels
 import numpy
 from nose.tools import assert_raises_regex, raises
+from nose.plugins.skip import SkipTest
 import warnings
 import mock
 import tempfile
@@ -90,10 +91,6 @@ def bngl_import_compare_nfsim(bng_file):
 
     # Check all species trajectories are equal (within numerical tolerance)
     for i in range(len(m.observables)):
-        print(i)
-        print(yfull1[i])
-        print(yfull2[i])
-        print(yfull1[i] == yfull2[i])
         assert yfull1[i] == yfull2[i]
 
 
@@ -211,11 +208,20 @@ def test_bngl_import_expected_errors():
                full_filename)
 
 
+def _require_atomizer():
+    try:
+        pf.get_path('atomizer')
+    except Exception:
+        raise SkipTest('atomizer (sbmlTranslator) not available')
+
+
 def test_sbml_import_flat_model():
+    _require_atomizer()
     model_from_sbml(_sbml_location('test_sbml_flat_SBML'))
 
 
 def test_sbml_import_structured_model():
+    _require_atomizer()
     model_from_sbml(_sbml_location('test_sbml_structured_SBML'), atomize=True)
 
 
@@ -229,6 +235,7 @@ def _sbml_for_mocks(accession_no, mirror):
 
 @mock.patch('pysb.importers.sbml._download_biomodels', _sbml_for_mocks)
 def test_biomodels_import_with_mock():
+    _require_atomizer()
     model_from_biomodels('1')
 
 

--- a/pysb/tests/test_simulator_bng.py
+++ b/pysb/tests/test_simulator_bng.py
@@ -216,7 +216,6 @@ def test_set_initials_by_params():
     # overwritten in bng file. lines 196-202.
     # Values from initials_dict are used, but it should take them from
     # self.initials, so I don't see how they are getting overwritten?
-    print(traj.dataframe.loc[0])
     assert np.allclose(traj.dataframe.loc[0][0:3], [1, 1, 1])
 
     # Same here

--- a/pysb/tests/test_simulator_scipy.py
+++ b/pysb/tests/test_simulator_scipy.py
@@ -516,6 +516,9 @@ if sys.version_info[0] < 3:
         simres = sim.run(tspan=t)
 
 
+@unittest.skip(
+    "Skipped: scipy VODE analytic Jacobian bug (scipy/scipy#24933)"
+)
 def test_multiprocessing_lambdify():
     model = tyson_oscillator.model
     pars = [p.value for p in model.parameters]


### PR DESCRIPTION
GH Actions was running extremely slowly on Linux and Mac, and not discovering tests at all on Windows.

Fixes in this PR to get CI working and performant:

* Fix Windows CI running 0 tests by switching from `nosetests .` to `nosetests pysb --traverse-namespace`.

* Skip the test_multiprocessing_lambdify() test for now. This test was either not completing or extremely slow. SciPy v1.17 introduced a bug in handling analytic jacobians: scipy/scipy#24933. I opened a PR to fix this scipy/scipy#24934 which has now been merged, but not yet released.

* Guard run_* example scripts with `__main__` check to prevent side effects when importing during test discovery, which was also causing slowdowns.

* Skip SBML import tests when atomizer (sbmlTranslator) binary is unavailable, and remove atomizer from Windows conda env as it has no upstream support and the Windows build on alubbock channel is very old.

Minor housekeeping also included:

* GitHub Actions version bumps:
  - macos-14 runner to macos-latest (in line with other OSes)
  - checkout@v4 action to v6
  - codecov-action@v4 action to v6

* Remove the Anaconda defaults channels from CI (use conda-forge instead).

* Remove extraneous print() calls in tests.

---
Fixes #597 