### PR TITLE
chore(codecov): only enforce on patch, not project

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
codecov provides two github actions checks, project and patch. Patch is the more useful - project's regular failure obscures our main test suite.

Convert the project check to informational only using codecov.yml