### PR TITLE
feat(importers): add libsbml-based SBML importer

### DIFF
--- a/doc/modules/importers/index.rst
+++ b/doc/modules/importers/index.rst
@@ -4,5 +4,15 @@ Importing from other formats (:py:mod:`pysb.importers`)
 .. automodule:: pysb.importers.bngl
    :members: model_from_bngl
 
+SBML import (:py:mod:`pysb.importers.sbml`)
+--------------------------------------------
+
 .. automodule:: pysb.importers.sbml
-   :members: model_from_sbml, model_from_biomodels, sbml_translator
+
+.. autoclass:: pysb.importers.sbml.SbmlImporter
+
+.. autofunction:: pysb.importers.sbml.model_from_sbml
+
+.. autofunction:: pysb.importers.sbml.model_from_biomodels
+
+.. autofunction:: pysb.importers.sbml.sbml_translator

--- a/pysb/builder.py
+++ b/pysb/builder.py
@@ -99,7 +99,7 @@ class Builder(object):
         self.model.add_component(m)
         return m
 
-    def parameter(self, name, value, factor=1, prior=None):
+    def parameter(self, name, value, factor=1, prior=None, nonnegative=True):
         """Adds a parameter to the Builder's model instance.
 
         Examines the params_dict attribute of the Builder instance (which is
@@ -129,6 +129,10 @@ class Builder(object):
             values for this parameter, if the parameter should be included among
             the parameters to estimate (contained in the set
             ``Builder.estimate_params``).
+        nonnegative : bool, optional
+            If True (default), the parameter is assumed to be non-negative and
+            an error is raised if a negative value is assigned.  Set to False
+            to allow negative values (e.g. reversal potentials).
         """
 
         if self.params_dict is None:
@@ -139,7 +143,7 @@ class Builder(object):
             else:
                 param_val = value * factor
 
-        p = Parameter(name, param_val, _export=False)
+        p = Parameter(name, param_val, _export=False, nonnegative=nonnegative)
         self.model.add_component(p)
 
         if prior is not None:

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -347,7 +347,22 @@ class SbmlExporter(Exporter):
             # For models without explicit compartments, V = 1 (no correction).
             bng_rate = reaction["rate"]
             if self.model.compartments:
-                n_reac = len(reaction["reactants"])
+                # Use net-consumed molecule count for the V^n exponent.
+                # BNG embeds 1/V^(n-1) for mass-action, where n is the number
+                # of *net-consumed* reactant molecules (reactant count minus the
+                # count of identical species that also appear as products, i.e.
+                # catalysts).  Using the raw reactant count over-corrects for
+                # catalyst reactions such as B+B->C+B (net consumed = 1, not 2).
+                reactant_counts = {}
+                for sp in reaction["reactants"]:
+                    reactant_counts[sp] = reactant_counts.get(sp, 0) + 1
+                product_counts = {}
+                for sp in reaction["products"]:
+                    product_counts[sp] = product_counts.get(sp, 0) + 1
+                n_reac = sum(
+                    max(0, r - product_counts.get(sp, 0))
+                    for sp, r in reactant_counts.items()
+                )
                 # Identify the reference species list (reactants if present,
                 # otherwise products) to determine the reaction compartment.
                 ref_indices = (

--- a/pysb/export/sbml.py
+++ b/pysb/export/sbml.py
@@ -3,14 +3,53 @@ Module containing a class for exporting a PySB model to SBML using libSBML
 
 For information on how to use the model exporters, see the documentation
 for :py:mod:`pysb.export`.
+
+Supported features
+------------------
+* Monomers, parameters, compartments, rules, observables, expressions, initials
+* Reversible rules (exported as a single reversible SBML reaction with a net
+  kinetic law)
+* Synthesis and degradation rules (``None`` on one side)
+* Fixed species (``ic.fixed=True`` -> ``boundaryCondition="true"``)
+* Multimeric reactions: duplicate reactant/product species are consolidated
+  into a single ``<speciesReference>`` with the correct stoichiometry
+* Local functions: expanded to per-rule derived expressions by BNG before
+  export; the tag-context structure is not preserved
+* Observable-based expressions (``expressions_dynamic``): expanded to bare
+  species-sum MathML in the assignment rule
+* The ``time`` special symbol in rate expressions: rendered as a SBML
+  ``<csymbol>`` per Level 3 section 3.4.6
+* Multiple compartments: species are assigned to their monomer-level
+  compartment
+* Volume correction: BNG's network generator produces concentration-based
+  rates (``dC/dt``).  SBML kinetic laws represent flux in amount/time
+  (``J = dN/dt = V * dC/dt``), so the exporter multiplies each kinetic law
+  by ``V^n`` where *n* is the number of reactant molecules.  Species are
+  exported with ``hasOnlySubstanceUnits=False`` so kinetic-law species
+  symbols are interpreted as concentrations, matching BNG's convention.
+
+Known limitations
+-----------------
+* **Energy models**: models that use ``EnergyPattern`` or energy rules raise
+  :py:exc:`pysb.export.EnergyNotSupported`.
+* **Tags / local-function structure**: the ``@tag`` context is unrolled by BNG
+  into derived expressions; the original local-function semantics are not
+  represented in the SBML output.
+* **Round-trip fidelity**: rule-based structure (sites, states) is flattened
+  by BNG before export.  The re-imported model faithfully reproduces the
+  same ODEs but may have different species names and no rule structure.
 """
+
+import re
 import pysb
 import pysb.bng
-from pysb.export import Exporter
+from pysb.core import SpecialSymbol
+from pysb.export import Exporter, EnergyNotSupported
 from sympy.printing.mathml import MathMLPrinter
 from sympy import Symbol
 from xml.dom.minidom import Document
 import itertools
+
 try:
     import libsbml
 except ImportError:
@@ -19,19 +58,21 @@ except ImportError:
 
 class MathMLContentPrinter(MathMLPrinter):
     """Prints an expression to MathML without presentation markup."""
+
     def _print_Symbol(self, sym):
         ci = self.dom.createElement(self.mathml_tag(sym))
         ci.appendChild(self.dom.createTextNode(sym.name))
         return ci
 
     def _print_SpecialSymbol(self, sym):
-        if sym.name == 'time':
+        if sym.name == "time":
             # SBML spec (Level 3 Version 2) provides example on page 26:
             # <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time">t</csymbol>
             csymbol = self.dom.createElement("csymbol")
             csymbol.setAttribute("encoding", "text")
-            csymbol.setAttribute("definitionURL",
-                                 "http://www.sbml.org/sbml/symbols/time")
+            csymbol.setAttribute(
+                "definitionURL", "http://www.sbml.org/sbml/symbols/time"
+            )
             csymbol.appendChild(self.dom.createTextNode("t"))
             return csymbol
 
@@ -48,28 +89,20 @@ def _check(value):
     """
     if type(value) is int and value != libsbml.LIBSBML_OPERATION_SUCCESS:
         raise ValueError(
-            'Error encountered converting to SBML. '
+            "Error encountered converting to SBML. "
             'LibSBML returned error code {}: "{}"'.format(
-                value,
-                libsbml.OperationReturnValue_toString(value).strip()
+                value, libsbml.OperationReturnValue_toString(value).strip()
             )
         )
     elif value is None:
-        raise ValueError('LibSBML returned a null value')
-
-
-def _add_ci(x_doc, x_parent, name):
-    """ Add <ci>name</ci> element to <x_parent> within x_doc """
-    ci = x_doc.createElement('ci')
-    ci.appendChild(x_doc.createTextNode(name))
-    x_parent.appendChild(ci)
+        raise ValueError("LibSBML returned a null value")
 
 
 def _xml_to_ast(x_element):
-    """ Wrap MathML fragment with <math> tag and convert to libSBML AST """
+    """Wrap MathML fragment with <math> tag and convert to libSBML AST"""
     x_doc = Document()
-    x_mathml = x_doc.createElement('math')
-    x_mathml.setAttribute('xmlns', 'http://www.w3.org/1998/Math/MathML')
+    x_mathml = x_doc.createElement("math")
+    x_mathml.setAttribute("xmlns", "http://www.w3.org/1998/Math/MathML")
 
     x_mathml.appendChild(x_element)
     x_doc.appendChild(x_mathml)
@@ -79,30 +112,16 @@ def _xml_to_ast(x_element):
     return mathml_ast
 
 
-def _mathml_expr_call(expr):
-    """ Generate an XML <apply> expression call """
-    x_doc = Document()
-    x_apply = x_doc.createElement('apply')
-    x_doc.appendChild(x_apply)
-
-    _add_ci(x_doc, x_apply, expr.name)
-    for sym in expr.expand_expr(expand_observables=True).free_symbols:
-        if isinstance(sym, pysb.Expression):
-            continue
-        _add_ci(x_doc, x_apply, sym.name if isinstance(sym, pysb.Parameter) else str(sym))
-
-    return x_apply
-
-
 class SbmlExporter(Exporter):
     """A class for returning the SBML for a given PySB model.
 
     Inherits from :py:class:`pysb.export.Exporter`, which implements
     basic functionality for all exporters.
     """
+
     def __init__(self, *args, **kwargs):
         if not libsbml:
-            raise ImportError('The SbmlExporter requires the libsbml python package')
+            raise ImportError("The SbmlExporter requires the libsbml python package")
         super(SbmlExporter, self).__init__(*args, **kwargs)
 
     def _sympy_to_sbmlast(self, sympy_expr):
@@ -120,18 +139,29 @@ class SbmlExporter(Exporter):
         Parameters
         ----------
         level: (int, int)
-            The SBML level and version to use. The default is SBML level 3, version 2. Conversion
-            to other levels/versions may not be possible or may lose fidelity.
+            The SBML level and version to use. The default is SBML level 3,
+            version 2. Conversion to other levels/versions may not be possible
+            or may lose fidelity.
 
         Returns
         -------
         libsbml.SBMLDocument
-            A libSBML document converted form the PySB model
+            A libSBML document converted from the PySB model
         """
         doc = libsbml.SBMLDocument(3, 2)
         smodel = doc.createModel()
         _check(smodel)
+
+        if self.model.uses_energy:
+            raise EnergyNotSupported()
+
         _check(smodel.setName(self.model.name))
+        # SBML IDs must match [a-zA-Z_][a-zA-Z0-9_]* -- replace any other
+        # characters (e.g. dots from Python module paths) with underscores.
+        safe_id = re.sub(r"[^a-zA-Z0-9_]", "_", self.model.name)
+        if safe_id and safe_id[0].isdigit():
+            safe_id = "_" + safe_id
+        _check(smodel.setId(safe_id))
 
         pysb.bng.generate_equations(self.model)
 
@@ -142,7 +172,7 @@ class SbmlExporter(Exporter):
                 <body xmlns="http://www.w3.org/1999/xhtml">
                     <p>%s</p>
                 </body>
-            </notes>""" % self.docstring.replace("\n", "<br />\n"+" "*20)
+            </notes>""" % self.docstring.replace("\n", "<br />\n" + " " * 20)
             _check(smodel.setNotes(notes_str))
 
         # Compartments
@@ -157,16 +187,16 @@ class SbmlExporter(Exporter):
         else:
             c = smodel.createCompartment()
             _check(c)
-            _check(c.setId('default'))
+            _check(c.setId("default"))
             _check(c.setSpatialDimensions(3))
             _check(c.setSize(1))
             _check(c.setConstant(True))
 
         # Expressions
         for expr in itertools.chain(
-                self.model.expressions_constant(),
-                self.model.expressions_dynamic(include_local=False),
-                self.model._derived_expressions
+            self.model.expressions_constant(),
+            self.model.expressions_dynamic(include_local=False),
+            self.model._derived_expressions,
         ):
             # create an observable "parameter"
             e = smodel.createParameter()
@@ -181,7 +211,9 @@ class SbmlExporter(Exporter):
             _check(expr_rule)
             _check(expr_rule.setVariable(e.getId()))
 
-            expr_mathml = self._sympy_to_sbmlast(expr.expand_expr(expand_observables=True))
+            expr_mathml = self._sympy_to_sbmlast(
+                expr.expand_expr(expand_observables=True)
+            )
             _check(expr_rule.setMath(expr_mathml))
 
         # Initial values/assignments
@@ -191,7 +223,7 @@ class SbmlExporter(Exporter):
             sp_idx = self.model.get_species_index(ic.pattern)
             ia = smodel.createInitialAssignment()
             _check(ia)
-            _check(ia.setSymbol('__s{}'.format(sp_idx)))
+            _check(ia.setSymbol("__s{}".format(sp_idx)))
             init_mathml = self._sympy_to_sbmlast(Symbol(ic.value.name))
             _check(ia.setMath(init_mathml))
             initial_species_idx.add(sp_idx)
@@ -203,36 +235,46 @@ class SbmlExporter(Exporter):
         for i, s in enumerate(self.model.species):
             sp = smodel.createSpecies()
             _check(sp)
-            _check(sp.setId('__s{}'.format(i)))
+            _check(sp.setId("__s{}".format(i)))
             if self.model.compartments:
                 # Try to determine compartment, which must be unique for the species
-                mon_cpt = set(mp.compartment for mp in s.monomer_patterns if mp.compartment is not None)
+                mon_cpt = set(
+                    mp.compartment
+                    for mp in s.monomer_patterns
+                    if mp.compartment is not None
+                )
                 if len(mon_cpt) == 0 and s.compartment:
-                    compartment_name = s.compartment_name
+                    compartment_name = s.compartment.name
                 elif len(mon_cpt) == 1:
                     mon_cpt = mon_cpt.pop()
                     if s.compartment is not None and mon_cpt != s.compartment:
-                        raise ValueError('Species {} has different monomer and species compartments, '
-                                         'which is not supported in SBML'.format(s))
+                        raise ValueError(
+                            "Species {} has different monomer and species "
+                            "compartments, which is not supported in "
+                            "SBML".format(s)
+                        )
                     compartment_name = mon_cpt.name
                 else:
-                    raise ValueError('Species {} has more than one different monomer compartment, '
-                                     'which is not supported in SBML'.format(s))
+                    raise ValueError(
+                        "Species {} has more than one different monomer "
+                        "compartment, which is not supported in "
+                        "SBML".format(s)
+                    )
             else:
-                compartment_name = 'default'
+                compartment_name = "default"
             _check(sp.setCompartment(compartment_name))
-            _check(sp.setName(str(s).replace('% ', '._br_')))
+            _check(sp.setName(str(s).replace("% ", "._br_")))
             _check(sp.setBoundaryCondition(i in fixed_species_idx))
             _check(sp.setConstant(False))
-            _check(sp.setHasOnlySubstanceUnits(True))
+            _check(sp.setHasOnlySubstanceUnits(False))
             if i not in initial_species_idx:
-                _check(sp.setInitialAmount(0.0))
-
+                _check(sp.setInitialConcentration(0.0))
 
         # Parameters
 
-        for param in itertools.chain(self.model.parameters,
-                                     self.model._derived_parameters):
+        for param in itertools.chain(
+            self.model.parameters, self.model._derived_parameters
+        ):
             p = smodel.createParameter()
             _check(p)
             _check(p.setId(param.name))
@@ -241,38 +283,103 @@ class SbmlExporter(Exporter):
             _check(p.setConstant(True))
 
         # Reactions
-        for i, reaction in enumerate(self.model.reactions_bidirectional):
+        # Use the unidirectional reaction list so each reaction has a single
+        # well-defined set of reactants and a single BNG rate expression.
+        # BNG rates are concentration-based (dC/dt), while SBML kinetic laws
+        # represent amount flux (J = dN/dt = V * dC/dt).  For a reaction with
+        # n reactant molecules in compartment of volume V, the relationship is:
+        #   J = V^n * BNG_rate
+        # (BNG embeds 1/V^(n-1) for mass-action, giving dC/dt = BNG_rate;
+        # multiplying by V restores J in amount/time units.)
+        for i, reaction in enumerate(self.model.reactions):
             rxn = smodel.createReaction()
             _check(rxn)
-            _check(rxn.setId('r{}'.format(i)))
-            _check(rxn.setName(' + '.join(reaction['rule'])))
-            _check(rxn.setReversible(reaction['reversible']))
+            _check(rxn.setId("r{}".format(i)))
+            _check(rxn.setName(" + ".join(reaction["rule"])))
+            _check(rxn.setReversible(False))
 
-            for sp in reaction['reactants']:
+            # Consolidate duplicate species indices into a single
+            # speciesReference with the appropriate stoichiometry.
+            reactant_counts = {}
+            for sp in reaction["reactants"]:
+                reactant_counts[sp] = reactant_counts.get(sp, 0) + 1
+            for sp, stoich in reactant_counts.items():
                 reac = rxn.createReactant()
                 _check(reac)
-                _check(reac.setSpecies('__s{}'.format(sp)))
+                _check(reac.setSpecies("__s{}".format(sp)))
+                _check(reac.setStoichiometry(stoich))
                 _check(reac.setConstant(True))
 
-            for sp in reaction['products']:
+            product_counts = {}
+            for sp in reaction["products"]:
+                product_counts[sp] = product_counts.get(sp, 0) + 1
+            for sp, stoich in product_counts.items():
                 prd = rxn.createProduct()
                 _check(prd)
-                _check(prd.setSpecies('__s{}'.format(sp)))
+                _check(prd.setSpecies("__s{}".format(sp)))
+                _check(prd.setStoichiometry(stoich))
                 _check(prd.setConstant(True))
 
-            for symbol in reaction['rate'].free_symbols:
+            # Collect species that are already reactants or products so we
+            # do not duplicate them as modifiers (invalid SBML).
+            rxn_species = set(
+                "__s{}".format(sp)
+                for sp in itertools.chain(reaction["reactants"], reaction["products"])
+            )
+
+            for symbol in reaction["rate"].free_symbols:
                 if isinstance(symbol, pysb.Expression):
                     expr = symbol.expand_expr(expand_observables=True)
                     for sym in expr.free_symbols:
-                        if not isinstance(sym, (pysb.Parameter, pysb.Expression)):
-                            # Species reference, needs to be specified as modifier
-                            modifier = rxn.createModifier()
-                            _check(modifier)
-                            _check(modifier.setSpecies(str(sym)))
+                        if not isinstance(
+                            sym, (pysb.Parameter, pysb.Expression, SpecialSymbol)
+                        ):
+                            # Species reference -- only add as modifier if not
+                            # already a reactant or product.
+                            if str(sym) not in rxn_species:
+                                modifier = rxn.createModifier()
+                                _check(modifier)
+                                _check(modifier.setSpecies(str(sym)))
+
+            # Volume correction: determine V for the reaction compartment.
+            # For reactions with reactants, use the reactant compartment.
+            # For synthesis (no reactants), use the product compartment.
+            # For models without explicit compartments, V = 1 (no correction).
+            bng_rate = reaction["rate"]
+            if self.model.compartments:
+                n_reac = len(reaction["reactants"])
+                # Identify the reference species list (reactants if present,
+                # otherwise products) to determine the reaction compartment.
+                ref_indices = (
+                    reaction["reactants"]
+                    if reaction["reactants"]
+                    else reaction["products"]
+                )
+                cpt_size = None
+                for sp_idx in ref_indices:
+                    sp = self.model.species[sp_idx]
+                    mon_cpts = [
+                        mp.compartment
+                        for mp in sp.monomer_patterns
+                        if mp.compartment is not None
+                    ]
+                    if mon_cpts:
+                        cpt = mon_cpts[0]
+                        if cpt.size is not None:
+                            cpt_size = Symbol(cpt.size.name)
+                        break
+                if cpt_size is not None:
+                    # J = V^n * BNG_rate converts concentration-based BNG
+                    # rates to the amount/time flux expected by SBML.
+                    kinetic_rate = cpt_size**n_reac * bng_rate
+                else:
+                    kinetic_rate = bng_rate
+            else:
+                kinetic_rate = bng_rate
 
             rate = rxn.createKineticLaw()
             _check(rate)
-            rate_mathml = self._sympy_to_sbmlast(reaction['rate'])
+            rate_mathml = self._sympy_to_sbmlast(kinetic_rate)
             _check(rate.setMath(rate_mathml))
 
         # Observables
@@ -280,7 +387,7 @@ class SbmlExporter(Exporter):
             # create an observable "parameter"
             obs = smodel.createParameter()
             _check(obs)
-            _check(obs.setId('__obs{}'.format(i)))
+            _check(obs.setId("__obs{}".format(i)))
             _check(obs.setName(observable.name))
             _check(obs.setConstant(False))
 
@@ -293,15 +400,12 @@ class SbmlExporter(Exporter):
             obs_mathml = self._sympy_to_sbmlast(observable.expand_obs())
             _check(obs_rule.setMath(obs_mathml))
 
-
-
-
         # Apply any requested level/version conversion
         if level != (3, 2):
             prop = libsbml.ConversionProperties(libsbml.SBMLNamespaces(*level))
-            prop.addOption('strict', False)
-            prop.addOption('setLevelAndVersion', True)
-            prop.addOption('ignorePackages', True)
+            prop.addOption("strict", False)
+            prop.addOption("setLevelAndVersion", True)
+            prop.addOption("ignorePackages", True)
             _check(doc.convert(prop))
 
         return doc
@@ -315,8 +419,9 @@ class SbmlExporter(Exporter):
         Parameters
         ----------
         level: (int, int)
-            The SBML level and version to use. The default is SBML level 3, version 2. Conversion
-            to other levels/versions may not be possible or may lose fidelity.
+            The SBML level and version to use. The default is SBML level 3,
+            version 2. Conversion to other levels/versions may not be possible
+            or may lose fidelity.
 
         Returns
         -------

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -1071,49 +1071,70 @@ class SbmlImporter(Builder):
             product = product * obs**stoich
         return product
 
-    def _combinatorial_correction(self, list_of_refs):
-        """Compute the combinatorial correction factor for a species-reference list.
+    def _combinatorial_correction(self, reactant_refs, product_refs=None):
+        """Compute the combinatorial correction factor for a reaction.
 
-        PySB/BNG divides the rule rate by ``n!`` for each species that appears
-        with stoichiometry *n* (identical-reactant symmetry correction).  The
-        SBML kinetic law encodes the *net flux* directly and does not include
-        this factor, so the importer must multiply the intrinsic rate by the
-        same ``n!`` to counteract BNG's division.
+        PySB/BNG divides the rule rate by ``n!`` for each species that is
+        *net consumed* with multiplicity *n* (statistical / symmetry factor).
+        The SBML kinetic law does not include this factor, so the importer must
+        multiply the recovered rate by the same ``n!`` to counteract BNG's
+        division.
 
-        For example, a homodimerisation reaction ``A + A -> B`` (stoichiometry
-        2 for A) gets a correction factor of ``2! = 2``.  A reaction with
-        distinct reactants (all stoichiometries equal to 1) gets a factor of 1
-        and no correction is needed.
+        Critically, BNG only applies the factor based on **net consumption**
+        (reactant stoichiometry minus product stoichiometry, floored at zero).
+        For a catalytic species that appears on both sides (e.g. ``B`` in
+        ``B + B -> C + B``), the net consumption is 1, giving ``1! = 1`` (no
+        correction).  Only species that are *fully consumed* (not regenerated as
+        products) contribute to the factor.
+
+        Examples:
+
+        * ``A + A -> D``: net consumed A = 2, correction = ``2! = 2``.
+        * ``B + B -> C + B``: net consumed B = 1, correction = ``1! = 1``.
+        * ``A + B -> C``: net consumed A = 1, B = 1, correction = 1.
 
         Parameters
         ----------
-        list_of_refs : libsbml.ListOfSpeciesReferences
-            Reactant (or product) species-reference list from a libsbml reaction.
+        reactant_refs : libsbml.ListOfSpeciesReferences
+            Reactant species-reference list from a libsbml reaction.
+        product_refs : libsbml.ListOfSpeciesReferences, optional
+            Product species-reference list.  When provided, the net-consumed
+            stoichiometry (reactant - product, ≥ 0) is used; when omitted the
+            raw reactant stoichiometry is used.
 
         Returns
         -------
         int
-            Product of ``stoich!`` over all unique species in *list_of_refs*.
+            Product of ``net_stoich!`` over all unique reactant species.
         """
-        # Accumulate stoichiometry per unique species ID
-        stoich_by_species = {}
-        for j in range(list_of_refs.size()):
-            sr = list_of_refs.get(j)
-            sp_id = sr.getSpecies()
-            # Boundary species are excluded from PySB rule patterns, so BNG
-            # applies no symmetry correction for them.  Skip them here.
-            if sp_id in self._boundary_species:
-                continue
-            stoich = 1
-            if sr.isSetStoichiometry():
-                s = sr.getStoichiometry()
-                stoich = (
-                    int(round(s)) if math.isclose(s, round(s), rel_tol=1e-9) else int(s)
-                )
-            stoich_by_species[sp_id] = stoich_by_species.get(sp_id, 0) + stoich
+
+        def _stoich_map(refs):
+            result = {}
+            if refs is None:
+                return result
+            for j in range(refs.size()):
+                sr = refs.get(j)
+                sp_id = sr.getSpecies()
+                if sp_id in self._boundary_species:
+                    continue
+                stoich = 1
+                if sr.isSetStoichiometry():
+                    s = sr.getStoichiometry()
+                    stoich = (
+                        int(round(s))
+                        if math.isclose(s, round(s), rel_tol=1e-9)
+                        else int(s)
+                    )
+                result[sp_id] = result.get(sp_id, 0) + stoich
+            return result
+
+        reactant_stoich = _stoich_map(reactant_refs)
+        product_stoich = _stoich_map(product_refs)
+
         correction = 1
-        for stoich in stoich_by_species.values():
-            correction *= math.factorial(stoich)
+        for sp_id, r_stoich in reactant_stoich.items():
+            net = max(0, r_stoich - product_stoich.get(sp_id, 0))
+            correction *= math.factorial(net)
         return correction
 
     def _stoich_refs_to_patterns(self, sbml_model, list_of_refs):
@@ -1321,7 +1342,7 @@ class SbmlImporter(Builder):
                 # Forward rule: reactants -> products
                 reactant_factor = self._obs_product_for_refs(rxn.getListOfReactants())
                 fwd_correction = self._combinatorial_correction(
-                    rxn.getListOfReactants()
+                    rxn.getListOfReactants(), rxn.getListOfProducts()
                 )
                 fwd_rate_expr = sympy.simplify(
                     fwd_correction * fwd_flux / (rxn_vol * reactant_factor)
@@ -1366,7 +1387,7 @@ class SbmlImporter(Builder):
                 if rev_flux is not None:
                     product_factor = self._obs_product_for_refs(rxn.getListOfProducts())
                     rev_correction = self._combinatorial_correction(
-                        rxn.getListOfProducts()
+                        rxn.getListOfProducts(), rxn.getListOfReactants()
                     )
                     rev_rate_expr = sympy.simplify(
                         rev_correction * rev_flux / (prod_vol * product_factor)
@@ -1412,7 +1433,9 @@ class SbmlImporter(Builder):
                 # BNG rules, then multiply by the combinatorial correction so
                 # that PySB/BNG's internal symmetry division cancels out.
                 reactant_factor = self._obs_product_for_refs(rxn.getListOfReactants())
-                correction = self._combinatorial_correction(rxn.getListOfReactants())
+                correction = self._combinatorial_correction(
+                    rxn.getListOfReactants(), rxn.getListOfProducts()
+                )
                 rate_expr = sympy.simplify(
                     correction * net_flux / (rxn_vol * reactant_factor)
                 )

--- a/pysb/importers/sbml.py
+++ b/pysb/importers/sbml.py
@@ -1,17 +1,196 @@
+"""
+Import SBML models into PySB.
+
+Two backends are provided:
+
+**libsbml (default)**
+    :class:`SbmlImporter` reads an SBML file via the ``python-libsbml``
+    package and builds a PySB model directly.  No external programs are
+    required.  Use :func:`model_from_sbml` (``use_libsbml=True``, the
+    default).
+
+**Legacy sbmlTranslator / Atomizer**
+    The BioNetGen ``sbmlTranslator`` binary (also known as *Atomizer*) can
+    attempt to infer higher-level rule-based structure from SBML.  Pass
+    ``use_libsbml=False`` to :func:`model_from_sbml` to use this path.
+    Atomizer must be installed separately (see :func:`sbml_translator`).
+
+SBML level and version support (libsbml importer)
+--------------------------------------------------
+
+The libsbml importer supports **SBML Level 2 Version 1–5** and
+**Level 3 Version 1–2**, which covers the vast majority of models in
+public repositories such as BioModels.
+
+**Level 1** SBML (versions 1–2) is read by libsbml and converted to an
+equivalent internal representation, so most Level 1 files will import
+correctly.  However Level 1 lacks several features (e.g. MathML,
+compartments, assignment rules, function definitions) and has not been
+validated as thoroughly as Level 2/3.
+
+SBML feature support (libsbml importer)
+----------------------------------------
+
+The table below summarises which SBML constructs are handled and how they
+map to PySB components.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - SBML construct
+     - PySB representation
+   * - ``<species>``
+     - :class:`~pysb.core.Monomer` with no sites +
+       :class:`~pysb.core.Observable` ``obs_<id>`` for use in rate laws
+   * - ``<reaction>`` (irreversible) with ``<kineticLaw>``
+     - :class:`~pysb.core.Rule` with a function-based
+       :class:`~pysb.core.Expression` rate equal to the kinetic law
+       **divided by the product of reactant observables and by the reaction
+       compartment volume** (so that PySB/BNG's implicit reactant-count
+       multiplication yields the correct concentration ODE flux,
+       ``dC/dt = J/V``).  A combinatorial correction (``n!`` for each
+       species appearing with stoichiometry *n*) is applied to cancel
+       BNG's internal symmetry-factor division for homo-multimers.
+       When reactants and products reside in different compartments
+       (transport), two rules are generated: a degradation rule for the
+       source compartment and a synthesis rule for the destination
+       compartment, so that each species ODE is divided by its own
+       compartment volume.
+   * - ``<reaction>`` (reversible, ``reversible="true"``) with ``<kineticLaw>``
+     - Two non-reversible :class:`~pysb.core.Rule` objects (``<id>_fwd``
+       and ``<id>_rev``).  The net-flux kinetic law is split into positive
+       and negative additive terms; each half is divided by the product of
+       the corresponding species observables, by the compartment volume,
+       and by the combinatorial correction.  If the split fails a warning
+       is issued and only the forward rule is created.  Cross-compartment
+       reactions produce up to four rules (``_fwd_deg``, ``_fwd_prod``,
+       ``_rev_deg``, ``_rev_prod``) for the same reason as the irreversible
+       case above.
+   * - ``<parameter>``
+     - :class:`~pysb.core.Parameter` (``nonnegative=False`` so negative
+       values such as reversal potentials are accepted)
+   * - ``<compartment>``
+     - :class:`~pysb.core.Compartment` + a size
+       :class:`~pysb.core.Parameter` named ``<id>_size``
+   * - ``<assignmentRule>``
+     - :class:`~pysb.core.Expression`
+   * - ``<rateRule>`` (ODE-only models)
+     - :class:`~pysb.core.Monomer` ``X()`` + production rule
+       ``None >> X()`` whose rate expression equals the full RHS, encoding
+       ``dX/dt = f(...)`` faithfully.  Concentrations may go negative
+       (e.g. membrane voltage), which :class:`~pysb.simulator.ScipyOdeSimulator`
+       handles correctly.
+   * - ``<initialAssignment>``
+     - Updates the species initial-condition parameter value
+   * - ``<functionDefinition>``
+     - Parsed to a Python callable used during kinetic-law function parsing
+   * - ``csymbol`` ``time``
+     - Maps to :data:`pysb.core.time`, PySB's simulation-time symbol
+   * - ``boundaryCondition="true"``
+     - :class:`~pysb.core.Initial` with ``fixed=True``; the species is
+       **excluded from all rule patterns** so BNG does not include it in
+       ODEs, but it may still appear in kinetic-law expressions
+   * - Integer stoichiometry *n* > 1
+     - *n* copies of the reactant/product :class:`~pysb.core.ComplexPattern`
+       in the rule, plus the combinatorial correction described above
+
+Known limitations
+-----------------
+
+* **Flat import only.** All species are created as site-less Monomers; no
+  binding-site structure is inferred.  For structure inference (atomisation)
+  use ``model_from_sbml(filename, use_libsbml=False, atomize=True)``.
+
+* **Algebraic rules are not supported** and raise :class:`SbmlImportError`
+  (or warn with ``force=True``).  Algebraic rules define implicit
+  constraints ``0 = f(...)`` that require a DAE solver, which PySB does
+  not provide.
+
+* **SBML Events are not supported** and raise :class:`SbmlImportError`
+  (or warn with ``force=True``).  Events describe triggered discontinuities
+  (e.g. stimulus pulses) that have no rule-based analogue in PySB.
+
+* **Non-integer stoichiometry** is truncated to the nearest integer and a
+  :mod:`warnings` warning is issued.  Use kinetic-law expressions to
+  represent fractional stoichiometries.
+
+* **Rate-rule variables placed in first compartment.** When a model has
+  compartments, rate-rule variables (which are SBML parameters, not species)
+  are assigned to the first compartment to satisfy PySB's concreteness
+  requirement.  This is a formal annotation that does not affect the ODEs.
+
+* **Stochastic simulation of rate-rule models.** ``None >> X()`` rules with
+  expressions that may be negative have no valid stochastic interpretation.
+  Use :class:`~pysb.simulator.ScipyOdeSimulator` for ODE integration.
+
+* **Unit definitions** are parsed but ignored; all quantities are treated as
+  dimensionless.
+
+* **Dynamic compartments** (compartments whose size changes via a rule) raise
+  :class:`SbmlImportError` (or warn with ``force=True``); the compartment
+  retains its initial size.
+
+* **Non-separable reversible kinetic laws**: when a reversible reaction's
+  kinetic law cannot be split into distinct positive (forward) and negative
+  (reverse) additive terms (e.g. a single Michaelis-Menten-like fraction that
+  spans both directions), :func:`_split_reversible_rate` returns
+  ``(None, None)`` and a warning is issued.  Only the forward rule is created
+  and the reverse direction is absent from the model.
+
+* **Reaction ``fast`` attribute**: ``fast="true"`` (quasi-steady-state,
+  deprecated in SBML Level 3 Version 2) issues a :mod:`warnings` warning and
+  is otherwise ignored.
+
+* **Local kinetic-law parameters**: parameters declared inside a
+  ``<kineticLaw>`` element that shadow global parameters of the same name are
+  not added to the PySB model.  A :mod:`warnings` warning is issued listing
+  the affected parameter IDs; the global parameter is used in its place.
+
+* **Unnamed reactions**: reactions with no ``id`` attribute are assigned the
+  fallback name ``r0``, ``r1``, …, ``rN``.
+
+* **Zero stoichiometry**: a stoichiometry value of 0 (unusual but valid in
+  SBML) produces zero pattern copies and is effectively a no-op for that
+  species reference.
+
+* **Multiple rate rules on the same variable** are not supported; the second
+  rule encountered for a given variable raises :class:`SbmlImportError` (or
+  warns with ``force=True``) because duplicate PySB rules are not valid.
+"""
+
 from pysb.importers.bngl import model_from_bngl
+from pysb.builder import Builder
+from pysb.core import (
+    MonomerPattern,
+    ComplexPattern,
+    RuleExpression,
+    ReactionPattern,
+    time as pysb_time,
+)
+from pysb.bng import parse_bngl_expr
+import pysb.logging
 import pysb.pathfinder as pf
 import subprocess
 import os
+import math
+import re
 import tempfile
 import shutil
-import re
+import sympy
+import warnings
 from urllib.request import urlretrieve
 from pysb.logging import get_logger, EXTENDED_DEBUG
 
-BIOMODELS_REGEX = re.compile(r'(BIOMD|MODEL)[0-9]{10}')
+try:
+    import libsbml
+except ImportError:
+    libsbml = None
+
+BIOMODELS_REGEX = re.compile(r"(BIOMD|MODEL)[0-9]{10}")
 BIOMODELS_URLS = {
-    'ebi': 'http://www.ebi.ac.uk/biomodels-main/download?mid={}',
-    'caltech': 'http://biomodels.caltech.edu/download?mid={}'
+    "ebi": "http://www.ebi.ac.uk/biomodels-main/download?mid={}",
+    "caltech": "http://biomodels.caltech.edu/download?mid={}",
 }
 
 
@@ -19,15 +198,1354 @@ class SbmlTranslationError(Exception):
     pass
 
 
-def sbml_translator(input_file,
-                    output_file=None,
-                    convention_file=None,
-                    naming_conventions=None,
-                    user_structures=None,
-                    molecule_id=False,
-                    atomize=False,
-                    pathway_commons=False,
-                    verbose=False):
+class SbmlImportError(Exception):
+    pass
+
+
+def _sanitize_id(sbml_id):
+    """Convert an SBML ID to a valid Python/PySB identifier"""
+    name = re.sub(r"[^a-zA-Z0-9_]", "_", sbml_id)
+    if name and name[0].isdigit():
+        name = "s_" + name
+    return name or "unnamed"
+
+
+_SBML_MATH_FUNCTIONS = {
+    "ln": sympy.log,
+    "log": sympy.log,
+    "exp": sympy.exp,
+    "sqrt": sympy.sqrt,
+    "abs": sympy.Abs,
+    "sin": sympy.sin,
+    "cos": sympy.cos,
+    "tan": sympy.tan,
+    "asin": sympy.asin,
+    "acos": sympy.acos,
+    "atan": sympy.atan,
+    "floor": sympy.floor,
+    "ceiling": sympy.ceiling,
+    "pow": sympy.Pow,
+    "root": sympy.sqrt,
+    "factorial": sympy.factorial,
+    "tanh": sympy.tanh,
+    "sinh": sympy.sinh,
+    "cosh": sympy.cosh,
+}
+
+
+class SbmlImporter(Builder):
+    """Import a flat SBML model using libsbml.
+
+    Reads an SBML file and constructs a PySB model.  The importer is a
+    :class:`~pysb.builder.Builder` subclass, so the resulting model is
+    available as ``importer.model`` after construction.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the SBML file (any SBML Level/Version supported by libsbml).
+    force : bool, optional
+        If False (default), raises :class:`SbmlImportError` when an
+        unsupported construct is encountered.  If True, issues a
+        :mod:`warnings` warning and continues, producing a partial model.
+
+    Raises
+    ------
+    ImportError
+        If the ``libsbml`` Python package is not installed.
+    SbmlImportError
+        If the SBML file contains fatal errors or an unsupported construct
+        is encountered (and ``force=False``).
+
+    Notes
+    -----
+    For most use cases the convenience functions :func:`model_from_sbml`,
+    or :func:`model_from_biomodels` are easier to use than instantiating
+    :class:`SbmlImporter` directly.
+
+    **SBML ID sanitisation**: SBML IDs may contain characters that are
+    invalid in Python identifiers (hyphens, dots, etc.).  These are replaced
+    with underscores by :func:`_sanitize_id`.  IDs that start with a digit
+    are prefixed with ``s_``.
+
+    **Species/observables**: each SBML ``<species>`` element becomes a
+    :class:`~pysb.core.Monomer` named after its SBML ID (sanitised) and a
+    corresponding :class:`~pysb.core.Observable` named ``obs_<id>``.  The
+    observable is used in kinetic-law and assignment-rule expressions so that
+    species amounts appear naturally in rate expressions.  Initial conditions
+    are created as ``<id>_0`` :class:`~pysb.core.Parameter` objects.
+
+    **Reactions**: each SBML ``<reaction>`` becomes a
+    :class:`~pysb.core.Rule`.  The kinetic law is parsed and stored as a
+    function-based :class:`~pysb.core.Expression`; BNG/PySB then use the
+    expression value directly as the ODE flux (no additional multiplication
+    by species counts).
+
+    **Parameters**: SBML ``<parameter>`` elements become PySB
+    :class:`~pysb.core.Parameter` objects with ``nonnegative=False`` so that
+    negative values (e.g. reversal potentials in electrophysiology models)
+    are accepted without error.
+
+    **Compartments**: each ``<compartment>`` becomes both a PySB
+    :class:`~pysb.core.Compartment` and a size
+    :class:`~pysb.core.Parameter` named ``<id>_size``.  The size parameter
+    is used inside kinetic-law expressions wherever the compartment ID
+    appears (consistent with the SBML convention of multiplying rates by
+    compartment volume).
+
+    **Assignment rules**: ``<assignmentRule>`` elements create PySB
+    :class:`~pysb.core.Expression` objects whose value tracks the rule RHS at
+    every time point.  The corresponding SBML parameter is *not* added to the
+    model as a plain ``Parameter``.
+
+    **Rate rules**: ``<rateRule>`` elements (ODE-only models) are
+    represented as synthesis rules ``None >> X()`` with a function-based rate
+    equal to the full RHS.  Because PySB/BNG use the expression as the
+    direct ODE flux, this faithfully encodes ``dX/dt = f(...)``.  Negative
+    flux values are valid (e.g. membrane voltage) and are handled correctly by
+    :class:`~pysb.simulator.ScipyOdeSimulator`.
+
+    **FunctionDefinitions**: SBML ``<functionDefinition>`` elements are
+    parsed into Python callables (via :mod:`sympy` substitution) and made
+    available when evaluating kinetic-law functions.
+
+    **Initial assignments**: ``<initialAssignment>`` elements override
+    species initial values.  This is the mechanism used by PySB's own SBML
+    exporter, so round-trip import/export is supported.
+
+    Examples
+    --------
+    >>> from pysb.importers.sbml import SbmlImporter
+    >>> imp = SbmlImporter('my_model.xml')        # doctest: +SKIP
+    >>> model = imp.model                         # doctest: +SKIP
+    >>> print(model.monomers)                     # doctest: +SKIP
+    """
+
+    def __init__(self, filename_or_string, force=False):
+        super().__init__()
+
+        if libsbml is None:
+            raise ImportError("The SbmlImporter requires the libsbml python package")
+
+        reader = libsbml.SBMLReader()
+
+        # Accept either a path to an SBML file or a raw SBML string/bytes so
+        # that callers (especially tests) can avoid writing temporary files.
+        if isinstance(filename_or_string, bytes):
+            sbml_string = filename_or_string.decode("utf-8")
+            doc = reader.readSBMLFromString(sbml_string)
+            source_name = None
+        elif isinstance(filename_or_string, str) and (
+            filename_or_string.lstrip().startswith("<") or "\n" in filename_or_string
+        ):
+            doc = reader.readSBMLFromString(filename_or_string)
+            source_name = None
+        else:
+            filename = os.path.abspath(filename_or_string)
+            doc = reader.readSBMLFromFile(filename)
+            source_name = filename
+
+        self._check_sbml_errors(doc, force)
+        self._check_sbml_level_version(doc)
+
+        sbml_model = doc.getModel()
+        if sbml_model is None:
+            raise SbmlImportError("No model found in SBML file")
+
+        model_id = sbml_model.getId()
+        if model_id:
+            name = model_id
+        elif source_name is not None:
+            name = os.path.splitext(os.path.basename(source_name))[0]
+        else:
+            name = "model"
+        self.model.name = _sanitize_id(name) or "model"
+
+        self._force = force
+        self._log = pysb.logging.get_logger(__name__)
+        self._id_map = {}  # SBML ID -> PySB component name
+        self._species_obs = {}  # SBML species ID -> Observable
+        self._func_defs = {}  # SBML function definition ID -> callable
+        self._boundary_species = set()  # SBML species IDs with boundaryCondition=True
+
+        # Collect variable IDs that are governed by rules (not plain Parameters)
+        self._assigned_vars = set()  # assignment rules -> Expressions
+        self._rate_rule_vars = set()  # rate rules -> Monomers + ODE rules
+        for i in range(sbml_model.getNumRules()):
+            rule = sbml_model.getRule(i)
+            tc = rule.getTypeCode()
+            if tc == libsbml.SBML_ASSIGNMENT_RULE:
+                self._assigned_vars.add(rule.getVariable())
+            elif tc == libsbml.SBML_RATE_RULE:
+                var_id = rule.getVariable()
+                if var_id in self._rate_rule_vars:
+                    self._warn_or_except(
+                        'Multiple rate rules for variable "{}"; only the first '
+                        "will be used".format(var_id)
+                    )
+                else:
+                    self._rate_rule_vars.add(var_id)
+            elif tc == libsbml.SBML_ALGEBRAIC_RULE:
+                self._warn_or_except(
+                    "Algebraic rules are not supported and cannot be "
+                    "represented in PySB (algebraic rule {} skipped)".format(
+                        rule.getId() or i
+                    )
+                )
+
+        if sbml_model.getNumEvents() > 0:
+            self._warn_or_except(
+                "SBML Events are not supported and will be ignored "
+                "({} event(s) found)".format(sbml_model.getNumEvents())
+            )
+
+        self._parse_function_definitions(sbml_model)
+        self._parse_compartments(sbml_model)
+        self._parse_species(sbml_model)
+        self._parse_parameters(sbml_model)
+        self._parse_initial_assignments(sbml_model)
+        self._parse_assignment_rules(sbml_model)
+        self._parse_rate_rules(sbml_model)
+        self._parse_reactions(sbml_model)
+
+    def _check_sbml_errors(self, doc, force):
+        """Raise or warn if the SBML document contains fatal error messages.
+
+        Iterates over libsbml error log entries and collects those with
+        severity at or above ``LIBSBML_SEV_ERROR``.  If any are found and
+        *force* is False, raises :class:`SbmlImportError`; with *force* True
+        a :mod:`warnings` warning is issued and the caller may continue with
+        a partial model.
+        """
+        errors = []
+        for i in range(doc.getNumErrors()):
+            error = doc.getError(i)
+            if error.getSeverity() >= libsbml.LIBSBML_SEV_ERROR:
+                errors.append("[{}] {}".format(error.getErrorId(), error.getMessage()))
+        if errors:
+            msg = "SBML file contains errors:\n" + "\n".join(errors)
+            if force:
+                warnings.warn(msg)
+            else:
+                raise SbmlImportError(msg)
+
+    def _check_sbml_level_version(self, doc):
+        """Warn if the SBML document level/version is outside the validated range.
+
+        The importer has been validated against SBML Level 2 Versions 1–5 and
+        Level 3 Versions 1–2.  Level 1 is readable but has limited features and
+        has not been thoroughly validated.  Unknown future levels/versions issue
+        a warning so the user is aware that results may be incorrect.
+        """
+        level = doc.getLevel()
+        version = doc.getVersion()
+        if level == 1:
+            warnings.warn(
+                "SBML Level 1 has limited support and has not been thoroughly "
+                "validated by the PySB importer. Consider upgrading to Level 2 "
+                "or 3."
+            )
+        elif level == 2 and version > 5:
+            warnings.warn(
+                "SBML Level 2 Version {} is not a known release; the importer "
+                "has been validated against Level 2 Versions 1–5.".format(version)
+            )
+        elif level == 3 and version > 2:
+            warnings.warn(
+                "SBML Level 3 Version {} has not been validated by the PySB "
+                "importer (validated against Level 3 Versions 1–2).".format(version)
+            )
+        elif level > 3:
+            warnings.warn(
+                "SBML Level {} is unknown to this importer; import may fail or "
+                "produce incorrect results.".format(level)
+            )
+
+    def _warn_or_except(self, msg):
+        """Issue a warning or raise :class:`SbmlImportError` depending on *force*.
+
+        When ``self._force`` is True the message is emitted via
+        :mod:`warnings`; otherwise :class:`SbmlImportError` is raised.
+        This gives callers a uniform way to handle unsupported constructs.
+        """
+        if self._force:
+            warnings.warn(msg)
+        else:
+            raise SbmlImportError(msg)
+
+    def _parse_function_definitions(self, sbml_model):
+        """Parse SBML FunctionDefinition elements into Python callables.
+
+        Each function definition is stored in ``self._func_defs`` and later
+        added to the local namespace used for SBML expression parsing.
+        """
+        for i in range(sbml_model.getNumFunctionDefinitions()):
+            fd = sbml_model.getFunctionDefinition(i)
+            fd_id = fd.getId()
+            math = fd.getMath()
+
+            if math is None or math.getType() != libsbml.AST_LAMBDA:
+                continue
+
+            # Children are formal arguments followed by the body expression
+            n_children = math.getNumChildren()
+            if n_children == 0:
+                continue
+            arg_names = [math.getChild(j).getName() for j in range(n_children - 1)]
+            body_node = math.getChild(n_children - 1)
+            body_formula = libsbml.formulaToL3String(body_node)
+            if body_formula is None:
+                continue
+
+            # Build a sympy lambda: parse the body with symbolic args so that
+            # calls can be substituted when the function is used in a rate law.
+            arg_syms = [sympy.Symbol(a) for a in arg_names]
+            try:
+                body_expr = parse_bngl_expr(
+                    body_formula, local_dict={a: s for a, s in zip(arg_names, arg_syms)}
+                )
+            except Exception as exc:
+                self._warn_or_except(
+                    'Could not parse function definition "{}": {}'.format(fd_id, exc)
+                )
+                continue
+
+            def _make_callable(arg_syms, body_expr):
+                def fn(*args):
+                    return body_expr.subs(dict(zip(arg_syms, args)))
+
+                return fn
+
+            self._func_defs[fd_id] = _make_callable(arg_syms, body_expr)
+
+    def _parse_compartments(self, sbml_model):
+        """Create PySB Compartments and matching size Parameters.
+
+        Each SBML ``<compartment>`` becomes a :class:`~pysb.core.Compartment`
+        plus a :class:`~pysb.core.Parameter` named ``<id>_size`` holding the
+        initial size.  Compartment hierarchies (the ``outside`` attribute) are
+        respected: the parent compartment must appear before the child in the
+        SBML document, which is the standard ordering.
+        """
+        for i in range(sbml_model.getNumCompartments()):
+            cpt = sbml_model.getCompartment(i)
+            cpt_id = cpt.getId()
+            cpt_name = _sanitize_id(cpt_id)
+            self._id_map[cpt_id] = cpt_name
+
+            size_val = cpt.getSize() if cpt.isSetSize() else 1.0
+            size_param = self.parameter(cpt_name + "_size", size_val, nonnegative=False)
+
+            parent = None
+            outside = cpt.getOutside() if cpt.isSetOutside() else None
+            if outside:
+                parent_name = self._id_map.get(outside, _sanitize_id(outside))
+                parent = self.model.compartments.get(parent_name)
+
+            dims = cpt.getSpatialDimensions()
+            self.compartment(
+                name=cpt_name,
+                parent=parent,
+                dimension=int(dims) if dims else 3,
+                size=size_param,
+            )
+
+    def _parse_species(self, sbml_model):
+        """Create Monomers, Observables, and initial conditions for SBML species.
+
+        Each ``<species>`` element becomes:
+
+        * A site-less :class:`~pysb.core.Monomer`.
+        * An :class:`~pysb.core.Observable` ``obs_<id>`` used in rate
+          expressions.
+        * An initial-condition :class:`~pysb.core.Parameter` ``<id>_0``
+          holding the ``initialAmount`` or ``initialConcentration`` value
+          (``initialAmount`` takes precedence when both are present, per the
+          SBML specification).
+
+        Species with ``boundaryCondition="true"`` are created as *fixed*
+        initials so their concentration is held constant throughout simulation,
+        **unless** a rate rule governs them; in that case the rate rule drives
+        their dynamics and the initial should not be fixed.
+        """
+        for i in range(sbml_model.getNumSpecies()):
+            sp = sbml_model.getSpecies(i)
+            sp_id = sp.getId()
+            sp_name = _sanitize_id(sp_id)
+            self._id_map[sp_id] = sp_name
+
+            mon = self.monomer(sp_name)
+
+            cpt_id = sp.getCompartment()
+            cpt = (
+                self.model.compartments.get(
+                    self._id_map.get(cpt_id, _sanitize_id(cpt_id))
+                )
+                if cpt_id
+                else None
+            )
+
+            mon_pat = MonomerPattern(mon, {}, cpt)
+            cp = ComplexPattern([mon_pat], cpt)
+
+            # Observable for use in kinetic law and assignment rule expressions
+            obs = self.observable("obs_" + sp_name, cp)
+            self._species_obs[sp_id] = obs
+
+            # Initial condition
+            if sp.isSetInitialAmount():
+                init_val = sp.getInitialAmount()
+            elif sp.isSetInitialConcentration():
+                init_val = sp.getInitialConcentration()
+            else:
+                init_val = 0.0
+
+            init_param = self.parameter(sp_name + "_0", init_val, nonnegative=False)
+            # Track boundary species (used later to exclude them from reaction
+            # patterns and rate-division factors).
+            if sp.getBoundaryCondition():
+                self._boundary_species.add(sp_id)
+            # A boundary species whose amount is governed by a rate rule must
+            # NOT be fixed: the rate rule drives its dynamics.  Only fix it
+            # when there is no rate rule (i.e. it is truly held constant).
+            is_fixed = sp.getBoundaryCondition() and sp_id not in self._rate_rule_vars
+            self.initial(cp, init_param, fixed=is_fixed)
+
+    def _parse_parameters(self, sbml_model):
+        """Create PySB Parameters for plain SBML parameters.
+
+        Parameters governed by ``<assignmentRule>`` or ``<rateRule>`` elements
+        are skipped here; they are handled by :meth:`_parse_assignment_rules`
+        and :meth:`_parse_rate_rules` respectively.  Parameters whose value
+        attribute is not set (valid in SBML when a value will be supplied
+        externally) are also skipped.
+        """
+        for i in range(sbml_model.getNumParameters()):
+            param = sbml_model.getParameter(i)
+            param_id = param.getId()
+            param_name = _sanitize_id(param_id)
+            self._id_map[param_id] = param_name
+
+            # Parameters governed by rules are handled separately
+            if param_id in self._assigned_vars or param_id in self._rate_rule_vars:
+                continue
+
+            if param.isSetValue():
+                self.parameter(param_name, param.getValue(), nonnegative=False)
+
+    def _parse_initial_assignments(self, sbml_model):
+        """Handle SBML initialAssignment elements.
+
+        These override any initialAmount/initialConcentration values set on
+        species, and are the mechanism used by PySB's SBML exporter.
+        """
+        for i in range(sbml_model.getNumInitialAssignments()):
+            ia = sbml_model.getInitialAssignment(i)
+            symbol = ia.getSymbol()
+            math = ia.getMath()
+            if math is None:
+                continue
+
+            # We only update species initials; parameter assignments are rare
+            sp_name = self._id_map.get(symbol)
+            if sp_name is None or sp_name not in self.model.monomers.keys():
+                continue
+
+            expr_val = self._formula_to_sympy(math)
+
+            # Replace the placeholder initial with the correct value
+            for ic in self.model.initials:
+                if (
+                    len(ic.pattern.monomer_patterns) == 1
+                    and ic.pattern.monomer_patterns[0].monomer.name == sp_name
+                ):
+                    if isinstance(expr_val, sympy.Expr) and expr_val.is_number:
+                        # Numerically constant expression: update the
+                        # existing placeholder Parameter value in place.
+                        ic.value.value = float(expr_val)
+                    elif isinstance(expr_val, sympy.Expr):
+                        # Expression with free symbols: try to evaluate it
+                        # numerically by substituting known Parameter values.
+                        # BNG/PySB require ic.value to be a Parameter, so
+                        # we cannot store a raw sympy Mul/Add there.
+                        from pysb import Parameter as _Parameter
+
+                        sub_map = {
+                            sym: sym.value
+                            for sym in expr_val.free_symbols
+                            if isinstance(sym, _Parameter)
+                        }
+                        numeric_val = expr_val.subs(sub_map)
+                        if (
+                            isinstance(numeric_val, sympy.Expr)
+                            and numeric_val.is_number
+                        ):
+                            ic.value.value = float(numeric_val)
+                        else:
+                            # Cannot reduce to a number; create a PySB
+                            # Expression and store it as ic.value.
+                            # (Rare; only happens when a free symbol is not a
+                            # known constant Parameter.)
+                            expr_comp = self.expression(sp_name + "_init", expr_val)
+                            ic.value = expr_comp
+                    break
+
+    def _build_formula_locals(self):
+        """Build a local namespace for sympy expression parsing."""
+        local_dict = dict(_SBML_MATH_FUNCTIONS)
+
+        # Map species IDs to their observables
+        for sp_id, obs in self._species_obs.items():
+            local_dict[sp_id] = obs
+
+        # Map SBML IDs and sanitised names to model components.
+        # Compartments are not sympy-compatible; map them to their size
+        # parameters instead (compartment volume as used in kinetic laws).
+        from pysb import Compartment as _Compartment
+
+        for orig_id, pysb_name in self._id_map.items():
+            if orig_id in local_dict:
+                continue
+            try:
+                comp = self.model.all_components()[pysb_name]
+            except KeyError:
+                continue
+            if isinstance(comp, _Compartment):
+                size_name = pysb_name + "_size"
+                try:
+                    comp = self.model.parameters[size_name]
+                except KeyError:
+                    continue
+            local_dict[orig_id] = comp
+            local_dict[pysb_name] = comp
+
+        # Map SBML csymbol 'time' to PySB's time special symbol so that
+        # time-varying kinetic laws are represented correctly in Expressions.
+        local_dict["time"] = pysb_time
+
+        # Include user-defined SBML functions
+        local_dict.update(self._func_defs)
+
+        return local_dict
+
+    def _formula_to_sympy(self, ast_node):
+        """Convert a libsbml ASTNode to a sympy expression.
+
+        Serialises *ast_node* to an L3 formula string via
+        ``libsbml.formulaToL3String``, then parses it with
+        :func:`~pysb.bng.parse_bngl_expr` using the local namespace built by
+        :meth:`_build_math_locals`.  Returns ``sympy.Integer(0)`` when the
+        node cannot be serialised or parsed (also calls :meth:`_warn_or_except`
+        so the failure is visible to the caller).
+        """
+        formula = libsbml.formulaToL3String(ast_node)
+        if formula is None:
+            return sympy.Integer(0)
+
+        try:
+            return parse_bngl_expr(formula, local_dict=self._build_formula_locals())
+        except Exception as exc:
+            self._warn_or_except(
+                'Could not parse SBML math "{}": {}'.format(formula, exc)
+            )
+            return sympy.Integer(0)
+
+    def _parse_assignment_rules(self, sbml_model):
+        """Create PySB Expressions for SBML assignmentRule elements.
+
+        Each rule ``variable = f(...)`` becomes an
+        :class:`~pysb.core.Expression` whose value is recomputed at every
+        time point.  Rules targeting compartment IDs (dynamic compartment
+        sizes) are not supported and trigger :meth:`_warn_or_except`.  Rules
+        whose variable name already maps to an existing model component (e.g.
+        a species observable) are silently skipped.
+        """
+        cpt_ids = {
+            sbml_model.getCompartment(i).getId()
+            for i in range(sbml_model.getNumCompartments())
+        }
+
+        for i in range(sbml_model.getNumRules()):
+            rule = sbml_model.getRule(i)
+            if rule.getTypeCode() != libsbml.SBML_ASSIGNMENT_RULE:
+                continue
+
+            var_id = rule.getVariable()
+            var_name = _sanitize_id(var_id)
+            self._id_map[var_id] = var_name
+
+            if var_id in cpt_ids:
+                self._warn_or_except(
+                    'Assignment rule targeting compartment "{}" (dynamic '
+                    "compartment size) is not supported and will be "
+                    "ignored".format(var_id)
+                )
+                continue
+
+            # Skip if already a model component (e.g., species observables)
+            if var_name in self.model.all_components().keys():
+                continue
+
+            math = rule.getMath()
+            if math is None:
+                continue
+
+            expr_val = self._formula_to_sympy(math)
+            self.expression(var_name, expr_val)
+
+    def _parse_rate_rules(self, sbml_model):
+        """Handle SBML rateRule elements.
+
+        Each rate-rule variable X is treated as a species (Monomer with no
+        sites) and its ODE is encoded as a synthesis rule::
+
+            None >> X()   with rate = full RHS expression
+
+        With a function-based rate, PySB/BNG use the expression value directly
+        as the ODE flux, so this faithfully encodes ``dX/dt = f(...)``.  The
+        concentration can go negative (e.g. membrane voltage), which is valid
+        for ScipyOdeSimulator.
+        """
+        # If the model has compartments, rate-rule variables (which are SBML
+        # parameters, not species) are assigned to the first compartment so
+        # that PySB patterns are concrete.  For truly ODE-only models this is
+        # a formal assignment that does not affect the mathematics.
+        cpt_list = list(self.model.compartments.values())
+        default_cpt = cpt_list[0] if cpt_list else None
+
+        # Collect compartment IDs for dynamic-compartment detection
+        cpt_ids = {
+            sbml_model.getCompartment(i).getId()
+            for i in range(sbml_model.getNumCompartments())
+        }
+
+        # Create Monomers/Observables/Initials for rate-rule variables that
+        # are not already SBML species
+        for var_id in self._rate_rule_vars:
+            if var_id in self._species_obs:
+                continue
+
+            if var_id in cpt_ids:
+                self._warn_or_except(
+                    'Rate rule targeting compartment "{}" (dynamic compartment '
+                    "size) is not supported and will be ignored".format(var_id)
+                )
+                continue
+
+            var_name = _sanitize_id(var_id)
+            self._id_map[var_id] = var_name
+
+            # Initial value comes from the SBML parameter definition
+            param = sbml_model.getParameter(var_id)
+            init_val = param.getValue() if (param and param.isSetValue()) else 0.0
+
+            mon = self.monomer(var_name)
+            cp = ComplexPattern([MonomerPattern(mon, {}, default_cpt)], default_cpt)
+            obs = self.observable("obs_" + var_name, cp)
+            self._species_obs[var_id] = obs
+
+            init_p = self.parameter(var_name + "_0", init_val, nonnegative=False)
+            self.initial(cp, init_p)
+
+        # Create one production rule per rate rule
+        # Track which variables have already been assigned a production rule
+        # so that duplicate rate rules (warned about during collection) are
+        # not processed a second time.
+        processed_rate_vars = set()
+        for i in range(sbml_model.getNumRules()):
+            rule = sbml_model.getRule(i)
+            if rule.getTypeCode() != libsbml.SBML_RATE_RULE:
+                continue
+
+            var_id = rule.getVariable()
+
+            # Skip duplicates: only the first rule for each variable is used.
+            if var_id not in self._rate_rule_vars:
+                continue
+            if var_id in processed_rate_vars:
+                continue
+            processed_rate_vars.add(var_id)
+
+            var_name = self._id_map.get(var_id, _sanitize_id(var_id))
+
+            math = rule.getMath()
+            if math is None:
+                continue
+
+            try:
+                rate_expr = self._formula_to_sympy(math)
+            except Exception as exc:
+                self._warn_or_except(
+                    'Could not parse rate rule for "{}": {}'.format(var_id, exc)
+                )
+                continue
+
+            rate_comp = self.expression(var_name + "_rate", rate_expr)
+
+            mon = self.model.monomers[var_name]
+            cp = ComplexPattern([MonomerPattern(mon, {}, default_cpt)], default_cpt)
+            rule_exp = RuleExpression(
+                ReactionPattern([]),  # null (no reactants)
+                ReactionPattern([cp]),  # >> X()
+                is_reversible=False,
+            )
+            self.rule(var_name + "_ode", rule_exp, rate_comp)
+
+    def _expr_or_param(self, expr, name):
+        """Return a bare Parameter if *expr* simplifies to one, else an Expression.
+
+        After dividing the SBML kinetic law by the reactant observable product,
+        many simple mass-action rates reduce to a single PySB
+        :class:`~pysb.core.Parameter`.  In that case creating a wrapping
+        :class:`~pysb.core.Expression` adds noise with no benefit; it is
+        cleaner to use the Parameter directly.
+
+        Parameters
+        ----------
+        expr : sympy.Expr
+            The simplified rate sympy expression.
+        name : str
+            The name to give the Expression if one must be created.
+
+        Returns
+        -------
+        pysb.core.Parameter or pysb.core.Expression
+        """
+        from pysb import Parameter as _Parameter
+
+        # A bare Parameter atom has exactly one free symbol and that symbol IS
+        # a PySB Parameter object already in the model.
+        free = expr.free_symbols
+        if len(free) == 1:
+            sym = next(iter(free))
+            if (
+                isinstance(sym, _Parameter)
+                and sym in self.model.parameters.values()
+                and expr == sym
+            ):
+                return sym
+        return self.expression(name, expr)
+
+    def _compartment_volume(self, cpt_id):
+        """Return the sympy size symbol for a compartment ID.
+
+        Looks up the ``<compartmentID>_size`` :class:`~pysb.core.Parameter`
+        created by :meth:`_parse_compartments`.  Returns ``sympy.Integer(1)``
+        when no compartment is specified, when the parameter does not exist, or
+        when the compartment size is trivially 1 (no-op for division).
+        """
+        if not cpt_id:
+            return sympy.Integer(1)
+        cpt_name = self._id_map.get(cpt_id, _sanitize_id(cpt_id))
+        size_param = self.model.parameters.get(cpt_name + "_size")
+        if size_param is None or size_param.value == 1.0:
+            return sympy.Integer(1)
+        return size_param
+
+    def _reaction_volume(self, sbml_model, rxn):
+        """Return the sympy compartment-size symbol for a reaction.
+
+        SBML kinetic laws give flux in **amount per time**.  PySB/BNG build
+        concentration ODEs, so each flux must be divided by the volume of the
+        reaction compartment.  This method returns the appropriate size
+        :class:`~pysb.core.Parameter` (or ``sympy.Integer(1)`` when no
+        compartment can be determined or the size is trivially 1).
+
+        The compartment is taken from (in order of preference):
+
+        1. The reaction's own ``compartment`` attribute (SBML Level 3).
+        2. The compartment of the first non-boundary reactant species.
+        3. The compartment of the first non-boundary product species.
+        4. The first compartment defined in the model.
+        5. ``sympy.Integer(1)`` (no compartments, bare ODE model).
+        """
+        # 1. SBML Level 3 reaction compartment attribute
+        cpt_id = rxn.getCompartment() if rxn.isSetCompartment() else None
+
+        # 2. First non-boundary reactant
+        if not cpt_id:
+            for j in range(rxn.getNumReactants()):
+                sr = rxn.getReactant(j)
+                sp_id = sr.getSpecies()
+                if sp_id in self._boundary_species:
+                    continue
+                sp = sbml_model.getSpecies(sp_id)
+                if sp and sp.isSetCompartment():
+                    cpt_id = sp.getCompartment()
+                    break
+
+        # 3. First non-boundary product
+        if not cpt_id:
+            for j in range(rxn.getNumProducts()):
+                sr = rxn.getProduct(j)
+                sp_id = sr.getSpecies()
+                if sp_id in self._boundary_species:
+                    continue
+                sp = sbml_model.getSpecies(sp_id)
+                if sp and sp.isSetCompartment():
+                    cpt_id = sp.getCompartment()
+                    break
+
+        # 4. First model compartment
+        if not cpt_id and sbml_model.getNumCompartments() > 0:
+            cpt_id = sbml_model.getCompartment(0).getId()
+
+        return self._compartment_volume(cpt_id)
+
+    def _product_volume(self, sbml_model, rxn):
+        """Return the sympy compartment-size symbol for the product side.
+
+        Mirrors :meth:`_reaction_volume` but looks at the product compartment
+        rather than the reactant compartment.  Used to detect and handle
+        cross-compartment transport reactions where the reactant and product
+        compartments differ (and therefore require different volume divisors for
+        each species ODE).
+
+        The compartment is taken from (in order of preference):
+
+        1. The reaction's own ``compartment`` attribute (SBML Level 3).
+        2. The compartment of the first non-boundary product species.
+        3. ``sympy.Integer(1)`` (no products / no compartment information).
+        """
+        # 1. SBML Level 3 reaction compartment attribute
+        cpt_id = rxn.getCompartment() if rxn.isSetCompartment() else None
+
+        # 2. First non-boundary product
+        if not cpt_id:
+            for j in range(rxn.getNumProducts()):
+                sr = rxn.getProduct(j)
+                sp_id = sr.getSpecies()
+                if sp_id in self._boundary_species:
+                    continue
+                sp = sbml_model.getSpecies(sp_id)
+                if sp and sp.isSetCompartment():
+                    cpt_id = sp.getCompartment()
+                    break
+
+        return self._compartment_volume(cpt_id)
+
+    def _obs_product_for_refs(self, list_of_refs):
+        """Build the sympy product of Observable objects for a species-reference list.
+
+        For each species reference in *list_of_refs*, looks up the corresponding
+        :class:`~pysb.core.Observable` (created in :meth:`_parse_species`) and
+        raises it to the power of its stoichiometry.  Returns
+        ``sympy.Integer(1)`` when the list is empty (source reactions).
+
+        This product is used to divide the SBML kinetic law and recover the
+        intrinsic rate expression expected by PySB/BNG rules. PySB/BNG multiply
+        the rule rate by the reactant species counts, so the kinetic law (which
+        already includes those factors) must be divided by them first.
+
+        The Observable *objects* are used directly (not their string names) so
+        that sympy can cancel identical Observable atoms in the numerator and
+        denominator of the division.
+
+        Parameters
+        ----------
+        list_of_refs : libsbml.ListOfSpeciesReferences
+            Reactant or product species-reference list from a libsbml reaction.
+
+        Returns
+        -------
+        sympy.Expr
+            Product of ``obs ** stoich`` for each species reference.
+        """
+        product = sympy.Integer(1)
+        for j in range(list_of_refs.size()):
+            sr = list_of_refs.get(j)
+            sp_id = sr.getSpecies()
+            # Boundary species are excluded from PySB rule patterns, so their
+            # observables must not be included in the division factor either.
+            if sp_id in self._boundary_species:
+                continue
+            obs = self._species_obs.get(sp_id)
+            if obs is None:
+                continue
+            stoich = 1
+            if sr.isSetStoichiometry():
+                s = sr.getStoichiometry()
+                stoich = (
+                    int(round(s)) if math.isclose(s, round(s), rel_tol=1e-9) else int(s)
+                )
+            product = product * obs**stoich
+        return product
+
+    def _combinatorial_correction(self, list_of_refs):
+        """Compute the combinatorial correction factor for a species-reference list.
+
+        PySB/BNG divides the rule rate by ``n!`` for each species that appears
+        with stoichiometry *n* (identical-reactant symmetry correction).  The
+        SBML kinetic law encodes the *net flux* directly and does not include
+        this factor, so the importer must multiply the intrinsic rate by the
+        same ``n!`` to counteract BNG's division.
+
+        For example, a homodimerisation reaction ``A + A -> B`` (stoichiometry
+        2 for A) gets a correction factor of ``2! = 2``.  A reaction with
+        distinct reactants (all stoichiometries equal to 1) gets a factor of 1
+        and no correction is needed.
+
+        Parameters
+        ----------
+        list_of_refs : libsbml.ListOfSpeciesReferences
+            Reactant (or product) species-reference list from a libsbml reaction.
+
+        Returns
+        -------
+        int
+            Product of ``stoich!`` over all unique species in *list_of_refs*.
+        """
+        # Accumulate stoichiometry per unique species ID
+        stoich_by_species = {}
+        for j in range(list_of_refs.size()):
+            sr = list_of_refs.get(j)
+            sp_id = sr.getSpecies()
+            # Boundary species are excluded from PySB rule patterns, so BNG
+            # applies no symmetry correction for them.  Skip them here.
+            if sp_id in self._boundary_species:
+                continue
+            stoich = 1
+            if sr.isSetStoichiometry():
+                s = sr.getStoichiometry()
+                stoich = (
+                    int(round(s)) if math.isclose(s, round(s), rel_tol=1e-9) else int(s)
+                )
+            stoich_by_species[sp_id] = stoich_by_species.get(sp_id, 0) + stoich
+        correction = 1
+        for stoich in stoich_by_species.values():
+            correction *= math.factorial(stoich)
+        return correction
+
+    def _stoich_refs_to_patterns(self, sbml_model, list_of_refs):
+        """Convert a ListOfSpeciesReferences to a list of ComplexPatterns.
+
+        Each species reference is expanded into *stoichiometry* copies of a
+        single-monomer :class:`~pysb.core.ComplexPattern`.  Non-integer
+        stoichiometry values are truncated and a :mod:`warnings` warning is
+        issued.  A stoichiometry of zero produces no patterns (effectively
+        removing that species reference from the rule).
+
+        Species with ``boundaryCondition="true"`` are **excluded** from the
+        returned pattern list.  Per the SBML specification, boundary species
+        are external: reactions proceed and can reference them in kinetic
+        laws, but their amounts are not changed by reactions (only by rate
+        rules or assignment rules).  Including them in the PySB rule pattern
+        would cause BNG to subtract/add them in the ODE, which is incorrect.
+        """
+        patterns = []
+        for j in range(list_of_refs.size()):
+            sr = list_of_refs.get(j)
+            sp_id = sr.getSpecies()
+            sp_name = self._id_map.get(sp_id, _sanitize_id(sp_id))
+
+            # Boundary species: skip; their amounts are not affected by rxns.
+            sbml_sp = sbml_model.getSpecies(sp_id)
+            if sbml_sp is not None and sbml_sp.getBoundaryCondition():
+                continue
+
+            stoich = 1
+            if sr.isSetStoichiometry():
+                s = sr.getStoichiometry()
+                if math.isclose(s, round(s), rel_tol=1e-9):
+                    stoich = int(round(s))
+                else:
+                    warnings.warn(
+                        'Non-integer stoichiometry ({}) for species "{}" is '
+                        "not supported; truncating to {}".format(s, sp_id, int(s))
+                    )
+                    stoich = int(s)
+
+            mon = self.model.monomers[sp_name]
+            sp = sbml_model.getSpecies(sp_id)
+            cpt_id = sp.getCompartment() if sp else None
+            cpt = (
+                self.model.compartments.get(
+                    self._id_map.get(cpt_id, _sanitize_id(cpt_id))
+                )
+                if cpt_id
+                else None
+            )
+
+            for _ in range(stoich):
+                patterns.append(ComplexPattern([MonomerPattern(mon, {}, cpt)], cpt))
+
+        return patterns
+
+    def _parse_reactions(self, sbml_model):
+        """Create PySB Rules for SBML reaction elements.
+
+        Each ``<reaction>`` normally becomes one or two non-reversible
+        :class:`~pysb.core.Rule` objects.  Cross-compartment transport
+        reactions (reactant compartment ≠ product compartment) are split into
+        an additional pair of rules; see below.
+
+        **ODE correctness**: PySB/BNG rules with :class:`~pysb.core.Expression`
+        rates multiply the expression value by the reactant species counts when
+        building ODEs (mass-action combinatorics).  SBML kinetic laws already
+        include the reactant species as factors (they express the net *flux*
+        directly).  The importer therefore divides the kinetic law by the
+        product of reactant observable symbols (each raised to its
+        stoichiometry) to recover the intrinsic rate expression:
+
+        .. math::
+
+            \\text{pysb\\_rate} = \\frac{J}{\\prod_i [S_i]^{s_i}}
+
+        For source reactions (no reactants) the kinetic law is used as-is.
+
+        **Compartment volume**: SBML kinetic laws give flux in amount/time.
+        PySB builds concentration-based ODEs, so the flux is divided by the
+        reaction compartment volume (``dC/dt = J/V``).
+
+        **Cross-compartment transport**: when the reactant compartment
+        ``V_src`` and product compartment ``V_dst`` differ, a single rule
+        would divide by the same volume on both sides, producing the wrong ODE
+        for one side.  Instead, the reaction is split into:
+
+        * A **degradation rule** ``reactants → ∅`` with rate
+          ``J / (V_src · ∏[S_i]^{s_i})``, giving ``dR/dt = −J/V_src``.
+        * A **synthesis rule** ``∅ → products`` with rate ``J / V_dst²``.
+          PySB/BNG internally multiply synthesis rates by the product
+          compartment volume, so the effective ODE contribution is
+          ``V_dst · (J/V_dst²) = J/V_dst``, giving ``dP/dt = +J/V_dst``.
+
+        **Reversible reactions**: when ``reversible="true"``, the kinetic law
+        encodes the net flux ``J = J_\\text{fwd} - J_\\text{rev}``.
+        :func:`_split_reversible_rate` is used to separate positive and
+        negative additive terms into the forward and reverse fluxes.  Each
+        half-flux is then divided by the product of the respective species
+        (reactants for the forward half, products for the reverse half) and
+        encoded as a separate non-reversible :class:`~pysb.core.Rule`.  If the
+        split fails (non-separable kinetic law), the reaction is encoded as a
+        single forward rule and a warning is issued.
+
+        The ``fast`` attribute (quasi-steady-state flag, deprecated in SBML
+        Level 3 Version 2) triggers a :mod:`warnings` warning and is otherwise
+        ignored.
+
+        Local parameters in kinetic laws (which shadow global parameters)
+        are not added to the PySB model; a :mod:`warnings` warning is issued
+        listing the affected parameter IDs.
+
+        Reactions without an ``id`` attribute receive the fallback name
+        ``r{i}``.
+        """
+        for i in range(sbml_model.getNumReactions()):
+            rxn = sbml_model.getReaction(i)
+            rxn_id = rxn.getId()
+            rxn_name = _sanitize_id(rxn_id) if rxn_id else "r{}".format(i)
+
+            # The SBML 'fast' attribute signals quasi-steady-state (QSS)
+            # treatment.  PySB has no QSS mechanism, so warn if set.
+            if rxn.isSetFast() and rxn.getFast():
+                warnings.warn(
+                    'Reaction "{}" has fast="true" (quasi-steady-state); '
+                    "this attribute has no effect in PySB and is "
+                    "ignored.".format(rxn_id)
+                )
+
+            reactant_pats = self._stoich_refs_to_patterns(
+                sbml_model, rxn.getListOfReactants()
+            )
+            product_pats = self._stoich_refs_to_patterns(
+                sbml_model, rxn.getListOfProducts()
+            )
+
+            kl = rxn.getKineticLaw()
+            if kl is None:
+                self._warn_or_except("Reaction {} has no kinetic law".format(rxn_id))
+                continue
+
+            # Handle local kinetic-law parameters.
+            # In SBML Level 2, parameters are declared inside <kineticLaw>
+            # elements via <listOfParameters>.  In Level 3, they appear in
+            # <listOfLocalParameters>.  libsbml's getNumParameters() covers
+            # both cases; getNumLocalParameters() returns 0 for L2.
+            #
+            # Local parameters that shadow a global parameter of the same name
+            # cannot be added (there is already a PySB Parameter with that
+            # name); we warn about the shadowing and use the global.
+            # Local parameters for which no global exists are promoted to
+            # global PySB Parameters so that the kinetic-law expression can
+            # reference them.
+            n_local = kl.getNumParameters()
+            if n_local > 0:
+                shadowed_ids = []
+                for j in range(n_local):
+                    lp = kl.getParameter(j)
+                    lp_id = lp.getId()
+                    lp_name = _sanitize_id(lp_id)
+                    if lp_name in self.model.parameters.keys():
+                        # Global parameter already exists; warn about shadow.
+                        shadowed_ids.append(lp_id)
+                    elif lp.isSetValue():
+                        # No global exists: promote to global Parameter.
+                        self.parameter(lp_name, lp.getValue(), nonnegative=False)
+                        self._id_map[lp_id] = lp_name
+                if shadowed_ids:
+                    warnings.warn(
+                        'Reaction "{}" has local kinetic-law parameters ({}) '
+                        "that shadow global parameters of the same name; the "
+                        "global parameters are used.".format(
+                            rxn_id, ", ".join(shadowed_ids)
+                        )
+                    )
+
+            net_flux = self._formula_to_sympy(kl.getMath())
+
+            # SBML kinetic laws give flux in amount/time.  PySB/BNG build
+            # concentration-based ODEs, so the flux must be divided by the
+            # reaction compartment volume (dC/dt = J/V).
+            rxn_vol = self._reaction_volume(sbml_model, rxn)
+
+            is_reversible = rxn.getReversible()
+
+            if is_reversible:
+                # Split net flux J = J_fwd - J_rev into forward and reverse
+                # half-fluxes, then divide each by the appropriate species
+                # product and by the compartment volume to obtain intrinsic
+                # rate expressions for PySB/BNG rules.
+                fwd_flux, rev_flux = _split_reversible_rate(net_flux)
+                if fwd_flux is None or rev_flux is None:
+                    warnings.warn(
+                        'Reversible reaction "{}" has a kinetic law that cannot '
+                        "be split into separable forward and reverse fluxes. "
+                        "The reaction is encoded as a single forward rule; "
+                        "the reverse direction will be absent from the model.".format(
+                            rxn_id
+                        )
+                    )
+                    fwd_flux = net_flux
+                    rev_flux = None
+
+                # Forward rule: reactants -> products
+                reactant_factor = self._obs_product_for_refs(rxn.getListOfReactants())
+                fwd_correction = self._combinatorial_correction(
+                    rxn.getListOfReactants()
+                )
+                fwd_rate_expr = sympy.simplify(
+                    fwd_correction * fwd_flux / (rxn_vol * reactant_factor)
+                )
+                fwd_rate = self._expr_or_param(fwd_rate_expr, rxn_name + "_fwd_rate")
+
+                prod_vol = self._product_volume(sbml_model, rxn)
+                if prod_vol != rxn_vol and product_pats:
+                    # Cross-compartment: split into deg + synth so each side
+                    # is divided by its own compartment volume.
+                    self.rule(
+                        rxn_name + "_fwd_deg",
+                        RuleExpression(
+                            ReactionPattern(reactant_pats),
+                            ReactionPattern([]),
+                            is_reversible=False,
+                        ),
+                        fwd_rate,
+                    )
+                    fwd_prod_rate = self._expr_or_param(
+                        sympy.simplify(fwd_flux / prod_vol**2),
+                        rxn_name + "_fwd_prod_rate",
+                    )
+                    self.rule(
+                        rxn_name + "_fwd_prod",
+                        RuleExpression(
+                            ReactionPattern([]),
+                            ReactionPattern(product_pats),
+                            is_reversible=False,
+                        ),
+                        fwd_prod_rate,
+                    )
+                else:
+                    fwd_rule_exp = RuleExpression(
+                        ReactionPattern(reactant_pats),
+                        ReactionPattern(product_pats),
+                        is_reversible=False,
+                    )
+                    self.rule(rxn_name + "_fwd", fwd_rule_exp, fwd_rate)
+
+                # Reverse rule: products -> reactants (if split succeeded)
+                if rev_flux is not None:
+                    product_factor = self._obs_product_for_refs(rxn.getListOfProducts())
+                    rev_correction = self._combinatorial_correction(
+                        rxn.getListOfProducts()
+                    )
+                    rev_rate_expr = sympy.simplify(
+                        rev_correction * rev_flux / (prod_vol * product_factor)
+                    )
+                    rev_rate = self._expr_or_param(
+                        rev_rate_expr, rxn_name + "_rev_rate"
+                    )
+
+                    if prod_vol != rxn_vol and reactant_pats:
+                        # Cross-compartment reverse: products -> None, None -> reactants
+                        self.rule(
+                            rxn_name + "_rev_deg",
+                            RuleExpression(
+                                ReactionPattern(product_pats),
+                                ReactionPattern([]),
+                                is_reversible=False,
+                            ),
+                            rev_rate,
+                        )
+                        rev_prod_rate = self._expr_or_param(
+                            sympy.simplify(rev_flux / rxn_vol**2),
+                            rxn_name + "_rev_prod_rate",
+                        )
+                        self.rule(
+                            rxn_name + "_rev_prod",
+                            RuleExpression(
+                                ReactionPattern([]),
+                                ReactionPattern(reactant_pats),
+                                is_reversible=False,
+                            ),
+                            rev_prod_rate,
+                        )
+                    else:
+                        rev_rule_exp = RuleExpression(
+                            ReactionPattern(product_pats),
+                            ReactionPattern(reactant_pats),
+                            is_reversible=False,
+                        )
+                        self.rule(rxn_name + "_rev", rev_rule_exp, rev_rate)
+            else:
+                # Irreversible: divide kinetic law by reactant observable
+                # product and compartment volume to get the intrinsic rate for
+                # BNG rules, then multiply by the combinatorial correction so
+                # that PySB/BNG's internal symmetry division cancels out.
+                reactant_factor = self._obs_product_for_refs(rxn.getListOfReactants())
+                correction = self._combinatorial_correction(rxn.getListOfReactants())
+                rate_expr = sympy.simplify(
+                    correction * net_flux / (rxn_vol * reactant_factor)
+                )
+                rate_comp = self._expr_or_param(rate_expr, rxn_name + "_rate")
+
+                prod_vol = self._product_volume(sbml_model, rxn)
+                if prod_vol != rxn_vol and reactant_pats and product_pats:
+                    # Cross-compartment transport: reactant and product
+                    # compartments differ, so a single rule would apply the
+                    # same volume divisor to both sides, which is incorrect when
+                    # V_src ≠ V_dst.  Split into a degradation rule (correct
+                    # V_src for the reactant ODE) and a synthesis rule whose
+                    # rate is scaled so that PySB/BNG's implicit V_dst
+                    # multiplication yield the correct product ODE
+                    # (flux / V_dst).
+                    self.rule(
+                        rxn_name + "_deg",
+                        RuleExpression(
+                            ReactionPattern(reactant_pats),
+                            ReactionPattern([]),
+                            is_reversible=False,
+                        ),
+                        rate_comp,
+                    )
+                    prod_rate = self._expr_or_param(
+                        sympy.simplify(net_flux / prod_vol**2),
+                        rxn_name + "_prod_rate",
+                    )
+                    self.rule(
+                        rxn_name + "_prod",
+                        RuleExpression(
+                            ReactionPattern([]),
+                            ReactionPattern(product_pats),
+                            is_reversible=False,
+                        ),
+                        prod_rate,
+                    )
+                else:
+                    rule_exp = RuleExpression(
+                        ReactionPattern(reactant_pats),
+                        ReactionPattern(product_pats),
+                        is_reversible=False,
+                    )
+                    self.rule(rxn_name, rule_exp, rate_comp)
+
+
+def _split_reversible_rate(expr):
+    """Split a net-flux sympy expression into forward and reverse parts.
+
+    SBML reversible reactions carry a single kinetic law representing the net
+    flux ``J = J_forward - J_reverse``.  PySB reversible rules require two
+    *separate* non-negative rate expressions.  This helper attempts the split
+    by partitioning the additive terms of *expr* according to the sign of each
+    term's leading rational coefficient:
+
+    * Terms whose leading coefficient is **positive** are collected into the
+      forward part.
+    * Terms whose leading coefficient is **negative** are negated and collected
+      into the reverse part.
+
+    Parameters
+    ----------
+    expr : sympy.Expr
+        The net-flux expression to split.
+
+    Returns
+    -------
+    tuple[sympy.Expr, sympy.Expr] or tuple[None, None]
+        ``(forward_expr, reverse_expr)`` if the split is unambiguous, i.e.
+        at least one term is positive **and** at least one is negative.
+        ``(None, None)`` otherwise (all terms share the same sign, or the
+        expression is not a plain sum of terms).
+    """
+    terms = sympy.Add.make_args(sympy.expand(expr))  # expand then split addends
+
+    forward_terms = []
+    reverse_terms = []
+
+    for term in terms:
+        coeff, _ = term.as_coeff_Mul()
+        if coeff > 0:
+            forward_terms.append(term)
+        elif coeff < 0:
+            reverse_terms.append(-term)  # negate so the rate is positive
+        else:
+            # Zero coefficient or symbolic coefficient: cannot determine sign
+            return None, None
+
+    if not forward_terms or not reverse_terms:
+        # All terms have the same sign: not a net-flux expression
+        return None, None
+
+    return sympy.Add(*forward_terms), sympy.Add(*reverse_terms)
+
+
+def _model_from_sbml_libsbml(filename_or_string, force=False):
+    """
+    Create a PySB Model from an SBML file or string using libsbml.
+
+    Thin wrapper around :class:`SbmlImporter`.  See that class and the
+    module docstring for full details of the SBML-to-PySB mapping and
+    known limitations.
+
+    Parameters
+    ----------
+    filename_or_string : str or bytes
+        Path to an SBML file **or** a raw SBML XML string/bytes.  A value is
+        treated as a string/bytes if it starts with ``<`` or contains a
+        newline; otherwise it is interpreted as a file path.
+    force : bool, optional
+        If False (default), raise :class:`SbmlImportError` on unsupported
+        constructs; if True, issue warnings and return a partial model.
+
+    Returns
+    -------
+    pysb.Model
+
+    """
+    importer = SbmlImporter(filename_or_string, force=force)
+    return importer.model
+
+
+def sbml_translator(
+    input_file,
+    output_file=None,
+    convention_file=None,
+    naming_conventions=None,
+    user_structures=None,
+    molecule_id=False,
+    atomize=False,
+    pathway_commons=False,
+    verbose=False,
+):
     """
     Run the BioNetGen sbmlTranslator binary to convert SBML to BNGL
 
@@ -41,7 +1559,8 @@ def sbml_translator(input_file,
     model can be imported to PySB in a single step with
     :func:`model_from_sbml`. However, users may wish to note the parameters
     for this function, which alter the way the SBML file is processed. These
-    parameters can be supplied as ``**kwargs`` to :func:`model_from_sbml`.
+    parameters can be supplied as ``**kwargs`` to :func:`model_from_sbml`
+    when ``use_libsbml=False``.
 
     For more detailed descriptions of the arguments, see the `sbmlTranslator
     documentation <http://bionetgen.org/index.php/SBML2BNGL>`_.
@@ -81,95 +1600,116 @@ def sbml_translator(input_file,
         BNGL output filename
     """
     logger = get_logger(__name__, log_level=verbose)
-    sbmltrans_bin = pf.get_path('atomizer')
+    sbmltrans_bin = pf.get_path("atomizer")
 
-    sbmltrans_args = [sbmltrans_bin, '-i', input_file]
+    sbmltrans_args = [sbmltrans_bin, "-i", input_file]
     if output_file is None:
-        output_file = os.path.splitext(input_file)[0] + '.bngl'
-    sbmltrans_args.extend(['-o', output_file])
+        output_file = os.path.splitext(input_file)[0] + ".bngl"
+    sbmltrans_args.extend(["-o", output_file])
 
     if convention_file:
-        sbmltrans_args.extend(['-c', convention_file])
+        sbmltrans_args.extend(["-c", convention_file])
 
     if naming_conventions:
-        sbmltrans_args.extend(['-n', naming_conventions])
+        sbmltrans_args.extend(["-n", naming_conventions])
 
     if user_structures:
-        sbmltrans_args.extend(['-u', user_structures])
+        sbmltrans_args.extend(["-u", user_structures])
 
     if molecule_id:
-        sbmltrans_args.append('-id')
+        sbmltrans_args.append("-id")
 
     if atomize:
-        sbmltrans_args.append('-a')
+        sbmltrans_args.append("-a")
 
     if pathway_commons:
-        sbmltrans_args.append('-p')
+        sbmltrans_args.append("-p")
 
     logger.debug("sbmlTranslator command: " + " ".join(sbmltrans_args))
 
-    p = subprocess.Popen(sbmltrans_args,
-                         cwd=os.getcwd(),
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        sbmltrans_args, cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
 
     if logger.getEffectiveLevel() <= EXTENDED_DEBUG:
-        output = "\n".join([line for line in iter(p.stdout.readline, b'')])
+        output = "\n".join([line for line in iter(p.stdout.readline, b"")])
         if output:
             logger.log(EXTENDED_DEBUG, "sbmlTranslator output:\n\n" + output)
     (p_out, p_err) = p.communicate()
     if p.returncode:
-        raise SbmlTranslationError(p_out.decode('utf-8') + "\n" +
-                                   p_err.decode('utf-8'))
+        raise SbmlTranslationError(p_out.decode("utf-8") + "\n" + p_err.decode("utf-8"))
 
     return output_file
 
 
-def model_from_sbml(filename, force=False, cleanup=True, **kwargs):
+def model_from_sbml(filename, force=False, cleanup=True, use_libsbml=True, **kwargs):
     """
-    Create a PySB Model object from an Systems Biology Markup Language (SBML)
-    file, using BioNetGen's
-    `sbmlTranslator <http://bionetgen.org/index.php/SBML2BNGL>`_,
-    which can attempt to extrapolate higher-level (rule-based) structure
-    from an SBML source file (argument atomize=True). The model is first
-    converted into BioNetGen language by sbmlTranslator, then PySB's
-    :class:`BnglBuilder` class converts the BioNetGen language model into a
-    PySB Model.
+    Create a PySB Model from a Systems Biology Markup Language (SBML) file.
 
-    Notes
-    -----
-
-    Requires the sbmlTranslator program (also known at Atomizer). If
-    PySB was installed using "conda", you can install sbmlTranslator using
-    "conda install -c alubbock atomizer". It is bundled with BioNetGen if
-    BNG is installed by manual download and unzip.
-
-    Read the `sbmlTranslator documentation
-    <http://bionetgen.org/index.php/SBML2BNGL>`_ for further information on
-    sbmlTranslator's limitations.
+    By default this uses libsbml for a direct flat import (``use_libsbml=True``).
+    To use the legacy BioNetGen sbmlTranslator/Atomizer backend, which can
+    attempt to infer higher-level rule-based structure, pass
+    ``use_libsbml=False``.
 
     Parameters
     ----------
-    filename :
-        A Systems Biology Markup Language .sbml file
+    filename : str
+        Path to the SBML file.
     force : bool, optional
-        The default, False, will raise an Exception if there are any errors
-        importing the model to PySB, e.g. due to unsupported features.
-        Setting to True will attempt to ignore any import errors, which may
-        lead to a model that only poorly represents the original. Use at own
-        risk!
-    cleanup : bool
-        Delete temporary directory on completion if True. Set to False for
-        debugging purposes.
-    **kwargs: kwargs
-        Keyword arguments to pass on to :func:`sbml_translator`
+        If False (default), raise on import errors; if True, warn and continue.
+    cleanup : bool, optional
+        Delete temporary files on completion (only relevant when
+        ``use_libsbml=False``).
+    use_libsbml : bool, optional
+        If True (default), use the libsbml-based importer.
+        If False, use the legacy sbmlTranslator/Atomizer pipeline.
+    **kwargs
+        Additional keyword arguments forwarded to :func:`sbml_translator`
+        when ``use_libsbml=False`` (e.g. ``atomize=True``).
+
+    Returns
+    -------
+    pysb.Model
+
+    Notes
+    -----
+    The libsbml importer performs a flat import: each SBML species becomes a
+    PySB Monomer with no sites, each reaction becomes a rule with a
+    function-based rate Expression, and rate-rule (ODE-only) models are
+    also supported.  See the module docstring and :class:`SbmlImporter` for
+    the full SBML feature mapping and known limitations.
+
+    For structure inference (atomisation) use ``use_libsbml=False`` and
+    pass ``atomize=True``.
+
+    The legacy sbmlTranslator backend requires the sbmlTranslator program
+    (also known as Atomizer). If PySB was installed with conda, install it
+    via ``conda install -c alubbock atomizer``. It is bundled with BioNetGen
+    if BNG is installed by manual download and unzip.
+
+    Examples
+    --------
+    Import a flat SBML model using the default libsbml backend:
+
+    >>> from pysb.importers.sbml import model_from_sbml
+    >>> model = model_from_sbml('my_model.xml')              # doctest: +SKIP
+
+    Use the legacy Atomizer backend to infer rule-based structure:
+
+    >>> model = model_from_sbml('my_model.xml',              # doctest: +SKIP
+    ...                         use_libsbml=False,
+    ...                         atomize=True)
     """
-    logger = get_logger(__name__, log_level=kwargs.get('verbose'))
+    if use_libsbml:
+        return _model_from_sbml_libsbml(filename, force=force)
+
+    logger = get_logger(__name__, log_level=kwargs.get("verbose"))
     tmpdir = tempfile.mkdtemp()
-    logger.debug("Performing SBML to BNGL translation in temporary "
-                 "directory %s" % tmpdir)
+    logger.debug(
+        "Performing SBML to BNGL translation in temporary directory %s" % tmpdir
+    )
     try:
-        bngl_file = os.path.join(tmpdir, 'model.bngl')
+        bngl_file = os.path.join(tmpdir, "model.bngl")
         sbml_translator(filename, bngl_file, **kwargs)
         return model_from_bngl(bngl_file, force=force, cleanup=cleanup)
     finally:
@@ -177,69 +1717,58 @@ def model_from_sbml(filename, force=False, cleanup=True, **kwargs):
             shutil.rmtree(tmpdir)
 
 
-def model_from_biomodels(accession_no, force=False, cleanup=True,
-                         mirror='ebi', **kwargs):
+def model_from_biomodels(
+    accession_no, force=False, cleanup=True, mirror="ebi", use_libsbml=True, **kwargs
+):
     """
-    Create a PySB Model based on a BioModels SBML model
+    Create a PySB Model based on a BioModels SBML model.
 
-    Downloads file from BioModels (https://www.ebi.ac.uk/biomodels-main/)
-    and runs it through :func:`model_from_sbml`. See that function for
-    further details on additional arguments and implementation details.
-    Utilizes BioNetGen's SBMLTranslator.
-
-    Notes
-    -----
-
-    Requires the sbmlTranslator program (also known at Atomizer). If
-    PySB was installed using "conda", you can install sbmlTranslator using
-    "conda install -c alubbock atomizer". It is bundled with BioNetGen if
-    BNG is installed by manual download and unzip.
-
-    Read the `sbmlTranslator documentation
-    <http://bionetgen.org/index.php/SBML2BNGL>`_ for further information on
-    sbmlTranslator's limitations.
+    Downloads the SBML file from BioModels (https://www.ebi.ac.uk/biomodels/)
+    and passes it to :func:`model_from_sbml`.
 
     Parameters
     ----------
     accession_no : str
-        A BioModels accession number - the string 'BIOMD' followed by 10
-        digits, e.g. 'BIOMD0000000001'. For brevity, just the last digits will
-        be accepted as a string, e.g. '1' is equivalent the accession number
-        in the previous sentence.
+        A BioModels accession number such as ``'BIOMD0000000001'``. For
+        brevity, just the numeric part is also accepted (e.g. ``'1'``).
     force : bool, optional
-        The default, False, will raise an Exception if there are any errors
-        importing the model to PySB, e.g. due to unsupported features.
-        Setting to True will attempt to ignore any import errors, which may
-        lead to a model that only poorly represents the original. Use at own
-        risk!
-    cleanup : bool
-        Delete temporary directory on completion if True. Set to False for
-        debugging purposes.
-    mirror : str
-        Which BioModels mirror to use, either 'ebi' or 'caltech'
-    **kwargs: kwargs
-        Keyword arguments to pass on to :func:`sbml_translator`
+        If False (default), raise on import errors; if True, warn and continue.
+    cleanup : bool, optional
+        Delete the downloaded SBML file after import.
+    mirror : str, optional
+        Which BioModels mirror to use: ``'ebi'`` (default) or ``'caltech'``.
+    use_libsbml : bool, optional
+        If True (default), use the libsbml-based importer.
+        If False, use the legacy sbmlTranslator/Atomizer pipeline.
+    **kwargs
+        Additional keyword arguments forwarded to :func:`model_from_sbml`.
+
+    Returns
+    -------
+    pysb.Model
 
     Examples
     --------
-
     >>> from pysb.importers.sbml import model_from_biomodels
     >>> model = model_from_biomodels('1')           #doctest: +SKIP
     >>> print(model)                                #doctest: +SKIP
     <Model 'pysb' (monomers: 12, rules: 17, parameters: 37, expressions: 0, ...
     """
-    logger = get_logger(__name__, log_level=kwargs.get('verbose'))
+    logger = get_logger(__name__, log_level=kwargs.get("verbose"))
     if not BIOMODELS_REGEX.match(accession_no):
         try:
-            accession_no = 'BIOMD{:010d}'.format(int(accession_no))
+            accession_no = "BIOMD{:010d}".format(int(accession_no))
         except ValueError:
-            raise ValueError('accession_no must be an integer or a BioModels '
-                             'accession number (BIOMDxxxxxxxxxx)')
-    logger.info('Importing model {} to PySB'.format(accession_no))
+            raise ValueError(
+                "accession_no must be an integer or a BioModels "
+                "accession number (BIOMDxxxxxxxxxx)"
+            )
+    logger.info("Importing model {} to PySB".format(accession_no))
     filename = _download_biomodels(accession_no, mirror=mirror)
     try:
-        return model_from_sbml(filename, force=force, cleanup=cleanup,
-                               **kwargs)
+        return model_from_sbml(
+            filename, force=force, cleanup=cleanup, use_libsbml=use_libsbml, **kwargs
+        )
     finally:
         try:
             os.remove(filename)
@@ -251,7 +1780,10 @@ def _download_biomodels(accession_no, mirror):
     try:
         url_fmt = BIOMODELS_URLS[mirror]
     except KeyError:
-        raise ValueError('Unknown Biomodels mirror: "{}". Choices are: {}'
-                         .format(mirror, BIOMODELS_URLS.keys()))
+        raise ValueError(
+            'Unknown Biomodels mirror: "{}". Choices are: {}'.format(
+                mirror, BIOMODELS_URLS.keys()
+            )
+        )
     filename, _ = urlretrieve(url_fmt.format(accession_no))
     return filename

--- a/pysb/tests/test_exporter_sbml.py
+++ b/pysb/tests/test_exporter_sbml.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for the libsbml-based SBML exporter (pysb.export.sbml.SbmlExporter).
+"""
+
+import re
+from collections import Counter
+
+from nose.plugins.skip import SkipTest
+from nose.tools import assert_raises
+
+from pysb.testing import with_model
+from pysb import (
+    Monomer,
+    Parameter,
+    Initial,
+    Rule,
+    Observable,
+    Expression,
+    time,
+)
+from pysb.core import EnergyPattern
+from pysb.bng import generate_equations
+from pysb.export import EnergyNotSupported
+
+try:
+    import libsbml
+
+    HAS_LIBSBML = True
+except ImportError:
+    HAS_LIBSBML = False
+
+if not HAS_LIBSBML:
+    raise SkipTest("libsbml not available")
+
+from pysb.export.sbml import SbmlExporter
+
+
+def _get_sbml_model(pysb_model):
+    """Return the libsbml Model object for *pysb_model*."""
+    return SbmlExporter(pysb_model).convert().getModel()
+
+
+def _sbml_string(pysb_model):
+    """Return the SBML XML string for *pysb_model*."""
+    return SbmlExporter(pysb_model).export()
+
+
+# Model ID
+
+@with_model
+def test_model_id_simple_name():
+    """A model whose name contains no special characters is exported as-is."""
+    Monomer("A")
+    Parameter("kdeg", 1.0)
+    Initial(A(), kdeg)
+    Rule("deg", A() >> None, kdeg)
+
+    # Rename the model after construction to avoid the auto-generated name.
+    model.name = "MySimpleModel"
+
+    smodel = _get_sbml_model(model)
+    assert smodel.getId() == "MySimpleModel", (
+        'Expected SBML model id "MySimpleModel", got "{}"'.format(smodel.getId())
+    )
+
+
+@with_model
+def test_model_id_dotted_name():
+    """Dots (from Python module paths) are replaced with underscores in the id."""
+    Monomer("A")
+    Parameter("kdeg", 1.0)
+    Initial(A(), kdeg)
+    Rule("deg", A() >> None, kdeg)
+
+    model.name = "pysb.examples.robertson"
+
+    smodel = _get_sbml_model(model)
+    model_id = smodel.getId()
+    # Dots must be gone; only word characters are allowed in SBML IDs.
+    assert re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", model_id), (
+        'SBML model id "{}" is not a valid SBML identifier'.format(model_id)
+    )
+    assert model_id == "pysb_examples_robertson", (
+        'Expected "pysb_examples_robertson", got "{}"'.format(model_id)
+    )
+
+
+@with_model
+def test_model_id_roundtrip():
+    """The model id written by the exporter can be read back by libsbml."""
+    Monomer("A")
+    Parameter("kdeg", 1.0)
+    Initial(A(), kdeg)
+    Rule("deg", A() >> None, kdeg)
+
+    model.name = "RoundTripModel"
+
+    sbml_str = _sbml_string(model)
+    doc2 = libsbml.readSBMLFromString(sbml_str)
+    assert doc2.getModel().getId() == "RoundTripModel"
+
+
+# Stoichiometry consolidation
+
+@with_model
+def test_stoichiometry_no_duplicate_reactants():
+    """A homodimerisation reaction must not produce duplicate speciesReference elements."""
+    Monomer("A")
+    Monomer("AA")
+    Parameter("kf", 1e-3)
+    Parameter("A_0", 100.0)
+    Initial(A(), A_0)
+    Rule("homodimer", A() + A() >> AA(), kf)
+
+    smodel = _get_sbml_model(model)
+
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        reactant_species = [
+            rxn.getReactant(j).getSpecies() for j in range(rxn.getNumReactants())
+        ]
+        counts = Counter(reactant_species)
+        duplicates = {sp: n for sp, n in counts.items() if n > 1}
+        assert not duplicates, (
+            "Reaction {} has duplicate reactant speciesReferences: {}".format(
+                rxn.getId(), duplicates
+            )
+        )
+
+
+@with_model
+def test_stoichiometry_value_homodimerisation():
+    """A + A -> AA should export A as a reactant with stoichiometry 2."""
+    Monomer("A")
+    Monomer("AA")
+    Parameter("kf", 1e-3)
+    Parameter("A_0", 100.0)
+    Initial(A(), A_0)
+    Rule("homodimer", A() + A() >> AA(), kf)
+
+    generate_equations(model)
+
+    # Find the species index for A(). Species are ComplexPatterns; match by str.
+    a_idx = next(i for i, s in enumerate(model.species) if str(s) == "A()")
+
+    smodel = _get_sbml_model(model)
+
+    found = False
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        for j in range(rxn.getNumReactants()):
+            sr = rxn.getReactant(j)
+            if sr.getSpecies() == "__s{}".format(a_idx):
+                assert sr.getStoichiometry() == 2.0, (
+                    "Expected stoichiometry 2 for __s{} in {}, got {}".format(
+                        a_idx, rxn.getId(), sr.getStoichiometry()
+                    )
+                )
+                found = True
+    assert found, "Species __s{} not found as reactant in any reaction".format(a_idx)
+
+
+@with_model
+def test_stoichiometry_no_duplicate_products():
+    """A dissociation reaction producing two identical species must use stoichiometry=2."""
+    Monomer("A")
+    Monomer("AA")
+    Parameter("kr", 1e-1)
+    Parameter("AA_0", 50.0)
+    Initial(AA(), AA_0)
+    Rule("dissoc", AA() >> A() + A(), kr)
+
+    generate_equations(model)
+    a_idx = next(i for i, s in enumerate(model.species) if str(s) == "A()")
+    smodel = _get_sbml_model(model)
+
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        product_species = [
+            rxn.getProduct(j).getSpecies() for j in range(rxn.getNumProducts())
+        ]
+        counts = Counter(product_species)
+        duplicates = {sp: n for sp, n in counts.items() if n > 1}
+        assert not duplicates, (
+            "Reaction {} has duplicate product speciesReferences: {}".format(
+                rxn.getId(), duplicates
+            )
+        )
+        # Also verify the consolidated stoichiometry
+        for j in range(rxn.getNumProducts()):
+            pr = rxn.getProduct(j)
+            if pr.getSpecies() == "__s{}".format(a_idx):
+                assert pr.getStoichiometry() == 2.0, (
+                    "Expected stoichiometry 2 for __s{} product, got {}".format(
+                        a_idx, pr.getStoichiometry()
+                    )
+                )
+
+
+# Modifiers must not duplicate reactants, products, or special symbols
+
+@with_model
+def test_no_reactant_as_modifier():
+    """Species listed as reactants must not also appear as modifiers."""
+    Monomer("S")
+    Monomer("E")
+    Monomer("P")
+    Parameter("kcat", 1.0)
+    Parameter("Km", 10.0)
+    Parameter("S_0", 100.0)
+    Parameter("E_0", 1.0)
+    Observable("obs_S", S())
+    Observable("obs_E", E())
+    Expression("rate_expr", obs_S * obs_E * kcat / (obs_S + Km))
+    Initial(S(), S_0)
+    Initial(E(), E_0)
+    Rule("conversion", S() >> P(), rate_expr)
+
+    smodel = _get_sbml_model(model)
+
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        reactant_ids = {
+            rxn.getReactant(j).getSpecies() for j in range(rxn.getNumReactants())
+        }
+        product_ids = {
+            rxn.getProduct(j).getSpecies() for j in range(rxn.getNumProducts())
+        }
+        rxn_species = reactant_ids | product_ids
+
+        for mod_idx in range(rxn.getNumModifiers()):
+            mod_id = rxn.getModifier(mod_idx).getSpecies()
+            assert mod_id not in rxn_species, (
+                "Reaction {}: species {} is listed as both a "
+                "reactant/product AND a modifier".format(rxn.getId(), mod_id)
+            )
+
+
+@with_model
+def test_no_product_as_modifier():
+    """Species listed as products must not also appear as modifiers."""
+    Monomer("A")
+    Monomer("B")
+    Observable("obs_B", B())
+    Parameter("krate", 1.0)
+    Parameter("A_0", 50.0)
+    Expression("rate_expr", obs_B * krate)
+    Initial(A(), A_0)
+    Rule("make_B", A() >> B(), rate_expr)
+
+    smodel = _get_sbml_model(model)
+
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        reactant_ids = {
+            rxn.getReactant(j).getSpecies() for j in range(rxn.getNumReactants())
+        }
+        product_ids = {
+            rxn.getProduct(j).getSpecies() for j in range(rxn.getNumProducts())
+        }
+        rxn_species = reactant_ids | product_ids
+
+        for mod_idx in range(rxn.getNumModifiers()):
+            mod_id = rxn.getModifier(mod_idx).getSpecies()
+            assert mod_id not in rxn_species, (
+                "Reaction {}: species {} is listed as both a "
+                "reactant/product AND a modifier".format(rxn.getId(), mod_id)
+            )
+
+
+@with_model
+def test_time_not_added_as_modifier():
+    """The PySB `time` symbol in a rate expression must not appear as a modifier."""
+    from sympy import exp
+
+    Monomer("A")
+    Parameter("kA", 1.0)
+    Parameter("A_0", 100.0)
+    # Rate expression that explicitly uses the `time` SpecialSymbol.
+    Expression("rate_expr", kA * exp(-time))
+    Initial(A(), A_0)
+    Rule("decay", A() >> None, rate_expr)
+
+    smodel = _get_sbml_model(model)
+
+    for rxn_idx in range(smodel.getNumReactions()):
+        rxn = smodel.getReaction(rxn_idx)
+        for mod_idx in range(rxn.getNumModifiers()):
+            mod_id = rxn.getModifier(mod_idx).getSpecies()
+            assert mod_id != "time", (
+                'Reaction {}: "time" was incorrectly added as a '
+                "modifierSpeciesReference".format(rxn.getId())
+            )
+
+
+# Fixed species, docstring notes, and level conversion
+
+@with_model
+def test_fixed_species_boundary_condition():
+    """A fixed initial condition is exported as boundaryCondition=true."""
+    Monomer("A")
+    Parameter("A_0", 100.0)
+    Parameter("kdeg", 1.0)
+    Initial(A(), A_0, fixed=True)
+    Rule("deg", A() >> None, kdeg)
+
+    smodel = _get_sbml_model(model)
+
+    a_species = next(
+        smodel.getSpecies(i)
+        for i in range(smodel.getNumSpecies())
+        if smodel.getSpecies(i).getName() == "A()"
+    )
+    assert a_species.getBoundaryCondition(), (
+        "Fixed species should have boundaryCondition=true"
+    )
+
+
+@with_model
+def test_docstring_exported_as_notes():
+    """A docstring passed to the exporter is written as SBML notes."""
+    Monomer("A")
+    Parameter("kdeg", 1.0)
+    Initial(A(), kdeg)
+    Rule("deg", A() >> None, kdeg)
+
+    doc = SbmlExporter(model, docstring="Test model description.").convert()
+    notes = doc.getModel().getNotesString()
+    assert "Test model description." in notes
+
+
+@with_model
+def test_level_conversion():
+    """Requesting SBML Level 2 produces a valid document at that level."""
+    Monomer("A")
+    Parameter("kdeg", 1.0)
+    Initial(A(), kdeg)
+    Rule("deg", A() >> None, kdeg)
+
+    doc = SbmlExporter(model).convert(level=(2, 4))
+    assert doc.getLevel() == 2
+
+
+# Energy models
+
+@with_model
+def test_energy_model_raises():
+    """Exporting an energy model must raise EnergyNotSupported."""
+    Monomer("A")
+    Parameter("G_A", 1.0)
+    EnergyPattern("ep_A", A(), G_A)
+
+    assert_raises(EnergyNotSupported, _sbml_string, model)

--- a/pysb/tests/test_exporter_sbml.py
+++ b/pysb/tests/test_exporter_sbml.py
@@ -47,6 +47,7 @@ def _sbml_string(pysb_model):
 
 # Model ID
 
+
 @with_model
 def test_model_id_simple_name():
     """A model whose name contains no special characters is exported as-is."""
@@ -101,6 +102,7 @@ def test_model_id_roundtrip():
 
 
 # Stoichiometry consolidation
+
 
 @with_model
 def test_stoichiometry_no_duplicate_reactants():
@@ -199,6 +201,7 @@ def test_stoichiometry_no_duplicate_products():
 
 # Modifiers must not duplicate reactants, products, or special symbols
 
+
 @with_model
 def test_no_reactant_as_modifier():
     """Species listed as reactants must not also appear as modifiers."""
@@ -295,6 +298,7 @@ def test_time_not_added_as_modifier():
 
 # Fixed species, docstring notes, and level conversion
 
+
 @with_model
 def test_fixed_species_boundary_condition():
     """A fixed initial condition is exported as boundaryCondition=true."""
@@ -343,6 +347,7 @@ def test_level_conversion():
 
 # Energy models
 
+
 @with_model
 def test_energy_model_raises():
     """Exporting an energy model must raise EnergyNotSupported."""
@@ -351,3 +356,48 @@ def test_energy_model_raises():
     EnergyPattern("ep_A", A(), G_A)
 
     assert_raises(EnergyNotSupported, _sbml_string, model)
+
+
+@with_model
+def test_catalyst_reaction_kinetic_law_volume_exponent():
+    """Catalyst reaction B+B->C+B in a non-unit compartment: kinetic law must
+    use V^1 (net-consumed = 1), not V^2 (raw reactant count = 2).
+
+    For Robertson's second reaction (B+B->C+B, BNG rate = k*[B]^2), the
+    SBML kinetic law J = V^n_net * k*[B]^2 where n_net = 1 (one B is
+    consumed net).  Previously the exporter used len(reactants)=2, writing
+    V^2*k*[B]^2 which inflated J by V and broke round-trip accuracy for
+    non-unit compartments.
+    """
+    from pysb import Compartment
+    from pysb.bng import generate_equations
+
+    Compartment("cell", dimension=3, size=Parameter("Vcell", 2.0))
+    Monomer("B")
+    Monomer("C")
+    Parameter("k2", 3e7)
+    Initial(B() ** cell, Parameter("B_0", 1e-3))
+    Initial(C() ** cell, Parameter("C_0", 0.0))
+    Rule("BB_to_BC", B() ** cell + B() ** cell >> C() ** cell + B() ** cell, k2)
+    Observable("obs_B", B() ** cell)
+    generate_equations(model)
+
+    sbml_model = _get_sbml_model(model)
+    # Find the reaction in the exported SBML
+    assert sbml_model.getNumReactions() == 1
+    rxn = sbml_model.getReaction(0)
+    math_str = libsbml.formulaToL3String(rxn.getKineticLaw().getMath())
+
+    # The kinetic law must contain Vcell^1 (i.e. "Vcell" appears exactly once
+    # as a factor), not Vcell^2.  We check that the string does NOT contain
+    # "Vcell^2" or "Vcell * Vcell".
+    assert "Vcell^2" not in math_str, (
+        "Kinetic law should use V^1 for catalyst reaction, got: {}".format(math_str)
+    )
+    assert "Vcell * Vcell" not in math_str, (
+        "Kinetic law should use V^1 for catalyst reaction, got: {}".format(math_str)
+    )
+    # And Vcell must appear at least once (volume correction is applied)
+    assert "Vcell" in math_str, (
+        "Kinetic law must include compartment volume, got: {}".format(math_str)
+    )

--- a/pysb/tests/test_importer_sbml.py
+++ b/pysb/tests/test_importer_sbml.py
@@ -380,8 +380,8 @@ def test_roundtrip_robertson():
 
     # Species count should match (exported as __s0, __s1, __s2)
     assert len(m.monomers) == len(robertson.model.species)
-    # Reaction count should match
-    assert len(m.rules) == len(robertson.model.reactions_bidirectional)
+    # Reaction count should match (exporter uses unidirectional reactions)
+    assert len(m.rules) == len(robertson.model.reactions)
     # Parameters should be preserved
     orig_pnames = {p.name for p in robertson.model.parameters}
     imp_pnames = {p.name for p in m.parameters}
@@ -403,6 +403,76 @@ def test_roundtrip_initial_values():
         ic_map[mon_name] = ic.value
     # A_0 must be 1.0 (referenced by initialAssignment)
     assert any(getattr(v, "value", None) == 1.0 for v in ic_map.values())
+
+
+def test_roundtrip_nonunit_compartment_trajectories():
+    """Export/import round-trip with a non-unit compartment must reproduce
+    the same ODE trajectories to within rtol=1e-3.
+
+    This is a regression test for a bug where the exporter wrote BNG's
+    concentration-based rates directly as SBML kinetic laws, causing the
+    importer to double-count the volume factor for non-unit compartments.
+    """
+    import numpy as np
+    import pysb.core
+    from pysb import (
+        Model,
+        Monomer,
+        Parameter,
+        Initial,
+        Observable,
+        Rule,
+        Compartment,
+    )
+    from pysb.export import export
+    from pysb.simulator import ScipyOdeSimulator
+
+    # Build a model with compartment size V=2 (non-unit) so the volume
+    # correction factor is 0.5 for bimolecular and 2 for synthesis.
+    # Parameters are chosen to give well-conditioned dynamics over t=[0, 10].
+    pysb.core.SelfExporter.cleanup()
+    m_orig = Model()
+    Compartment("cell", dimension=3, size=Parameter("Vcell", 2.0))
+    Monomer("A")
+    Monomer("B")
+    Monomer("C")
+    Parameter("kf", 0.1)
+    Parameter("kr", 0.5)
+    Initial(A() ** cell, Parameter("A0", 1.0))
+    Initial(B() ** cell, Parameter("B0", 2.0))
+    Initial(C() ** cell, Parameter("C0", 0))
+    Observable("obs_A", A() ** cell)
+    Observable("obs_B", B() ** cell)
+    Observable("obs_C", C() ** cell)
+    Rule("bind", A() ** cell + B() ** cell >> C() ** cell, kf)
+    Rule("unbind", C() ** cell >> A() ** cell + B() ** cell, kr)
+
+    try:
+        t = np.linspace(0, 10, 51)
+        traj_orig = ScipyOdeSimulator(m_orig, tspan=t).run().dataframe
+
+        sbml_str = export(m_orig, "sbml")
+        m_rt = _model_from_sbml_libsbml(sbml_str)
+        traj_rt = ScipyOdeSimulator(m_rt, tspan=t).run().dataframe
+
+        # Match observables by position: obs_A -> obs___s0, etc.
+        # (the re-imported model uses BNG species indices as names)
+        for orig_col, rt_col in [
+            ("obs_A", "obs___s0"),
+            ("obs_B", "obs___s1"),
+            ("obs_C", "obs___s2"),
+        ]:
+            orig_vals = traj_orig[orig_col].values
+            rt_vals = traj_rt[rt_col].values
+            scale = np.abs(orig_vals).max() + 1e-30
+            rel_err = np.max(np.abs(orig_vals - rt_vals)) / scale
+            assert rel_err < 1e-3, (
+                "Round-trip trajectory mismatch for {}: max rel error {:.2e}".format(
+                    orig_col, rel_err
+                )
+            )
+    finally:
+        pysb.core.SelfExporter.cleanup()
 
 
 # ---------------------------------------------------------------------------

--- a/pysb/tests/test_importer_sbml.py
+++ b/pysb/tests/test_importer_sbml.py
@@ -1,0 +1,2323 @@
+"""
+Tests for the libsbml-based SBML importer (pysb.importers.sbml.SbmlImporter).
+
+The legacy atomizer-based SBML import tests remain in test_importers.py.
+"""
+
+import os
+import tempfile
+import shutil
+import textwrap
+
+import sympy
+from unittest import mock
+from nose.plugins.skip import SkipTest
+from nose.tools import assert_raises_regex
+
+import pysb.pathfinder as pf
+from pysb.importers.sbml import (
+    SbmlImporter,
+    SbmlImportError,
+    model_from_sbml,
+    _model_from_sbml_libsbml,
+    model_from_biomodels,
+    _sanitize_id,
+    _split_reversible_rate,
+)
+
+try:
+    import libsbml
+
+    HAS_LIBSBML = True
+except ImportError:
+    HAS_LIBSBML = False
+
+if not HAS_LIBSBML:
+    raise SkipTest("libsbml not available")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bng_validate_directory():
+    bng_exec = os.path.realpath(pf.get_path("bng"))
+    if bng_exec.endswith(".bat"):
+        conda_prefix = os.environ.get("CONDA_PREFIX")
+        if conda_prefix:
+            return os.path.join(conda_prefix, r"share\bionetgen\Validate")
+    return os.path.join(os.path.dirname(bng_exec), "Validate")
+
+
+def _sbml_location(filename):
+    return os.path.join(_bng_validate_directory(), "INPUT_FILES", filename + ".xml")
+
+
+_DEFAULT_COMPARTMENT = '<compartment id="c" size="1"/>'
+
+
+def _minimal_sbml(
+    species=None,
+    parameters=None,
+    reactions=None,
+    rules=None,
+    compartments=_DEFAULT_COMPARTMENT,
+    level=2,
+    version=3,
+):
+    """Build a minimal SBML string for testing.
+
+    Optional blocks (species, parameters, reactions, rules) are omitted
+    entirely when empty to keep the document valid (SBML forbids empty
+    listOf* elements).
+    """
+    blocks = []
+    if compartments:
+        blocks.append(
+            "<listOfCompartments>{}</listOfCompartments>".format(compartments)
+        )
+    if species:
+        blocks.append("<listOfSpecies>{}</listOfSpecies>".format(species))
+    if parameters:
+        blocks.append("<listOfParameters>{}</listOfParameters>".format(parameters))
+    if rules:
+        blocks.append("<listOfRules>{}</listOfRules>".format(rules))
+    if reactions:
+        blocks.append("<listOfReactions>{}</listOfReactions>".format(reactions))
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level{lv}/version{vn}"'
+        ' level="{lv}" version="{vn}">\n'
+        '  <model id="test_model">\n'
+        "    {body}\n"
+        "  </model>\n"
+        "</sbml>"
+    ).format(lv=level, vn=version, body="\n    ".join(blocks))
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_id
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_id_plain():
+    assert _sanitize_id("A") == "A"
+
+
+def test_sanitize_id_hyphen():
+    assert _sanitize_id("my-species") == "my_species"
+
+
+def test_sanitize_id_leading_digit():
+    assert _sanitize_id("2fast") == "s_2fast"
+
+
+def test_sanitize_id_spaces():
+    assert _sanitize_id("A B") == "A_B"
+
+
+def test_sanitize_id_empty():
+    assert _sanitize_id("") == "unnamed"
+
+
+# ---------------------------------------------------------------------------
+# SbmlImporter – flat test file
+# ---------------------------------------------------------------------------
+
+
+class TestFlatSbml:
+    """Tests against the BNG validation flat SBML file."""
+
+    def setup(self):
+        path = _sbml_location("test_sbml_flat_SBML")
+        self.model = SbmlImporter(path).model
+
+    def test_model_name(self):
+        assert self.model.name == "plain"
+
+    def test_monomers(self):
+        assert set(self.model.monomers.keys()) == {"S1", "S2", "S3", "S4", "S5"}
+
+    def test_parameters_present(self):
+        pnames = set(self.model.parameters.keys())
+        for p in ("k1_f", "k1_r", "k2_f", "k2_r", "k3_f", "k3_r"):
+            assert p in pnames
+
+    def test_parameter_values(self):
+        assert self.model.parameters["k1_f"].value == 1.0
+        assert self.model.parameters["k1_r"].value == 0.1
+
+    def test_compartment(self):
+        assert "cell" in self.model.compartments.keys()
+
+    def test_rules(self):
+        rnames = set(self.model.rules.keys())
+        for r in ("R1", "R2", "R3", "R4", "R5", "R6"):
+            assert r in rnames
+
+    def test_rule_count(self):
+        assert len(self.model.rules) == 6
+
+    def test_initials_count(self):
+        assert len(self.model.initials) == 5
+
+    def test_initials_values(self):
+        vals = {
+            ic.pattern.monomer_patterns[0].monomer.name: ic.value.value
+            for ic in self.model.initials
+        }
+        assert vals["S1"] == 1.0
+        assert vals["S2"] == 2.0
+        assert vals["S5"] == 5.0
+
+    def test_species_observables(self):
+        obs_names = set(self.model.observables.keys())
+        for sp in ("S1", "S2", "S3", "S4", "S5"):
+            assert "obs_" + sp in obs_names
+
+    def test_assignment_rules_as_expressions(self):
+        expr_names = set(self.model.expressions.keys())
+        for e in ("A", "B", "C", "D", "AA", "dim_r"):
+            assert e in expr_names
+
+    def test_dim_r_expression(self):
+        """dim_r = k3_r should produce an expression referencing k3_r."""
+        dim_r = self.model.expressions["dim_r"]
+        assert self.model.parameters["k3_r"] in dim_r.expr.free_symbols
+
+    def test_r1_rate_expression(self):
+        """R1 rate (k1_f*S1*S2 divided by obs_S1*obs_S2) simplifies to k1_f.
+
+        Because the simplified rate is a bare Parameter, no wrapping Expression
+        is created; the rule's rate_forward is the Parameter itself.
+        """
+        r1 = self.model.rules["R1"]
+        # After dividing (k1_f*S1*S2) by (obs_S1*obs_S2) the rate is k1_f:
+        # a bare Parameter, so no R1_rate Expression is created.
+        assert r1.rate_forward is self.model.parameters["k1_f"]
+        assert "R1_rate" not in self.model.expressions.keys()
+
+    def test_r5_rate_homodimer(self):
+        """R5 homodimerisation: SBML kinetic law is ``0.5 * k3_f * S1^2``.
+
+        The importer divides by ``obs_S1^2`` to get the intrinsic rate, then
+        multiplies by the combinatorial correction ``2! = 2`` to compensate for
+        PySB's symmetry-factor halving.  Net result: ``0.5 * k3_f * 2 = k3_f``,
+        stored as the expression ``1.0 * k3_f``.
+        """
+        r5_rate = self.model.expressions["R5_rate"]
+        # After the combinatorial correction the only free symbol is k3_f;
+        # no 0.5 factor should remain.
+        assert self.model.parameters["k3_f"] in r5_rate.expr.free_symbols
+        nums = r5_rate.expr.atoms(sympy.Number)
+        # The sole numeric coefficient must be 1 (stored as Float 1.0)
+        assert all(abs(float(n) - 1.0) < 1e-9 for n in nums)
+
+    def test_rule_reactants_products(self):
+        """R1: S1 + S2 -> S3."""
+        r1 = self.model.rules["R1"]
+        reactant_names = sorted(
+            mp.monomer.name
+            for cp in r1.rule_expression.reactant_pattern.complex_patterns
+            for mp in cp.monomer_patterns
+        )
+        product_names = [
+            mp.monomer.name
+            for cp in r1.rule_expression.product_pattern.complex_patterns
+            for mp in cp.monomer_patterns
+        ]
+        assert reactant_names == ["S1", "S2"]
+        assert product_names == ["S3"]
+
+
+# ---------------------------------------------------------------------------
+# model_from_sbml (libsbml default)
+# ---------------------------------------------------------------------------
+
+
+def test_model_from_sbml_uses_libsbml_by_default():
+    path = _sbml_location("test_sbml_flat_SBML")
+    m = model_from_sbml(path)
+    assert set(m.monomers.keys()) == {"S1", "S2", "S3", "S4", "S5"}
+
+
+def test__model_from_sbml_libsbml_function():
+    path = _sbml_location("test_sbml_flat_SBML")
+    m = _model_from_sbml_libsbml(path)
+    assert len(m.rules) == 6
+
+
+def test_model_from_sbml_force_flag():
+    """force=True should not raise on a valid file."""
+    path = _sbml_location("test_sbml_flat_SBML")
+    m = model_from_sbml(path, force=True)
+    assert m is not None
+
+
+# ---------------------------------------------------------------------------
+# Legacy atomizer path preserved
+# ---------------------------------------------------------------------------
+
+
+def _require_atomizer():
+    try:
+        pf.get_path("atomizer")
+    except Exception:
+        raise SkipTest("atomizer (sbmlTranslator) not available")
+
+
+def test_model_from_sbml_atomizer_flat():
+    _require_atomizer()
+    path = _sbml_location("test_sbml_flat_SBML")
+    m = model_from_sbml(path, use_libsbml=False)
+    assert m is not None
+
+
+def test_model_from_sbml_atomizer_structured():
+    _require_atomizer()
+    path = _sbml_location("test_sbml_structured_SBML")
+    m = model_from_sbml(path, use_libsbml=False, atomize=True)
+    assert m is not None
+
+
+# ---------------------------------------------------------------------------
+# model_from_biomodels – mocked download
+# ---------------------------------------------------------------------------
+
+
+def _biomodels_mock(accession_no, mirror):
+    """Mock _download_biomodels: copy the flat test SBML to a temp file."""
+    _, path = tempfile.mkstemp(suffix=".xml")
+    shutil.copy(_sbml_location("test_sbml_flat_SBML"), path)
+    return path
+
+
+@mock.patch("pysb.importers.sbml._download_biomodels", _biomodels_mock)
+def test_biomodels_libsbml_mock():
+    m = model_from_biomodels("1")
+    assert len(m.monomers) == 5
+
+
+@mock.patch("pysb.importers.sbml._download_biomodels", _biomodels_mock)
+def test_biomodels_atomizer_mock():
+    _require_atomizer()
+    m = model_from_biomodels("1", use_libsbml=False)
+    assert m is not None
+
+
+@mock.patch("pysb.importers.sbml._download_biomodels", _biomodels_mock)
+def test_biomodels_full_accession():
+    m = model_from_biomodels("BIOMD0000000001")
+    assert m is not None
+
+
+def test_biomodels_invalid_mirror():
+    assert_raises_regex(ValueError, "", model_from_biomodels, "1", mirror="spam")
+
+
+def test_biomodels_invalid_accession():
+    assert_raises_regex(ValueError, "", model_from_biomodels, "not_a_number")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_sbml_raises():
+    assert_raises_regex(SbmlImportError, "", SbmlImporter, "this is not valid XML")
+
+
+def test_invalid_sbml_force_warns():
+    """An SBML document with parse errors issues a warning when force=True."""
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        try:
+            SbmlImporter("this is not valid XML", force=True)
+        except Exception:
+            pass
+    assert any("error" in str(warning.message).lower() for warning in w)
+
+
+def test_invalid_sbml_force_continues():
+    sbml = """\
+        <?xml version="1.0"?>
+        <sbml xmlns="http://www.sbml.org/sbml/level2/version3" level="2" version="3">
+          <model id="m"/>
+        </sbml>"""
+    # Empty model (no species/reactions) should succeed with force=True
+    m = SbmlImporter(textwrap.dedent(sbml), force=True).model
+    assert m is not None
+
+
+def test_libsbml_missing():
+    import pysb.importers.sbml as sbml_mod
+
+    with mock.patch.object(sbml_mod, "libsbml", None):
+        assert_raises_regex(
+            ImportError,
+            "libsbml",
+            SbmlImporter.__new__(SbmlImporter).__init__,
+            "dummy.xml",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: PySB SBML exporter → libsbml importer
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_robertson():
+    """Export the Robertson model to SBML, import back, check structure."""
+    from pysb.examples import robertson
+    from pysb.export import export
+
+    sbml_str = export(robertson.model, "sbml")
+    m = _model_from_sbml_libsbml(sbml_str)
+
+    # Species count should match (exported as __s0, __s1, __s2)
+    assert len(m.monomers) == len(robertson.model.species)
+    # Reaction count should match
+    assert len(m.rules) == len(robertson.model.reactions_bidirectional)
+    # Parameters should be preserved
+    orig_pnames = {p.name for p in robertson.model.parameters}
+    imp_pnames = {p.name for p in m.parameters}
+    assert orig_pnames <= imp_pnames
+
+
+def test_roundtrip_initial_values():
+    """Initial values set via initialAssignment are correctly imported."""
+    from pysb.examples import robertson
+    from pysb.export import export
+
+    sbml_str = export(robertson.model, "sbml")
+    m = _model_from_sbml_libsbml(sbml_str)
+
+    # Robertson: A_0=1, B_0=0, C_0=0
+    ic_map = {}
+    for ic in m.initials:
+        mon_name = ic.pattern.monomer_patterns[0].monomer.name
+        ic_map[mon_name] = ic.value
+    # A_0 must be 1.0 (referenced by initialAssignment)
+    assert any(getattr(v, "value", None) == 1.0 for v in ic_map.values())
+
+
+# ---------------------------------------------------------------------------
+# Minimal SBML constructs
+# ---------------------------------------------------------------------------
+
+
+def test_no_compartments():
+    """Model with no explicit compartments imports without error."""
+    sbml = _minimal_sbml(
+        compartments="",
+        species='<species id="A" initialAmount="1"/>',
+        parameters='<parameter id="k" value="1.0" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <listOfProducts/>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert "A" in m.monomers.keys()
+    assert len(m.rules) == 1
+
+
+def test_species_initial_concentration():
+    """initialConcentration is accepted."""
+    sbml = _minimal_sbml(
+        species='<species id="X" compartment="c" initialConcentration="3.0"/>',
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert m.parameters["X_0"].value == 3.0
+
+
+def test_species_boundary_condition():
+    """Boundary condition (fixed) species are imported as fixed initials."""
+    sbml = _minimal_sbml(
+        species='<species id="S" compartment="c" initialAmount="5" '
+        'boundaryCondition="true"/>',
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert m.initials[0].fixed is True
+
+
+def test_stoichiometry_attribute():
+    """Explicit stoichiometry=2 creates two copies of the reactant pattern."""
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="10"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="0.5" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    r = m.rules["r1"]
+    reactant_cps = r.rule_expression.reactant_pattern.complex_patterns
+    assert len(reactant_cps) == 2
+
+
+def test_assignment_rule_references_parameter():
+    """An assignment rule referencing a parameter creates an Expression."""
+    sbml = _minimal_sbml(
+        parameters=(
+            '<parameter id="k" value="2.0" constant="true"/>'
+            '<parameter id="k2" constant="false"/>'
+        ),
+        rules="""
+          <assignmentRule variable="k2">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><times/><cn>3</cn><ci>k</ci></apply>
+            </math>
+          </assignmentRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert "k2" in m.expressions.keys()
+    assert m.parameters["k"] in m.expressions["k2"].expr.free_symbols
+
+
+def test_reaction_no_kinetic_law_with_force():
+    """A reaction missing a kinetic law raises without force, warns with."""
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <listOfProducts/>
+          </reaction>""",
+    )
+    assert_raises_regex(SbmlImportError, "", _model_from_sbml_libsbml, sbml)
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml, force=True)
+    assert any("kinetic law" in str(warning.message).lower() for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# Algebraic rules
+# ---------------------------------------------------------------------------
+
+
+def test_algebraic_rule_raises_by_default():
+    """An algebraic rule raises SbmlImportError (unsupportable in PySB)."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="1" constant="false"/>',
+        rules="""
+          <algebraicRule>
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><minus/><ci>x</ci><cn>1</cn></apply>
+            </math>
+          </algebraicRule>""",
+    )
+    assert_raises_regex(SbmlImportError, "[Aa]lgebraic", _model_from_sbml_libsbml, sbml)
+
+
+def test_algebraic_rule_warns_with_force():
+    """An algebraic rule issues a warning when force=True."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="1" constant="false"/>',
+        rules="""
+          <algebraicRule>
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><minus/><ci>x</ci><cn>1</cn></apply>
+            </math>
+          </algebraicRule>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _model_from_sbml_libsbml(sbml, force=True)
+    assert any("lgebraic" in str(warning.message) for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+def test_event_raises_by_default():
+    """An SBML event raises SbmlImportError (not supported in PySB)."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="0" constant="false"/>',
+    ).replace(
+        "</model>",
+        """<listOfEvents>
+          <event id="ev1" useValuesFromTriggerTime="true">
+            <trigger initialValue="false" persistent="true">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><gt/><ci>x</ci><cn>1</cn></apply>
+              </math>
+            </trigger>
+          </event>
+        </listOfEvents></model>""",
+    )
+    assert_raises_regex(SbmlImportError, "[Ee]vent", _model_from_sbml_libsbml, sbml)
+
+
+def test_event_warns_with_force():
+    """An SBML event issues a warning when force=True."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="0" constant="false"/>',
+    ).replace(
+        "</model>",
+        """<listOfEvents>
+          <event id="ev1" useValuesFromTriggerTime="true">
+            <trigger initialValue="false" persistent="true">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><gt/><ci>x</ci><cn>1</cn></apply>
+              </math>
+            </trigger>
+          </event>
+        </listOfEvents></model>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _model_from_sbml_libsbml(sbml, force=True)
+    assert any("vent" in str(warning.message) for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# Non-integer stoichiometry
+# ---------------------------------------------------------------------------
+
+
+def test_non_integer_stoichiometry_warns():
+    """Non-integer stoichiometry issues a warning and is truncated."""
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="10"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="1.5"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    assert any("stoichiometry" in str(warning.message).lower() for warning in w)
+    # 1.5 truncated to 1 → one reactant pattern copy
+    r = m.rules["r1"]
+    assert len(r.rule_expression.reactant_pattern.complex_patterns) == 1
+
+
+# ---------------------------------------------------------------------------
+# Time variable
+# ---------------------------------------------------------------------------
+
+
+def test_time_variable_in_rate_law():
+    """SBML csymbol 'time' maps to pysb.core.time in rate expressions."""
+    from pysb.core import time as pysb_time
+
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="0"/>',
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfProducts>
+              <speciesReference species="A"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><csymbol encoding="text"
+                  definitionURL="http://www.sbml.org/sbml/symbols/time">
+                  time</csymbol></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    rate_expr = m.expressions["r1_rate"].expr
+    assert pysb_time in rate_expr.free_symbols
+
+
+def test_time_variable_simulation():
+    """A rate-law with 'time' integrates correctly: dA/dt = k*t => A=k*t^2/2."""
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+    from pysb.core import time as pysb_time
+
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="0"/>',
+        parameters='<parameter id="k" value="2" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfProducts><speciesReference species="A"/></listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><csymbol encoding="text"
+                  definitionURL="http://www.sbml.org/sbml/symbols/time">
+                  time</csymbol></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 3, 40)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+    # dA/dt = 2t  =>  A(t) = t^2
+    np.testing.assert_allclose(res.observables["obs_A"], tspan**2, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# _split_reversible_rate unit tests (no libsbml needed)
+# ---------------------------------------------------------------------------
+
+
+def test_split_reversible_rate_simple():
+    """kf*A - kr*B splits into (kf*A, kr*B)."""
+    kf, kr, A, B = sympy.symbols("kf kr A B", positive=True)
+    expr = kf * A - kr * B
+    fwd, rev = _split_reversible_rate(expr)
+    assert fwd is not None
+    assert rev is not None
+    assert sympy.simplify(fwd - kf * A) == 0
+    assert sympy.simplify(rev - kr * B) == 0
+
+
+def test_split_reversible_rate_single_positive_term():
+    """A single positive term has no negative part, so returns (None, None)."""
+    k, A = sympy.symbols("k A", positive=True)
+    fwd, rev = _split_reversible_rate(k * A)
+    assert fwd is None
+    assert rev is None
+
+
+def test_split_reversible_rate_single_negative_term():
+    """A single negative term has no positive part, so returns (None, None)."""
+    k, A = sympy.symbols("k A", positive=True)
+    fwd, rev = _split_reversible_rate(-k * A)
+    assert fwd is None
+    assert rev is None
+
+
+def test_split_reversible_rate_multiple_positive():
+    """All positive terms cannot be split, so returns (None, None)."""
+    k1, k2, A, B = sympy.symbols("k1 k2 A B", positive=True)
+    fwd, rev = _split_reversible_rate(k1 * A + k2 * B)
+    assert fwd is None
+    assert rev is None
+
+
+def test_split_reversible_rate_three_terms():
+    """k1*A + k2*B - k3*C: two positive and one negative term."""
+    k1, k2, k3, A, B, C = sympy.symbols("k1 k2 k3 A B C", positive=True)
+    expr = k1 * A + k2 * B - k3 * C
+    fwd, rev = _split_reversible_rate(expr)
+    assert fwd is not None
+    assert rev is not None
+    # Forward should contain k1*A and k2*B; reverse should contain k3*C
+    fwd_syms = fwd.free_symbols
+    rev_syms = rev.free_symbols
+    assert k3 in rev_syms
+    assert C in rev_syms
+    assert k1 in fwd_syms
+    assert k2 in fwd_syms
+
+
+# ---------------------------------------------------------------------------
+# Reversible reaction import tests
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_compartment_assignment_rule_raises():
+    """An assignment rule on a compartment raises SbmlImportError."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="t2" value="0" constant="false"/>',
+        rules="""
+          <assignmentRule variable="c">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><plus/><cn>1</cn><ci>t2</ci></apply>
+            </math>
+          </assignmentRule>""",
+    )
+    assert_raises_regex(
+        SbmlImportError, "[Dd]ynamic compartment", _model_from_sbml_libsbml, sbml
+    )
+
+
+def test_dynamic_compartment_rate_rule_raises():
+    """A rate rule on a compartment raises SbmlImportError."""
+    sbml = _minimal_sbml(
+        rules="""
+          <rateRule variable="c">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn>0.1</cn>
+            </math>
+          </rateRule>""",
+    )
+    assert_raises_regex(
+        SbmlImportError, "[Dd]ynamic compartment", _model_from_sbml_libsbml, sbml
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rate rules (ODE-only models)
+# ---------------------------------------------------------------------------
+
+
+def test_rate_rule_creates_monomer_and_rule():
+    """A rate-rule variable becomes a Monomer and a None>>X() ODE rule."""
+    sbml = _minimal_sbml(
+        parameters=(
+            '<parameter id="V" value="-65" constant="false"/>'
+            '<parameter id="gK" value="36" constant="true"/>'
+            '<parameter id="EK" value="-77" constant="true"/>'
+        ),
+        rules="""
+          <rateRule variable="V">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><times/><cn>-1</cn><ci>gK</ci>
+                <apply><minus/><ci>V</ci><ci>EK</ci></apply>
+              </apply>
+            </math>
+          </rateRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    assert "V" in m.monomers.keys()
+    assert "obs_V" in m.observables.keys()
+    assert "V_rate" in m.expressions.keys()
+    assert "V_ode" in m.rules.keys()
+    # Not a plain Parameter
+    assert "V" not in m.parameters.keys()
+    # Initial value preserved
+    assert abs(m.parameters["V_0"].value - (-65.0)) < 1e-9
+
+
+def test_rate_rule_initial_value():
+    """Initial value of a rate-rule variable is created as a parameter."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="3.14" constant="false"/>',
+        rules="""
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn>1</cn>
+            </math>
+          </rateRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    assert abs(m.parameters["x_0"].value - 3.14) < 1e-9
+
+
+def test_rate_rule_expression_references_other_vars():
+    """Rate-rule RHS that references another rate-rule variable is parsed."""
+    sbml = _minimal_sbml(
+        parameters=(
+            '<parameter id="V" value="-65" constant="false"/>'
+            '<parameter id="n" value="0.3" constant="false"/>'
+        ),
+        rules="""
+          <rateRule variable="V">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><minus/><ci>n</ci></apply>
+            </math>
+          </rateRule>
+          <rateRule variable="n">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><minus/><ci>V</ci><ci>n</ci></apply>
+            </math>
+          </rateRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    # Both variables become monomers; V_rate references obs_n
+    V_rate_syms = {s.name for s in m.expressions["V_rate"].expr.free_symbols}
+    assert "obs_n" in V_rate_syms
+
+
+def test_rate_rule_model_simulates():
+    """An ODE-only (rate-rule) model can be integrated with ScipyOdeSimulator."""
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    sbml = _minimal_sbml(
+        parameters=(
+            '<parameter id="x" value="1.0" constant="false"/>'
+            '<parameter id="k" value="0.5" constant="true"/>'
+        ),
+        rules="""
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <apply><times/><cn>-1</cn><ci>k</ci><ci>x</ci></apply>
+            </math>
+          </rateRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 4, 50)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+    # dx/dt = -0.5 x  =>  x(t) = exp(-0.5 t)
+    expected = np.exp(-0.5 * tspan)
+    np.testing.assert_allclose(res.observables["obs_x"], expected, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_parameter_without_value_is_skipped():
+    """A parameter with no value attribute is silently skipped."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="k" constant="false"/>',
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    # k has no value -> not added as a Parameter
+    assert "k" not in m.parameters.keys()
+
+
+def test_function_definition_non_lambda_skipped():
+    """A functionDefinition whose math is not a lambda is silently skipped."""
+    # Use a bare <cn> instead of an <lambda> as the math for the function.
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="k" value="1" constant="true"/>',
+    ).replace(
+        '<model id="test_model">',
+        """<model id="test_model">
+    <listOfFunctionDefinitions>
+      <functionDefinition id="bad_fn">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn>42</cn>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>""",
+    )
+    # Should import cleanly – the malformed function is skipped
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert m is not None
+
+
+def test_function_definition_zero_arg_lambda_skipped():
+    """A lambda with zero children (malformed) is silently skipped."""
+    # libsbml will reject a truly empty lambda via schema validation, so we
+    # build a lambda with only a body and no arguments (n_children == 1, but
+    # n_children - 1 == 0 argument names).  This exercises the arg_names=[]
+    # path and verifies the importer does not crash.
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfProducts><speciesReference species="A"/></listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    ).replace(
+        '<model id="test_model">',
+        """<model id="test_model">
+    <listOfFunctionDefinitions>
+      <functionDefinition id="fn0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <cn>1</cn>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert "A" in m.monomers.keys()
+
+
+def test_sbml_l3v1_model():
+    """An SBML Level 3 Version 1 model is imported correctly."""
+    sbml = _minimal_sbml(
+        compartments='<compartment id="c" size="1" constant="true"/>',
+        species=(
+            '<species id="A" compartment="c" initialConcentration="2.0"'
+            ' hasOnlySubstanceUnits="false" boundaryCondition="false"'
+            ' constant="false"/>'
+            '<species id="B" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false" boundaryCondition="false"'
+            ' constant="false"/>'
+        ),
+        parameters='<parameter id="k" value="0.1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false" fast="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="1" constant="true"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B" stoichiometry="1" constant="true"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+        level=3,
+        version=1,
+    ).replace(
+        'xmlns="http://www.sbml.org/sbml/level3/version1"',
+        'xmlns="http://www.sbml.org/sbml/level3/version1/core"',
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    assert "A" in m.monomers.keys()
+    assert "B" in m.monomers.keys()
+    assert "r1" in m.rules.keys()
+    assert abs(m.parameters["A_0"].value - 2.0) < 1e-9
+
+
+def test_initial_amount_takes_precedence_over_concentration():
+    """When both initialAmount and initialConcentration are set, amount wins."""
+    # Build SBML manually since _minimal_sbml doesn't support both attributes
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        '  <model id="test_model">\n'
+        "    <listOfCompartments>"
+        '<compartment id="c" size="1"/>'
+        "</listOfCompartments>\n"
+        "    <listOfSpecies>"
+        '<species id="A" compartment="c"'
+        ' initialAmount="7.0" initialConcentration="3.0"/>'
+        "</listOfSpecies>\n"
+        "  </model>\n"
+        "</sbml>"
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert abs(m.parameters["A_0"].value - 7.0) < 1e-9
+
+
+def test_zero_dimensional_compartment():
+    """A compartment with spatialDimensions=0 imports with dimension 3 fallback."""
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        '  <model id="test_model">\n'
+        "    <listOfCompartments>"
+        '<compartment id="c" size="1" spatialDimensions="0"/>'
+        "</listOfCompartments>\n"
+        "  </model>\n"
+        "</sbml>"
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    assert "c" in m.compartments.keys()
+
+
+def test_reaction_naming_uses_sanitised_id():
+    """A reaction with id='r0' produces a rule named 'r0'."""
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r0" reversible="false">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    assert "r0" in m.rules.keys()
+
+
+def test_reaction_fallback_name_when_no_id():
+    """A reaction with no id attribute receives the fallback name r{i}.
+
+    SBML Level 2 requires a reaction ``id``; omitting it produces a parse
+    error, so ``force=True`` is needed to continue past the error.  The
+    fallback name ``r0`` (index 0) should be assigned to the rule.
+    """
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction reversible="false">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True):
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml, force=True)
+    assert "r0" in m.rules.keys()
+
+
+def test_reversible_reaction_split_into_two_rules():
+    """A reversible SBML reaction with separable kinetic law produces two rules.
+
+    The net-flux kinetic law ``kf*A - kr*B`` is split into a forward flux
+    ``kf*A`` and a reverse flux ``kr*B``.  Each half is divided by the
+    appropriate species observable to obtain the intrinsic rate constant, and
+    two non-reversible PySB rules are created: ``r1_fwd`` (A -> B at kf) and
+    ``r1_rev`` (B -> A at kr).
+    """
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="1"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters=(
+            '<parameter id="kf" value="1" constant="true"/>'
+            '<parameter id="kr" value="0.5" constant="true"/>'
+        ),
+        reactions="""
+          <reaction id="r1" reversible="true">
+            <listOfReactants>
+              <speciesReference species="A"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><minus/>
+                  <apply><times/><ci>kf</ci><ci>A</ci></apply>
+                  <apply><times/><ci>kr</ci><ci>B</ci></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    # No warnings expected for cleanly separable kinetic law
+    assert not any("cannot be split" in str(warning.message) for warning in w)
+    # Two rules created: forward and reverse
+    assert "r1_fwd" in m.rules.keys()
+    assert "r1_rev" in m.rules.keys()
+    assert "r1" not in m.rules.keys()
+    # Both rules are non-reversible
+    assert m.rules["r1_fwd"].rule_expression.is_reversible is False
+    assert m.rules["r1_rev"].rule_expression.is_reversible is False
+    # Forward rate = kf (kinetic law kf*A divided by obs_A → bare Parameter)
+    assert m.rules["r1_fwd"].rate_forward is m.parameters["kf"]
+    assert "r1_fwd_rate" not in m.expressions.keys()
+    # Reverse rate = kr (kinetic law kr*B divided by obs_B → bare Parameter)
+    assert m.rules["r1_rev"].rate_forward is m.parameters["kr"]
+    assert "r1_rev_rate" not in m.expressions.keys()
+
+
+def test_reversible_reaction_unseparable_warns():
+    """A reversible reaction with unseparable kinetic law warns and creates one rule.
+
+    When ``_split_reversible_rate`` cannot decompose the kinetic law (e.g.
+    all terms have the same sign, or there is only one term), a warning is
+    issued and only the forward rule is created.
+    """
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="1"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="true">
+            <listOfReactants>
+              <speciesReference species="A"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    # Warning about unseparable kinetic law
+    assert any("cannot be split" in str(warning.message) for warning in w)
+    # Only the forward rule is created
+    assert "r1_fwd" in m.rules.keys()
+    assert "r1_rev" not in m.rules.keys()
+    assert m.rules["r1_fwd"].rule_expression.is_reversible is False
+
+
+def test_duplicate_rate_rule_raises():
+    """Two rate rules for the same variable raise SbmlImportError."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="1" constant="false"/>',
+        rules="""
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML"><cn>1</cn></math>
+          </rateRule>
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML"><cn>2</cn></math>
+          </rateRule>""",
+    )
+    assert_raises_regex(
+        SbmlImportError, "[Mm]ultiple rate rules", _model_from_sbml_libsbml, sbml
+    )
+
+
+def test_duplicate_rate_rule_warns_with_force():
+    """Two rate rules for the same variable warn when force=True."""
+    sbml = _minimal_sbml(
+        parameters='<parameter id="x" value="1" constant="false"/>',
+        rules="""
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML"><cn>1</cn></math>
+          </rateRule>
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML"><cn>2</cn></math>
+          </rateRule>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml, force=True)
+    assert any("rate rule" in str(warning.message).lower() for warning in w)
+    # Only one ODE rule should exist for x
+    assert "x_ode" in m.rules.keys()
+
+
+def test_compartment_hierarchy():
+    """Nested compartments (outer/inner) are linked via the parent attribute."""
+    sbml = _minimal_sbml(
+        compartments=(
+            '<compartment id="outer" size="10"/>'
+            '<compartment id="inner" size="1" outside="outer"/>'
+        ),
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    inner = m.compartments["inner"]
+    outer = m.compartments["outer"]
+    assert inner.parent is outer
+
+
+def test_integer_stoichiometry_float_representation():
+    """Stoichiometry given as 2.0 (exact float) is treated as integer 2."""
+    # Some SBML files write stoichiometry as floating-point (e.g. 2.0).
+    # The math.isclose fix ensures 2.0 is recognised as integer 2.
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="10"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="0.5" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    # No truncation warning should be raised for exact integer 2.0
+    assert not any("stoichiometry" in str(warning.message).lower() for warning in w)
+    r = m.rules["r1"]
+    assert len(r.rule_expression.reactant_pattern.complex_patterns) == 2
+
+
+# ---------------------------------------------------------------------------
+# Additional branch-coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_sbml_no_model_raises():
+    """An SBML document that libsbml reports as having no model raises SbmlImportError."""
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3"/>\n'
+    )
+    assert_raises_regex(SbmlImportError, "", _model_from_sbml_libsbml, sbml)
+
+
+def test_rate_rule_for_existing_species():
+    """A rate rule whose variable is already an SBML species is handled
+    without creating a duplicate Monomer (the species is reused)."""
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        rules="""
+          <rateRule variable="A">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn>-1</cn>
+            </math>
+          </rateRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    # A should be a Monomer (from species), not duplicated
+    assert "A" in m.monomers.keys()
+
+
+def test_assignment_rule_skips_existing_component():
+    """An assignment rule targeting a name that already exists as a model
+    component (e.g. an observable) is silently skipped."""
+    # The species 'A' creates obs_A; an assignment rule for 'obs_A' should
+    # be ignored because that name already exists as a model component.
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="obs_A" constant="false" value="0"/>',
+        rules="""
+          <assignmentRule variable="obs_A">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <ci>A</ci>
+            </math>
+          </assignmentRule>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    # obs_A is already an Observable from the species; the assignment rule
+    # for 'obs_A' parameter should not overwrite it.
+    assert "obs_A" in m.observables.keys()
+
+
+def test_split_reversible_rate_zero_coeff():
+    """A term with a zero coefficient (e.g. the integer 0 itself) returns (None, None)."""
+    # sympy.Integer(0) has as_coeff_Mul() == (0, 1): zero coefficient path
+    fwd, rev = _split_reversible_rate(sympy.Integer(0))
+    assert fwd is None
+    assert rev is None
+
+
+def test_split_reversible_rate_symbolic_coefficient():
+    """A term whose leading coefficient cannot be determined as positive or
+    negative (e.g. a bare symbolic product without a numeric leading factor)
+    returns (None, None)."""
+    # sin(A)*B: as_coeff_Mul -> (1, sin(A)*B), coeff is 1, positive
+    # This exercises the positive-term path but results in (None, None)
+    # because there's no negative term.
+    A, B = sympy.symbols("A B")
+    expr = sympy.sin(A) * B
+    fwd, rev = _split_reversible_rate(expr)
+    # Single positive term → no split
+    assert fwd is None
+    assert rev is None
+
+
+def test_model_name_from_filename_when_no_model_id():
+    """When the SBML model element has no id, the filename stem is used."""
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        "  <model>\n"
+        "  </model>\n"
+        "</sbml>"
+    )
+    fd, path = tempfile.mkstemp(suffix=".xml", prefix="my_model_")
+    os.close(fd)
+    with open(path, "w") as f:
+        f.write(sbml)
+    try:
+        m = _model_from_sbml_libsbml(path, force=True)
+        # Model name should be derived from the file basename (without .xml)
+        assert "my_model_" in m.name
+    finally:
+        os.unlink(path)
+
+
+def test_function_definition_used_in_rate_law():
+    """A valid SBML functionDefinition is parsed and used in a kinetic law."""
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="1"/>',
+        parameters='<parameter id="k" value="2.0" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><ci>myfunc</ci><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    ).replace(
+        '<model id="test_model">',
+        """<model id="test_model">
+    <listOfFunctionDefinitions>
+      <functionDefinition id="myfunc">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar><ci>x</ci></bvar>
+            <bvar><ci>y</ci></bvar>
+            <apply><times/><ci>x</ci><ci>y</ci></apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    # myfunc(k, A) = k*A; after dividing by obs_A (reactant) the rate = k
+    # (bare Parameter), so no r1_rate Expression is created.
+    assert m.rules["r1"].rate_forward is m.parameters["k"]
+    assert "r1_rate" not in m.expressions.keys()
+
+
+def test_initial_assignment_numeric_updates_ic():
+    """A numeric initialAssignment updates the species initial condition value."""
+    sbml = _minimal_sbml(
+        species='<species id="A" compartment="c" initialAmount="0"/>',
+        parameters='<parameter id="a0" value="5.0" constant="true"/>',
+    ).replace(
+        "</model>",
+        """<listOfInitialAssignments>
+      <initialAssignment symbol="A">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn>7.0</cn>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments></model>""",
+    )
+    m = _model_from_sbml_libsbml(sbml, force=True)
+    # The numeric initialAssignment should update A_0 to 7.0
+    assert abs(m.parameters["A_0"].value - 7.0) < 1e-9
+
+
+def test_fast_reaction_warns():
+    """A reaction with fast='true' issues a warning and is imported normally."""
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="1"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="1" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false" fast="true">
+            <listOfReactants><speciesReference species="A"/></listOfReactants>
+            <listOfProducts><speciesReference species="B"/></listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    assert any("fast" in str(warning.message).lower() for warning in w)
+    assert "r1" in m.rules.keys()
+
+
+def test_local_kinetic_law_parameter_promoted():
+    """Local kinetic-law parameters with no global counterpart are promoted to global Parameters."""
+    # Use L2 SBML which has <listOfParameters> inside <kineticLaw>
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        '  <model id="test_model">\n'
+        "    <listOfCompartments>"
+        '<compartment id="c" size="1"/>'
+        "</listOfCompartments>\n"
+        "    <listOfSpecies>"
+        '<species id="A" compartment="c" initialAmount="1"/>'
+        '<species id="B" compartment="c" initialAmount="0"/>'
+        "</listOfSpecies>\n"
+        "    <listOfReactions>"
+        '      <reaction id="r1" reversible="false">\n'
+        "        <listOfReactants>"
+        '<speciesReference species="A"/>'
+        "</listOfReactants>\n"
+        "        <listOfProducts>"
+        '<speciesReference species="B"/>'
+        "</listOfProducts>\n"
+        "        <kineticLaw>\n"
+        '          <math xmlns="http://www.w3.org/1998/Math/MathML">\n'
+        "            <apply><times/><ci>k_local</ci><ci>A</ci></apply>\n"
+        "          </math>\n"
+        "          <listOfParameters>"
+        '<parameter id="k_local" value="0.5"/>'
+        "</listOfParameters>\n"
+        "        </kineticLaw>\n"
+        "      </reaction>\n"
+        "    </listOfReactions>\n"
+        "  </model>\n"
+        "</sbml>"
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    # k_local should have been promoted to a global Parameter
+    assert "k_local" in m.parameters.keys(), "k_local not promoted to global Parameter"
+    assert m.parameters["k_local"].value == 0.5
+    assert "r1" in m.rules.keys()
+
+
+def test_local_kinetic_law_parameter_shadow_warns():
+    """A local kinetic-law parameter that shadows a global one issues a warning."""
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        '  <model id="test_model">\n'
+        "    <listOfCompartments>"
+        '<compartment id="c" size="1"/>'
+        "</listOfCompartments>\n"
+        "    <listOfSpecies>"
+        '<species id="A" compartment="c" initialAmount="1"/>'
+        '<species id="B" compartment="c" initialAmount="0"/>'
+        "</listOfSpecies>\n"
+        # Global parameter k_local = 1.0
+        "    <listOfParameters>"
+        '<parameter id="k_local" value="1.0"/>'
+        "</listOfParameters>\n"
+        "    <listOfReactions>"
+        '      <reaction id="r1" reversible="false">\n'
+        "        <listOfReactants>"
+        '<speciesReference species="A"/>'
+        "</listOfReactants>\n"
+        "        <listOfProducts>"
+        '<speciesReference species="B"/>'
+        "</listOfProducts>\n"
+        "        <kineticLaw>\n"
+        '          <math xmlns="http://www.w3.org/1998/Math/MathML">\n'
+        "            <apply><times/><ci>k_local</ci><ci>A</ci></apply>\n"
+        "          </math>\n"
+        # Local parameter with same name shadows global
+        "          <listOfParameters>"
+        '<parameter id="k_local" value="0.5"/>'
+        "</listOfParameters>\n"
+        "        </kineticLaw>\n"
+        "      </reaction>\n"
+        "    </listOfReactions>\n"
+        "  </model>\n"
+        "</sbml>"
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        m = _model_from_sbml_libsbml(sbml)
+    assert any("shadow" in str(warning.message).lower() for warning in w), (
+        "Expected a shadowing warning for local parameter k_local"
+    )
+    assert "r1" in m.rules.keys()
+
+
+# ---------------------------------------------------------------------------
+# _check_sbml_level_version tests
+# ---------------------------------------------------------------------------
+
+
+def test_sbml_level1_warns():
+    """Importing an SBML Level 1 document issues a warning about limited support."""
+    import warnings as _warnings
+
+    sbml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level1" level="1" version="2">\n'
+        '  <model name="test_model"/>\n'
+        "</sbml>"
+    )
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _model_from_sbml_libsbml(sbml, force=True)
+    assert any("Level 1" in str(warning.message) for warning in w)
+
+
+def test_sbml_l2v5_no_version_warning():
+    """SBML Level 2 Version 5 (latest known L2) does not trigger a version warning."""
+    import warnings as _warnings
+
+    # Use _minimal_sbml at L2V5; no level/version warning expected
+    sbml = _minimal_sbml(level=2, version=5)
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _model_from_sbml_libsbml(sbml, force=True)
+    version_warns = [
+        warning
+        for warning in w
+        if "Version" in str(warning.message) and "Level 2" in str(warning.message)
+    ]
+    assert not version_warns
+
+
+def test_sbml_l3v2_no_version_warning():
+    """SBML Level 3 Version 2 (latest known L3) does not trigger a version warning."""
+    import warnings as _warnings
+
+    sbml = _minimal_sbml(
+        compartments='<compartment id="c" size="1" constant="true"/>',
+        level=3,
+        version=2,
+    ).replace(
+        'xmlns="http://www.sbml.org/sbml/level3/version2"',
+        'xmlns="http://www.sbml.org/sbml/level3/version2/core"',
+    )
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _model_from_sbml_libsbml(sbml, force=True)
+    version_warns = [
+        warning
+        for warning in w
+        if "Version" in str(warning.message) and "Level 3" in str(warning.message)
+    ]
+    assert not version_warns
+
+
+def test_sbml_unknown_level_warns():
+    """A document whose libsbml-reported level is >3 issues an 'unknown' warning."""
+    import warnings as _warnings
+
+    # We mock _check_sbml_level_version's call to doc.getLevel()/getVersion()
+    # by patching the libsbml SBMLDocument object after reading.
+    sbml = _minimal_sbml(level=2, version=3)
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        # Patch readSBMLFromString to return a doc whose level reports as 4
+        import pysb.importers.sbml as sbml_mod
+
+        real_reader_cls = sbml_mod.libsbml.SBMLReader
+
+        class _FakeReader:
+            def readSBMLFromString(self, xml_string):
+                doc = real_reader_cls().readSBMLFromString(xml_string)
+                doc.getLevel = lambda: 4
+                doc.getVersion = lambda: 1
+                return doc
+
+        with mock.patch.object(sbml_mod.libsbml, "SBMLReader", _FakeReader):
+            _model_from_sbml_libsbml(sbml, force=True)
+    assert any("Level 4" in str(warning.message) for warning in w)
+
+
+def test_sbml_future_l2_version_warns():
+    """A document with a future L2 version (>5) issues a warning."""
+    import warnings as _warnings
+
+    sbml = _minimal_sbml(level=2, version=3)
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        import pysb.importers.sbml as sbml_mod
+
+        real_reader_cls = sbml_mod.libsbml.SBMLReader
+
+        class _FakeReader:
+            def readSBMLFromString(self, xml_string):
+                doc = real_reader_cls().readSBMLFromString(xml_string)
+                doc.getLevel = lambda: 2
+                doc.getVersion = lambda: 99
+                return doc
+
+        with mock.patch.object(sbml_mod.libsbml, "SBMLReader", _FakeReader):
+            _model_from_sbml_libsbml(sbml, force=True)
+    assert any("Level 2 Version 99" in str(warning.message) for warning in w)
+
+
+def test_sbml_future_l3_version_warns():
+    """A document with a future L3 version (>2) issues a warning."""
+    import warnings as _warnings
+
+    sbml = _minimal_sbml(level=2, version=3)
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        import pysb.importers.sbml as sbml_mod
+
+        real_reader_cls = sbml_mod.libsbml.SBMLReader
+
+        class _FakeReader:
+            def readSBMLFromString(self, xml_string):
+                doc = real_reader_cls().readSBMLFromString(xml_string)
+                doc.getLevel = lambda: 3
+                doc.getVersion = lambda: 9
+                return doc
+
+        with mock.patch.object(sbml_mod.libsbml, "SBMLReader", _FakeReader):
+            _model_from_sbml_libsbml(sbml, force=True)
+    assert any("Level 3 Version 9" in str(warning.message) for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# Cross-compartment transport tests
+# ---------------------------------------------------------------------------
+
+
+def _cross_compartment_sbml(
+    V_src,
+    V_dst,
+    k,
+    A0,
+    reversible=False,
+    kr=None,
+    B0=0.0,
+):
+    """Build minimal SBML for a transport reaction A(src) <-> B(dst).
+
+    For irreversible: A -> B, kinetic law = k * A * V_src
+    For reversible:   net flux = k * A * V_src - kr * B * V_dst
+    (Kinetic laws in amount/time; BNG-style volume-corrected rate extraction
+    is what we are testing.)
+    """
+    fwd_law = "<apply><times/><ci>k</ci><ci>A</ci><cn>{}</cn></apply>".format(V_src)
+    if reversible:
+        rev_law = "<apply><times/><ci>kr</ci><ci>B</ci><cn>{}</cn></apply>".format(
+            V_dst
+        )
+        kinetic_math = "<apply><minus/>{}{}</apply>".format(fwd_law, rev_law)
+        rev_attr = 'reversible="true"'
+        kr_param = '<parameter id="kr" value="{}" constant="true"/>'.format(kr)
+        B_init = 'initialConcentration="{}"'.format(B0)
+    else:
+        kinetic_math = fwd_law
+        rev_attr = 'reversible="false"'
+        kr_param = ""
+        B_init = 'initialConcentration="0.0"'
+
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<sbml xmlns="http://www.sbml.org/sbml/level2/version3"'
+        ' level="2" version="3">\n'
+        '  <model id="transport_model">\n'
+        "    <listOfCompartments>\n"
+        '      <compartment id="src" size="{V_src}"/>\n'
+        '      <compartment id="dst" size="{V_dst}"/>\n'
+        "    </listOfCompartments>\n"
+        "    <listOfSpecies>\n"
+        '      <species id="A" compartment="src"'
+        ' initialConcentration="{A0}" hasOnlySubstanceUnits="false"/>\n'
+        '      <species id="B" compartment="dst"'
+        ' {B_init} hasOnlySubstanceUnits="false"/>\n'
+        "    </listOfSpecies>\n"
+        "    <listOfParameters>\n"
+        '      <parameter id="k" value="{k}" constant="true"/>\n'
+        "      {kr_param}\n"
+        "    </listOfParameters>\n"
+        "    <listOfReactions>\n"
+        '      <reaction id="r1" {rev_attr}>\n'
+        "        <listOfReactants>\n"
+        '          <speciesReference species="A"/>\n'
+        "        </listOfReactants>\n"
+        "        <listOfProducts>\n"
+        '          <speciesReference species="B"/>\n'
+        "        </listOfProducts>\n"
+        "        <kineticLaw>\n"
+        '          <math xmlns="http://www.w3.org/1998/Math/MathML">\n'
+        "            {kinetic_math}\n"
+        "          </math>\n"
+        "        </kineticLaw>\n"
+        "      </reaction>\n"
+        "    </listOfReactions>\n"
+        "  </model>\n"
+        "</sbml>"
+    ).format(
+        V_src=V_src,
+        V_dst=V_dst,
+        A0=A0,
+        B_init=B_init,
+        k=k,
+        kr_param=kr_param,
+        rev_attr=rev_attr,
+        kinetic_math=kinetic_math,
+    )
+
+
+def test_cross_compartment_irreversible_structure():
+    """Cross-compartment irreversible transport creates deg + prod split rules."""
+    sbml = _cross_compartment_sbml(V_src=2.0, V_dst=5.0, k=0.3, A0=1.0)
+    m = _model_from_sbml_libsbml(sbml)
+    rule_names = set(m.rules.keys())
+    # Must have deg (A -> None) and prod (None -> B) rules; original r1 absent
+    assert "r1_deg" in rule_names, "Expected r1_deg rule"
+    assert "r1_prod" in rule_names, "Expected r1_prod rule"
+    assert "r1" not in rule_names, "Original r1 rule should not exist"
+    # r1_deg reactants contain A; r1_prod products contain B
+    deg_reactants = [
+        mp.monomer.name
+        for cp in m.rules["r1_deg"].rule_expression.reactant_pattern.complex_patterns
+        for mp in cp.monomer_patterns
+    ]
+    assert "A" in deg_reactants
+    prod_products = [
+        mp.monomer.name
+        for cp in m.rules["r1_prod"].rule_expression.product_pattern.complex_patterns
+        for mp in cp.monomer_patterns
+    ]
+    assert "B" in prod_products
+
+
+def test_cross_compartment_irreversible_simulation():
+    """Cross-compartment irreversible transport integrates correctly.
+
+    SBML model: A(src, V=2) -> B(dst, V=5), J = k*A*V_src = k*[A]*V_src
+    ODEs:  d[A]/dt = -k*[A]   (k = 0.3)
+           d[B]/dt = +k*[A]*V_src/V_dst = 0.12*[A]
+    Analytic solution (A0=1, B0=0):
+           [A](t) = exp(-k*t)
+           [B](t) = (k*V_src/V_dst) * (1 - exp(-k*t)) / k
+                  = (V_src/V_dst) * (1 - exp(-k*t))
+                  = 0.4 * (1 - exp(-0.3*t))
+    """
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    k, V_src, V_dst, A0 = 0.3, 2.0, 5.0, 1.0
+    sbml = _cross_compartment_sbml(V_src=V_src, V_dst=V_dst, k=k, A0=A0)
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 5, 100)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+
+    A_sim = res.observables["obs_A"]
+    B_sim = res.observables["obs_B"]
+    A_ref = A0 * np.exp(-k * tspan)
+    B_ref = (V_src / V_dst) * (1.0 - np.exp(-k * tspan))
+
+    np.testing.assert_allclose(A_sim, A_ref, rtol=1e-4, err_msg="[A] mismatch")
+    np.testing.assert_allclose(B_sim, B_ref, rtol=1e-4, err_msg="[B] mismatch")
+
+
+def test_cross_compartment_reversible_structure():
+    """Cross-compartment reversible transport creates four split rules."""
+    sbml = _cross_compartment_sbml(
+        V_src=2.0, V_dst=5.0, k=0.3, kr=0.1, A0=1.0, B0=0.5, reversible=True
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    rule_names = set(m.rules.keys())
+    expected = {"r1_fwd_deg", "r1_fwd_prod", "r1_rev_deg", "r1_rev_prod"}
+    for name in expected:
+        assert name in rule_names, "Expected rule {} missing".format(name)
+    assert "r1" not in rule_names
+    assert "r1_fwd" not in rule_names
+    assert "r1_rev" not in rule_names
+
+
+def test_cross_compartment_reversible_simulation():
+    """Cross-compartment reversible transport integrates to analytic solution.
+
+    SBML model: A(src, V=2) <-> B(dst, V=5)
+    J_net = kf*[A]*V_src - kr*[B]*V_dst  (kf=0.3, kr=0.1)
+    ODEs:
+        d[A]/dt = -J_net/V_src = -kf*[A] + kr*[B]*V_dst/V_src
+        d[B]/dt = +J_net/V_dst = +kf*[A]*V_src/V_dst - kr*[B]
+    At steady state:  kf*[A]_ss*V_src = kr*[B]_ss*V_dst
+    Conservation:     [A]*V_src + [B]*V_dst = A0*V_src + B0*V_dst (amounts)
+    """
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+    from scipy.integrate import solve_ivp
+
+    kf, kr, V_src, V_dst, A0, B0 = 0.3, 0.1, 2.0, 5.0, 1.0, 0.0
+    sbml = _cross_compartment_sbml(
+        V_src=V_src, V_dst=V_dst, k=kf, kr=kr, A0=A0, B0=B0, reversible=True
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 10, 200)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+
+    # Analytic reference via scipy solve_ivp
+    def odes(t, y):
+        A, B = y
+        J = kf * A * V_src - kr * B * V_dst
+        return [-J / V_src, J / V_dst]
+
+    ref = solve_ivp(odes, [0, tspan[-1]], [A0, B0], t_eval=tspan, rtol=1e-10)
+    A_ref = ref.y[0]
+    B_ref = ref.y[1]
+
+    np.testing.assert_allclose(
+        res.observables["obs_A"], A_ref, rtol=1e-3, err_msg="[A] mismatch"
+    )
+    np.testing.assert_allclose(
+        res.observables["obs_B"], B_ref, rtol=1e-3, err_msg="[B] mismatch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Homo-multimer and stoichiometry regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_homodimer_simulation_accuracy():
+    """Homodimerisation A+A->D: ODE must use correct combinatorial factor.
+
+    SBML kinetic law: J = k * A^2  (mass-action, amount/time in a unit
+    compartment so J = k * [A]^2).
+
+    ODE: d[A]/dt = -2*k*[A]^2,  d[D]/dt = +k*[A]^2
+    Analytic solution with A0=1, D0=0:
+        [A](t) = 1 / (1 + 2*k*t)
+        [D](t) = (1 - [A]) / 2 = k*t / (1 + 2*k*t)
+
+    The combinatorial correction (2! = 2) must cancel the 0.5 implicit
+    symmetry factor that BNG applies, so the effective rate seen by the ODE
+    is k, not k/2.
+    """
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    k = 0.5
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="D" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="D"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci>
+                  <apply><power/><ci>A</ci><cn>2</cn></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 5, 200)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+
+    A_sim = res.observables["obs_A"]
+    D_sim = res.observables["obs_D"]
+    A_ref = 1.0 / (1.0 + 2.0 * k * tspan)
+    D_ref = k * tspan / (1.0 + 2.0 * k * tspan)
+
+    np.testing.assert_allclose(A_sim, A_ref, rtol=1e-4, err_msg="[A] mismatch")
+    np.testing.assert_allclose(D_sim, D_ref, rtol=1e-4, err_msg="[D] mismatch")
+
+
+def test_homodimer_combinatorial_correction_value():
+    """Rate expression for A+A->D contains factor 2! = 2 (no 0.5 remaining)."""
+    import sympy
+
+    k = 0.5
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="D" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="D"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci>
+                  <apply><power/><ci>A</ci><cn>2</cn></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    # After dividing by obs_A^2 and multiplying by 2!, kinetic law k*A^2 /
+    # (A^2) * 2 = 2k = 1.0.  Rate should be stored as a bare Parameter with
+    # value 1.0, or as an Expression with no sub-1 numeric coefficients.
+    rate = m.rules["r1"].rate_forward
+    if hasattr(rate, "expr"):
+        nums = rate.expr.atoms(sympy.Number)
+        assert all(float(n) >= 1.0 for n in nums if float(n) != 0), (
+            "Unexpected sub-1 coefficient in rate: {}".format(rate.expr)
+        )
+    else:
+        # Bare Parameter: value must be 2*k = 1.0
+        assert abs(float(rate.value) - 2.0 * k) < 1e-9
+
+
+def test_product_stoichiometry_two():
+    """A -> 2B creates two product-pattern copies in the rule."""
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialAmount="10"/>'
+            '<species id="B" compartment="c" initialAmount="0"/>'
+        ),
+        parameters='<parameter id="k" value="1.0" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B" stoichiometry="2"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    r = m.rules["r1"]
+    product_cps = r.rule_expression.product_pattern.complex_patterns
+    assert len(product_cps) == 2, "Expected 2 product patterns, got {}".format(
+        len(product_cps)
+    )
+    product_names = [
+        mp.monomer.name for cp in product_cps for mp in cp.monomer_patterns
+    ]
+    assert product_names == ["B", "B"]
+
+
+def test_product_stoichiometry_two_simulation():
+    """A -> 2B: conservation [B] = 2*(A0 - [A]) must hold."""
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    k = 0.2
+    A0 = 1.0
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialConcentration="{}" '
+            'hasOnlySubstanceUnits="false"/>'.format(A0)
+            + '<species id="B" compartment="c" initialConcentration="0.0" '
+            'hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B" stoichiometry="2"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>A</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 10, 100)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+    A_sim = res.observables["obs_A"]
+    B_sim = res.observables["obs_B"]
+    A_ref = A0 * np.exp(-k * tspan)
+    np.testing.assert_allclose(A_sim, A_ref, rtol=1e-4, err_msg="[A] mismatch")
+    np.testing.assert_allclose(
+        B_sim, 2.0 * (A0 - A_ref), rtol=1e-4, err_msg="[B] mismatch"
+    )
+
+
+def test_trimerisation_combinatorial_correction():
+    """3A -> T: combinatorial correction must be 3! = 6."""
+    import sympy
+
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="T" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="1.0" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="3"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="T"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci>
+                  <apply><power/><ci>A</ci><cn>3</cn></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    # Intrinsic rate = 6! * k * A^3 / A^3 / V = 6k.
+    # Stored as bare Parameter (value 6.0) or Expression with coefficient 6.
+    rate = m.rules["r1"].rate_forward
+    if hasattr(rate, "expr"):
+        # Extract leading numeric coefficient
+        coeff = float(rate.expr.as_coeff_Mul()[0])
+        assert abs(coeff - 6.0) < 1e-9, "Expected coeff 6, got {}".format(coeff)
+    else:
+        assert abs(float(rate.value) - 6.0) < 1e-9, "Expected value 6.0, got {}".format(
+            rate.value
+        )
+
+
+def test_reversible_homodimer_combinatorial_correction():
+    """A+A <-> D: both directions must apply the correct correction.
+
+    Forward (reactant stoich=2): correction = 2! = 2
+    Reverse (product stoich=2 for the reverse rule): correction = 2! = 2
+    With kinetic law kf*A^2 - kr*D, after split:
+        fwd rate = 2 * kf*A^2 / A^2 = 2*kf  (bare param or expr coefficient 2)
+        rev rate = 1 * kr*D  / D    = kr    (bare param or expr coefficient 1)
+    """
+    import sympy
+
+    kf, kr = 1.0, 0.5
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="A" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="D" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters=(
+            '<parameter id="kf" value="{}" constant="true"/>'.format(kf)
+            + '<parameter id="kr" value="{}" constant="true"/>'.format(kr)
+        ),
+        reactions="""
+          <reaction id="r1" reversible="true">
+            <listOfReactants>
+              <speciesReference species="A" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="D"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><minus/>
+                  <apply><times/><ci>kf</ci>
+                    <apply><power/><ci>A</ci><cn>2</cn></apply>
+                  </apply>
+                  <apply><times/><ci>kr</ci><ci>D</ci></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    assert "r1_fwd" in m.rules.keys(), "Expected r1_fwd rule"
+    assert "r1_rev" in m.rules.keys(), "Expected r1_rev rule"
+
+    # Forward rate: 2*kf*A^2 / A^2 = 2*kf → coefficient on kf must be 2
+    fwd_rate = m.rules["r1_fwd"].rate_forward
+    if hasattr(fwd_rate, "expr"):
+        fwd_coeff = float(fwd_rate.expr.as_coeff_Mul()[0])
+    else:
+        fwd_coeff = float(fwd_rate.value) / kf
+    assert abs(fwd_coeff - 2.0) < 1e-9, "Forward coeff should be 2, got {}".format(
+        fwd_coeff
+    )
+
+    # Reverse rate: 1*kr*D / D = kr → simplifies to bare Parameter kr
+    rev_rate = m.rules["r1_rev"].rate_forward
+    if hasattr(rev_rate, "expr"):
+        free = rev_rate.expr.free_symbols
+        assert m.parameters["kr"] in free, "kr should appear in reverse rate"
+        nums = rev_rate.expr.atoms(sympy.Number)
+        # No coefficient other than 1 (or 1.0)
+        assert all(abs(float(n) - 1.0) < 1e-9 for n in nums if float(n) != 0)
+    else:
+        assert abs(float(rev_rate.value) - kr) < 1e-9
+
+
+def test_boundary_species_excluded_from_rule_pattern():
+    """Boundary species appears in kinetic law but is absent from rule pattern.
+
+    A boundary species' amount is not changed by reactions.  The importer must
+    omit it from the PySB rule pattern so BNG does not subtract it in the ODE,
+    while still allowing it to appear in the kinetic-law Expression.
+    """
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="S" compartment="c" initialConcentration="2.0"'
+            ' boundaryCondition="true" hasOnlySubstanceUnits="false"/>'
+            '<species id="P" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="1.0" constant="true"/>',
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="S"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="P"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>S</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    r = m.rules["r1"]
+    reactant_names = [
+        mp.monomer.name
+        for cp in r.rule_expression.reactant_pattern.complex_patterns
+        for mp in cp.monomer_patterns
+    ]
+    # S is boundary: must not appear in rule pattern
+    assert "S" not in reactant_names, (
+        "Boundary species S must be absent from rule pattern"
+    )
+    # P should appear as product
+    product_names = [
+        mp.monomer.name
+        for cp in r.rule_expression.product_pattern.complex_patterns
+        for mp in cp.monomer_patterns
+    ]
+    assert "P" in product_names
+
+
+def test_boundary_species_in_rate_expression():
+    """Boundary species drives a synthesis rate even though excluded from pattern."""
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    # S is boundary (fixed at 2.0), P is produced at rate k*S = 2.0*k
+    k, S_fixed, P0 = 0.3, 2.0, 0.0
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="S" compartment="c" initialConcentration="{}"'
+            ' boundaryCondition="true" hasOnlySubstanceUnits="false"/>'.format(S_fixed)
+            + '<species id="P" compartment="c" initialConcentration="{}"'
+            ' hasOnlySubstanceUnits="false"/>'.format(P0)
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="S"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="P"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci><ci>S</ci></apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 5, 100)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+    # S fixed → S stays at S_fixed; P grows linearly: d[P]/dt = k*S_fixed
+    P_sim = res.observables["obs_P"]
+    P_ref = P0 + k * S_fixed * tspan
+    np.testing.assert_allclose(P_sim, P_ref, rtol=1e-4, err_msg="[P] mismatch")
+
+
+# ---------------------------------------------------------------------------
+# Roadrunner ground-truth numerical validation
+# ---------------------------------------------------------------------------
+
+
+try:
+    import roadrunner as _roadrunner
+
+    HAS_ROADRUNNER = True
+except ImportError:
+    HAS_ROADRUNNER = False
+
+
+def test_libsbml_matches_roadrunner_flat_sbml():
+    """libsbml importer trajectories must match roadrunner to within rtol=1e-3.
+
+    This test validates the combinatorial-correction fix: previously the
+    homodimerisation reaction R5 produced a 2x rate error causing large
+    trajectory divergence.  After the fix all species agree with roadrunner
+    to better than 0.1%.
+    """
+    if not HAS_ROADRUNNER:
+        raise SkipTest("roadrunner (libroadrunner) not installed")
+
+    import numpy as np
+    import warnings as _warnings
+    from pysb.simulator import ScipyOdeSimulator
+
+    path = _sbml_location("test_sbml_flat_SBML")
+    tspan = np.linspace(0, 5, 200)
+
+    # PySB/libsbml simulation
+    with _warnings.catch_warnings(record=True):
+        _warnings.simplefilter("always")
+        model = SbmlImporter(path).model
+    sim_result = ScipyOdeSimulator(model, tspan=tspan, compiler="python").run()
+
+    # Roadrunner ground-truth simulation
+    rr_model = _roadrunner.RoadRunner(path)
+    rr_result = rr_model.simulate(float(tspan[0]), float(tspan[-1]), len(tspan))
+
+    species = ["S1", "S2", "S3", "S4", "S5"]
+    rtol = 1e-3
+
+    for sp_id in species:
+        pysb_traj = sim_result.observables["obs_" + sp_id]
+        rr_traj = rr_result["[{}]".format(sp_id)]
+        scale = max(float(np.max(np.abs(rr_traj))), 1e-30)
+        rel_err = float(np.max(np.abs(pysb_traj - rr_traj))) / scale
+        assert rel_err <= rtol, (
+            "Species {} relative error vs roadrunner: {:.3e} > rtol={}".format(
+                sp_id, rel_err, rtol
+            )
+        )

--- a/pysb/tests/test_importer_sbml.py
+++ b/pysb/tests/test_importer_sbml.py
@@ -2248,6 +2248,149 @@ def test_reversible_homodimer_combinatorial_correction():
         assert abs(float(rev_rate.value) - kr) < 1e-9
 
 
+def test_catalyst_combinatorial_correction_value():
+    """Catalyst reaction B+B->C+B: combinatorial correction must be 1, not 2.
+
+    BNG only applies the symmetry factor to *net-consumed* species.  In
+    B+B->C+B one copy of B is regenerated as a product, so the net consumption
+    of B is 1 and BNG applies no 1/2 factor.  The importer must also compute
+    the correction from the net-consumed stoichiometry (2 - 1 = 1, 1! = 1) to
+    avoid inflating the recovered rate by a spurious factor of 2.
+    """
+    k = 3e7
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="B" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="C" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="B" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B" stoichiometry="1"/>
+              <speciesReference species="C" stoichiometry="1"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci>
+                  <apply><power/><ci>B</ci><cn>2</cn></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    rate = m.rules["r1"].rate_forward
+    # Net-consumed B = 2 - 1 = 1, so correction = 1! = 1.
+    # The recovered rule rate must equal k (not 2*k).
+    if hasattr(rate, "expr"):
+        coeff = float(rate.expr.as_coeff_Mul()[0])
+    else:
+        coeff = float(rate.value)
+    assert abs(coeff - k) < 1.0, (
+        "Catalyst rate coefficient should be k={}, got {}".format(k, coeff)
+    )
+
+
+def test_catalyst_simulation_accuracy():
+    """B+B->C+B: ODE trajectories must match the analytic solution.
+
+    This is a regression test for the catalyst symmetry-factor bug where
+    _combinatorial_correction used the raw reactant stoichiometry (2) instead
+    of the net-consumed stoichiometry (1), inflating the rate constant by 2.
+
+    With rate k and initial [B]=1, [C]=0:
+        d[B]/dt = -k*[B]^2  =>  [B](t) = 1 / (1 + k*t)
+        d[C]/dt = +k*[B]^2  =>  [C](t) = k*t / (1 + k*t)
+    """
+    import numpy as np
+    from pysb.simulator import ScipyOdeSimulator
+
+    k = 0.5
+    sbml = _minimal_sbml(
+        species=(
+            '<species id="B" compartment="c" initialConcentration="1.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+            '<species id="C" compartment="c" initialConcentration="0.0"'
+            ' hasOnlySubstanceUnits="false"/>'
+        ),
+        parameters='<parameter id="k" value="{}" constant="true"/>'.format(k),
+        reactions="""
+          <reaction id="r1" reversible="false">
+            <listOfReactants>
+              <speciesReference species="B" stoichiometry="2"/>
+            </listOfReactants>
+            <listOfProducts>
+              <speciesReference species="B" stoichiometry="1"/>
+              <speciesReference species="C" stoichiometry="1"/>
+            </listOfProducts>
+            <kineticLaw>
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply><times/><ci>k</ci>
+                  <apply><power/><ci>B</ci><cn>2</cn></apply>
+                </apply>
+              </math>
+            </kineticLaw>
+          </reaction>""",
+    )
+    m = _model_from_sbml_libsbml(sbml)
+    tspan = np.linspace(0, 5, 200)
+    res = ScipyOdeSimulator(m, tspan=tspan, compiler="python").run()
+
+    B_sim = res.observables["obs_B"]
+    C_sim = res.observables["obs_C"]
+    B_ref = 1.0 / (1.0 + k * tspan)
+    C_ref = k * tspan / (1.0 + k * tspan)
+
+    np.testing.assert_allclose(B_sim, B_ref, rtol=1e-4, err_msg="[B] mismatch")
+    np.testing.assert_allclose(C_sim, C_ref, rtol=1e-4, err_msg="[C] mismatch")
+
+
+def test_roundtrip_robertson_trajectories():
+    """Round-trip Robertson model and verify ODE trajectories match exactly.
+
+    This is a regression test for the catalyst symmetry-factor bug in the
+    importer (_combinatorial_correction used raw stoichiometry for B in the
+    B+B->C+B reaction, giving rate 2*k2 instead of k2).  After the fix the
+    re-imported model must reproduce the original trajectories to machine
+    precision (since Robertson has no compartment, V=1 and the exporter
+    applies no volume correction).
+    """
+    import importlib
+    import numpy as np
+    import pysb.examples.robertson as _robertson_module
+    from pysb.export import export
+    from pysb.simulator import ScipyOdeSimulator
+
+    # Re-load the module to ensure the model attribute is present even if a
+    # prior test called SelfExporter.cleanup() (which removes module-level
+    # model objects from their parent module's namespace).
+    importlib.reload(_robertson_module)
+    robertson_model = _robertson_module.model
+
+    tspan = np.linspace(0, 40, 500)
+    sim_orig = ScipyOdeSimulator(robertson_model, tspan=tspan, compiler="python").run()
+
+    sbml_str = export(robertson_model, "sbml")
+    m_imp = _model_from_sbml_libsbml(sbml_str)
+    sim_imp = ScipyOdeSimulator(m_imp, tspan=tspan, compiler="python").run()
+
+    for i in range(len(robertson_model.species)):
+        orig = sim_orig.species[:, i]
+        imp = sim_imp.species[:, i]
+        np.testing.assert_allclose(
+            imp,
+            orig,
+            rtol=1e-6,
+            err_msg="Round-trip trajectory mismatch for species s{}".format(i),
+        )
+
+
 def test_boundary_species_excluded_from_rule_pattern():
     """Boundary species appears in kinetic law but is absent from rule pattern.
 

--- a/pysb/tests/test_importers.py
+++ b/pysb/tests/test_importers.py
@@ -216,13 +216,15 @@ def _require_atomizer():
 
 
 def test_sbml_import_flat_model():
-    _require_atomizer()
+    # Default importer is now libsbml; no atomizer required
     model_from_sbml(_sbml_location('test_sbml_flat_SBML'))
 
 
 def test_sbml_import_structured_model():
+    # Structured (atomised) import still requires sbmlTranslator
     _require_atomizer()
-    model_from_sbml(_sbml_location('test_sbml_structured_SBML'), atomize=True)
+    model_from_sbml(_sbml_location('test_sbml_structured_SBML'),
+                    use_libsbml=False, atomize=True)
 
 
 def _sbml_for_mocks(accession_no, mirror):
@@ -235,7 +237,7 @@ def _sbml_for_mocks(accession_no, mirror):
 
 @mock.patch('pysb.importers.sbml._download_biomodels', _sbml_for_mocks)
 def test_biomodels_import_with_mock():
-    _require_atomizer()
+    # Default importer is now libsbml; no atomizer required
     model_from_biomodels('1')
 
 


### PR DESCRIPTION
Add a new `SbmlImporter` class that imports SBML models directly via the `python-libsbml` package, with no dependency on external executables.

sbmlTranslator/Atomizer backend is preserved and selectable via `use_libsbml=False` with `model_from_sbml()` and `model_from_biomodels()` functions.

Discovered some issues with the SBML exporter during round-trip tests - these are also included, namely:
- Replace dots in model name with underscores for valid SBML ids
- Consolidate duplicate reactant/product species into a single
  speciesReference with the correct stoichiometry (homodimers etc.)
- Guard against reactants/products being added as modifiers
- Exclude the `time` SpecialSymbol from modifierSpeciesReference
- Fix `s.compartment_name` AttributeError -> `s.compartment.name`
- Raise EnergyNotSupported before any export logic for energy models
- Switch from reactions_bidirectional to unidirectional reactions list
  so each exported SBML reaction has a single well-defined rate and
  reactant set, enabling correct per-reaction volume correction
- Set hasOnlySubstanceUnits=False (concentration-based, matching BNG)
- Multiply each kinetic law by V^n (n = number of reactant molecules)
  to convert BNG concentration rates to SBML amount/time flux J
- Update test_roundtrip_robertson to use len(reactions) not
  len(reactions_bidirectional) after the exporter change
- Add test_roundtrip_nonunit_compartment_trajectories regression test
  that catches the double-volume-division bug for non-unit compartments
- Add test_exporter_sbml.py covering 13 exporter structural tests